### PR TITLE
Include teacher user id in config

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -350,6 +350,10 @@ public class InformationController {
         try {
           sharedTeacherUserInfo.put("workgroupId", sharedTeacherWorkgroup.getId());
           sharedTeacherUserInfo.put("username", sharedTeacherWorkgroup.generateWorkgroupName());
+          sharedTeacherUserInfo.put(
+              "userId",
+              sharedTeacherWorkgroup.getMembers().iterator().next().getId()
+          );
 
           String sharedTeacherRole = runService.getSharedTeacherRole(run, sharedOwner);
           if (sharedTeacherRole == null) {
@@ -380,6 +384,7 @@ public class InformationController {
 
       teacherUserInfo.put("workgroupId", runOwnerWorkgroup.getId());
       teacherUserInfo.put("username", runOwner.getUserDetails().getUsername());
+      teacherUserInfo.put("userId", runOwner.getId());
     } catch (JSONException e1) {
       e1.printStackTrace();
     }

--- a/src/main/java/org/wise/vle/domain/work/Event.java
+++ b/src/main/java/org/wise/vle/domain/work/Event.java
@@ -145,6 +145,10 @@ public class Event extends PersistableDomain {
         eventJSONObject.put("workgroupId", workgroupId);
       }
 
+      if (user != null) {
+        eventJSONObject.put("userId", user.getId());
+      }
+
       if (nodeId != null) {
         eventJSONObject.put("nodeId", nodeId);
       }


### PR DESCRIPTION
Make sure the teacher userId is included in the teacherUserInfo and sharedTeacherUserInfos in the config when the VLE or Classroom Monitor is loaded.

Closes #7