### PR TITLE
Add discourseCategoryURL field to unit metadata.

### DIFF
--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectMetadataImpl.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectMetadataImpl.java
@@ -141,6 +141,10 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
   @Setter
   private String standardsAddressed;
 
+  @Getter
+  @Setter
+  private String discourseCategoryURL;
+
   @Column(name = "keywords")
   @Getter
   @Setter
@@ -315,6 +319,12 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
       standardsAddressed = new JSONObject();
     }
     setStandardsAddressed(standardsAddressed.toString());
+
+    String discourseCategoryURL = metadataJSON.optString("discourseCategoryURL", "");
+    if (discourseCategoryURL.equals("null")) {
+      discourseCategoryURL = "";
+    }
+    setDiscourseCategoryURL(discourseCategoryURL);
 
     String keywords = metadataJSON.optString("keywords", "");
     if (keywords.equals("null")) {

--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectMetadataImpl.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectMetadataImpl.java
@@ -320,11 +320,7 @@ public class ProjectMetadataImpl implements ProjectMetadata, Serializable {
     }
     setStandardsAddressed(standardsAddressed.toString());
 
-    String discourseCategoryURL = metadataJSON.optString("discourseCategoryURL", "");
-    if (discourseCategoryURL.equals("null")) {
-      discourseCategoryURL = "";
-    }
-    setDiscourseCategoryURL(discourseCategoryURL);
+    setDiscourseCategoryURL(metadataJSON.optString("discourseCategoryURL", ""));
 
     String keywords = metadataJSON.optString("keywords", "");
     if (keywords.equals("null")) {


### PR DESCRIPTION
## Changes
Added support for a `discourseCategoryURL ` field in the unit (project) metadata.

Resolves #12.

## Test
- Add a key-value pair to a unit's `metadata` in the project.json file (e.g. `"discourseCategoryURL": "https://wise-discuss.berkeley.edu/c/wise-curricula/what-makes-a-good-cancer-medicine/40"`) using the authoring tool (Advanced -> Show JSON).
- Confirm that new key-value pair is included in the unit's json data returned from a call to `/api/project/library`, `/api/project/community`, `/api/project/shared`, or `/api/project/personal`.