### PR TITLE
Add simulationProjectId to the config

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -291,6 +291,7 @@ public class AuthorAPIController {
       ObjectMapper mapper = new ObjectMapper();
       Map<String, Integer> map = mapper.readValue(structures, Map.class);
       config.put("automatedAssessmentProjectId", map.get("automatedAssessmentProjectId"));
+      config.put("simulationProjectId", map.get("simulationProjectId"));
     }
 
     MutableUserDetails userDetails = user.getUserDetails();


### PR DESCRIPTION
1. In the database portal table, set the simulationProjectId field into the JSON in the structures column.

Example
Before
```{"automatedAssessmentProjectId":3}```
After
```{"automatedAssessmentProjectId":3, "simulationProjectId":51}```

2. Log in as a teacher.
3. Open a unit in the Authoring Tool.
4. Look at the config request in the Network tab and make sure the simulationProjectId field is included.

Closes #14