### PR TITLE
Importing a step or component that contains an asset with a space in the file name does not import the asset

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -213,7 +213,6 @@ public class AuthorAPIController {
     if (projectService.canAuthorProject(project, user)) {
       String projectAssetsFolderPathString = projectService.getProjectLocalPath(project)
           + "/assets";
-      ;
       Path fromImagePath = null;
       if (isCustom) {
         fromImagePath = Paths.get(projectAssetsFolderPathString + "/" + projectIcon);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -31,13 +31,13 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -151,9 +151,8 @@ public class AuthorAPIController {
     if (projectIdStr != null && !projectIdStr.equals("") && !projectIdStr.equals("none")) {
       project = projectService.getById(Long.parseLong(projectIdStr));
       if (project.getWiseVersion().equals(5)) {
-        return new ModelAndView(
-            new RedirectView(appProperties.getProperty("wise.hostname") +
-            "/teacher/edit/unit/" + projectIdStr));
+        return new ModelAndView(new RedirectView(
+            appProperties.getProperty("wise.hostname") + "/teacher/edit/unit/" + projectIdStr));
       } else if (project.getWiseVersion().equals(4)) {
         ModelAndView wise4AuthoringView = new ModelAndView(
             new RedirectView("/legacy/author/authorproject.html?projectId=" + projectIdStr));
@@ -212,7 +211,9 @@ public class AuthorAPIController {
     Project project = projectService.getById(projectId);
     HashMap<String, String> response = new HashMap<String, String>();
     if (projectService.canAuthorProject(project, user)) {
-      String projectAssetsFolderPathString = projectService.getProjectLocalPath(project) + "/assets";;
+      String projectAssetsFolderPathString = projectService.getProjectLocalPath(project)
+          + "/assets";
+      ;
       Path fromImagePath = null;
       if (isCustom) {
         fromImagePath = Paths.get(projectAssetsFolderPathString + "/" + projectIcon);
@@ -473,7 +474,6 @@ public class AuthorAPIController {
   protected String importSteps(Authentication auth, @RequestBody ObjectNode objectNode)
       throws Exception {
     String steps = objectNode.get("steps").asText();
-    steps = steps.replaceAll("%20", " ");
     Integer toProjectId = objectNode.get("toProjectId").asInt();
     Integer fromProjectId = objectNode.get("fromProjectId").asInt();
     User user = userService.retrieveUserByUsername(auth.getName());
@@ -482,25 +482,6 @@ public class AuthorAPIController {
       return null;
     }
 
-    /*
-     * Regex string to match asset file references in the step/component content. e.g. carbon.png
-     */
-    String patternString = "(\'|\"|\\\\\'|\\\\\")([^:][^/]?[^/]?[a-zA-Z0-9@\\._\\/\\s\\-]*[.]"
-        + "(png|PNG|jpe?g|JPE?G|pdf|PDF|gif|GIF|mov|MOV|mp4|MP4|mp3|MP3|wav|WAV|swf|SWF|css|CSS"
-        + "|txt|TXT|json|JSON|xlsx?|XLSX?|doc|DOC|html.*?|HTML.*?|js|JS)).*?(\'|\"|\\\\\'|\\\\\")";
-    Pattern pattern = Pattern.compile(patternString);
-    Matcher matcher = pattern.matcher(steps);
-
-    /*
-     * this list will hold all the file names that are referenced by the steps that we are importing
-     */
-    List<String> fileNames = new ArrayList<String>();
-    while (matcher.find()) {
-      fileNames.add(matcher.group(2));
-    }
-
-    // remove duplicates from the list of file names
-    fileNames = fileNames.stream().distinct().collect(Collectors.toList());
     Project fromProject = projectService.getById(fromProjectId);
     String fromProjectUrl = fromProject.getModulePath();
     Project toProject = projectService.getById(toProjectId);
@@ -531,7 +512,7 @@ public class AuthorAPIController {
     String toProjectAssetsUrl = fullToProjectFolderUrl + "/assets";
     File toProjectAssetsFolder = new File(toProjectAssetsUrl);
 
-    for (String fileName : fileNames) {
+    for (String fileName : getAssetFileNames(steps)) {
       /*
        * Import the asset to the project we are importing to. If the project already contains a file
        * with the same file name and does not have the same file content, it will be given a new
@@ -549,6 +530,24 @@ public class AuthorAPIController {
 
     // send back the steps string which may have been modified if we needed to change a file name
     return steps;
+  }
+
+  protected List<String> getAssetFileNames(String stepsText) {
+    // Replace %20 with a space so that file names with a space will be properly found. Sometimes
+    // html content that contains a file name with a space will replace the space with %20.
+    String stepsTextModified = stepsText.replaceAll("%20", " ");
+
+    // Regex string to match asset file references in the step/component content. e.g. carbon.png
+    String patternString = "(\'|\"|\\\\\'|\\\\\")([^:][^/]?[^/]?[a-zA-Z0-9@\\._\\/\\s\\-]*[.]"
+        + "(png|PNG|jpe?g|JPE?G|pdf|PDF|gif|GIF|mov|MOV|mp4|MP4|mp3|MP3|wav|WAV|swf|SWF|css|CSS"
+        + "|txt|TXT|json|JSON|xlsx?|XLSX?|doc|DOC|html.*?|HTML.*?|js|JS)).*?(\'|\"|\\\\\'|\\\\\")";
+    Pattern pattern = Pattern.compile(patternString);
+    Matcher matcher = pattern.matcher(stepsTextModified);
+    HashSet<String> fileNames = new HashSet<String>();
+    while (matcher.find()) {
+      fileNames.add(matcher.group(2));
+    }
+    return new ArrayList<String>(fileNames);
   }
 
   private void createNewProjectDirectory(String projectId) throws IOException {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -473,6 +473,7 @@ public class AuthorAPIController {
   protected String importSteps(Authentication auth, @RequestBody ObjectNode objectNode)
       throws Exception {
     String steps = objectNode.get("steps").asText();
+    steps = steps.replaceAll("%20", " ");
     Integer toProjectId = objectNode.get("toProjectId").asInt();
     Integer fromProjectId = objectNode.get("fromProjectId").asInt();
     User user = userService.retrieveUserByUsername(auth.getName());

--- a/src/test/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIControllerTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -269,5 +270,23 @@ public class AuthorAPIControllerTest extends APIControllerTest {
         projectJSONString);
     assertEquals("success", response.getStatus());
     assertEquals("projectSaved", response.getMessageCode());
+  }
+
+  @Test
+  public void getAssetFileNames_withDuplicateReferences_shouldReturnUniqueFileNames()
+      throws Exception {
+    String stepsText = "<img src=\"carbon.png\"/><img src=\"carbon.png\"/>";
+    List<String> fileNames = authorAPIController.getAssetFileNames(stepsText);
+    assertEquals(fileNames.size(), 1);
+    assertEquals(fileNames.get(0), "carbon.png");
+  }
+
+  @Test
+  public void getAssetFileNames_withASpace_shouldReturnFileNames() throws Exception {
+    String stepsText = "<img src=\"carbon%20dioxide.png\"/><img src=\"carbon monoxide.png\"/>";
+    List<String> fileNames = authorAPIController.getAssetFileNames(stepsText);
+    assertEquals(fileNames.size(), 2);
+    assertTrue(fileNames.contains("carbon dioxide.png"));
+    assertTrue(fileNames.contains("carbon monoxide.png"));
   }
 }


### PR DESCRIPTION
1. Open a unit in the Authoring Tool.
2. Import a step or component that contains a reference to an image that contains a space in the image file name.
3. The image asset should be copied to your project. Previously it would not copy the image asset to your project.

Closes #16