### PR TITLE
Added api endpoint for changing workgroup's period

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/ChangeWorkgroupPeriodController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/ChangeWorkgroupPeriodController.java
@@ -1,0 +1,45 @@
+package org.wise.portal.presentation.web.controllers.teacher.management;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.group.GroupService;
+import org.wise.portal.service.run.RunService;
+import org.wise.portal.service.workgroup.WorkgroupService;
+
+@Secured({ "ROLE_TEACHER" })
+@RestController
+public class ChangeWorkgroupPeriodController {
+
+  @Autowired
+  private GroupService groupService;
+
+  @Autowired
+  private RunService runService;
+
+  @Autowired
+  private WorkgroupService workgroupService;
+
+  @PostMapping("/api/teacher/run/{runId}/team/{workgroupId}/change-period")
+  void changeWorkgroupPeriod(Authentication auth, @PathVariable Long runId,
+      @PathVariable Long workgroupId, @RequestBody Long newPeriodId)
+      throws ObjectNotFoundException {
+    Run run = runService.retrieveById(runId);
+    if (runService.hasWritePermission(auth, run)) {
+      Workgroup workgroup = workgroupService.retrieveById(workgroupId);
+      Group newPeriod = groupService.retrieveById(newPeriodId);
+      workgroupService.changePeriod(workgroup, newPeriod);
+    } else {
+      throw new AccessDeniedException("User does not have permission to change period");
+    }
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -31,6 +31,7 @@ import org.wise.portal.domain.user.impl.UserImpl;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.service.authentication.UserDetailsService;
+import org.wise.portal.service.group.GroupService;
 import org.wise.portal.service.portal.PortalService;
 import org.wise.portal.service.project.ProjectService;
 import org.wise.portal.service.run.RunService;
@@ -102,6 +103,9 @@ public class APIControllerTest {
 
   @Mock
   protected HttpServletRequest request;
+
+  @Mock
+  protected GroupService groupService;
 
   @Mock
   protected UserService userService;

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/management/ChangeWorkgroupPeriodControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/management/ChangeWorkgroupPeriodControllerTest.java
@@ -1,0 +1,51 @@
+package org.wise.portal.presentation.web.controllers.teacher.management;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.PeriodNotFoundException;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@RunWith(EasyMockRunner.class)
+public class ChangeWorkgroupPeriodControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private ChangeWorkgroupPeriodController controller = new ChangeWorkgroupPeriodController();
+
+  @Test
+  public void changeWorkgroupPeriod_TeacherWithNoWritePermission_ThrowAccessDenied()
+      throws PeriodNotFoundException, ObjectNotFoundException {
+    expect(runService.retrieveById(runId3)).andReturn(run3);
+    expect(runService.hasWritePermission(teacherAuth, run3)).andReturn(false);
+    replay(runService);
+    try {
+      controller.changeWorkgroupPeriod(teacherAuth, runId3, workgroup1.getId(), 2L);
+      fail("AccessDeniedException expected but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verify(runService);
+  }
+
+  @Test
+  public void changeWorkgroupPeriod_TeacherWithPermission_ChangePeriod()
+      throws ObjectNotFoundException {
+    expect(runService.retrieveById(run1.getId())).andReturn(run1);
+    expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(true);
+    expect(workgroupService.retrieveById(workgroup1.getId())).andReturn(workgroup1);
+    expect(groupService.retrieveById(2L)).andReturn(run1Period2);
+    workgroupService.changePeriod(workgroup1, run1Period2);
+    expectLastCall();
+    replay(runService, groupService, workgroupService);
+    controller.changeWorkgroupPeriod(teacherAuth, runId1, workgroup1.getId(), 2L);
+    verify(runService, groupService, workgroupService);
+  }
+}


### PR DESCRIPTION
## Changes
- Added api endpoint for changing workgroup's period.
```
url: /api/teacher/run/{runId}/team/{workgroupId}/change-period
method: POST
body: periodId
```
- Added unit tests

## Test
- Teacher without write access to the run throws AccessDeniedException
- Teacher with write access to the run changes workgroup period
 
Closes #18