### PR TITLE
Change workgroup membership and fetch all workgroups

### DIFF
--- a/src/main/java/org/wise/portal/domain/workgroup/WorkgroupSerializer.java
+++ b/src/main/java/org/wise/portal/domain/workgroup/WorkgroupSerializer.java
@@ -1,0 +1,19 @@
+package org.wise.portal.domain.workgroup;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class WorkgroupSerializer extends JsonSerializer<Workgroup> {
+
+  @Override
+  public void serialize(Workgroup workgroup, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeStartObject();
+    gen.writeObjectField("id", workgroup.getId());
+    gen.writeObjectField("periodId", workgroup.getPeriod().getId());
+    gen.writeEndObject();
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupGetAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupGetAPIController.java
@@ -1,0 +1,27 @@
+package org.wise.portal.presentation.web.controllers.teacher.run;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.run.RunService;
+
+@Secured({ "ROLE_TEACHER" })
+@RestController
+public class WorkgroupGetAPIController {
+
+  @Autowired
+  protected RunService runService;
+
+  @GetMapping("/api/teacher/run/{runId}/period/{periodId}/workgroups")
+  protected List<Workgroup> getWorkgroups(@PathVariable Long runId, @PathVariable Long periodId)
+      throws ObjectNotFoundException {
+    return runService.getWorkgroups(runId, periodId);
+  }
+
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIController.java
@@ -1,0 +1,38 @@
+package org.wise.portal.presentation.web.controllers.teacher.run;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.domain.impl.ChangeWorkgroupParameters;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.user.UserService;
+import org.wise.portal.service.workgroup.WorkgroupService;
+
+@Secured({ "ROLE_TEACHER" })
+@RestController
+public class WorkgroupMembershipAPIController {
+
+  @Autowired
+  protected UserService userService;
+
+  @Autowired
+  protected WorkgroupService workgroupService;
+
+  @PostMapping("/api/teacher/run/{runId}/workgroup/move-user/{userId}")
+  protected void moveUserBetweenWorkgroups(@PathVariable Long runId, @PathVariable Long userId,
+      @RequestBody ObjectNode postedParams) throws Exception {
+    ChangeWorkgroupParameters params = new ChangeWorkgroupParameters();
+    params.setRunId(runId);
+    params.setStudent(userService.retrieveById(userId));
+    Workgroup fromWorkgroup = workgroupService.retrieveById(postedParams.get("workgroupIdFrom").asLong());
+    params.setWorkgroupFrom(fromWorkgroup);
+    params.setWorkgroupTo(workgroupService.retrieveById(postedParams.get("workgroupIdTo").asLong()));
+    params.setPeriodId(fromWorkgroup.getPeriod().getId());
+    workgroupService.updateWorkgroupMembership(params);
+  }
+}

--- a/src/main/java/org/wise/portal/service/workgroup/WorkgroupJsonModule.java
+++ b/src/main/java/org/wise/portal/service/workgroup/WorkgroupJsonModule.java
@@ -1,0 +1,17 @@
+package org.wise.portal.service.workgroup;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.springframework.stereotype.Service;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.domain.workgroup.WorkgroupSerializer;
+
+@Service
+public class WorkgroupJsonModule extends SimpleModule {
+
+  private static final long serialVersionUID = 1L;
+
+  public WorkgroupJsonModule() {
+    this.addSerializer(Workgroup.class, new WorkgroupSerializer());
+  }
+}

--- a/src/test/java/org/wise/portal/domain/workgroup/WorkgroupTest.java
+++ b/src/test/java/org/wise/portal/domain/workgroup/WorkgroupTest.java
@@ -1,0 +1,33 @@
+package org.wise.portal.domain.workgroup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wise.portal.domain.DomainTest;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
+import org.wise.portal.service.workgroup.WorkgroupJsonModule;
+
+public class WorkgroupTest extends DomainTest {
+
+  Workgroup workgroup;
+
+  @Before
+  public void setup() {
+    super.setup();
+    workgroup = new WorkgroupImpl();
+    workgroup.setId(123L);
+    workgroup.setPeriod(period);
+  }
+
+  @Test
+  public void serialize() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule((new WorkgroupJsonModule()));
+    String json = mapper.writeValueAsString(workgroup);
+    String expectedJson = "{\"id\":123,\"periodId\":100}";
+    assertEquals(expectedJson, json);
+  }
+}


### PR DESCRIPTION
## Changes

## Test
1. Test fetching all workgroups in a period. This should return a list of all workgroups in the period, including empty workgroups. Each workgroup only has two fields at the moment: id and periodId.
```
url: /api/teacher/run/RUN_ID/period/PERIOD_ID/workgroups
method: GET
```

2. Test moving a user from from an old group to a new group. If all goes well (i.e., no exception is thrown in the process), the member should be moved from workgroupIdFrom to workgroupIdTo.
```
url: /api/teacher/run/RUN_ID/workgroup/move-user/USER_ID
method: POST
body: 
  {
        workgroupIdFrom: WORKGROUP_ID<number>,
        workgroupIdTo: WORKGROUP_ID<number>
  }
```


Closes #20 
Closes #21