### PR TITLE
New Endpoint for creating new team and showing unassigned students

### DIFF
--- a/src/main/java/org/wise/portal/domain/workgroup/impl/WorkgroupImpl.java
+++ b/src/main/java/org/wise/portal/domain/workgroup/impl/WorkgroupImpl.java
@@ -93,6 +93,33 @@ public class WorkgroupImpl implements Workgroup, Comparable<WorkgroupImpl> {
   @JoinTable(name = "workgroups_related_to_tags", joinColumns = { @JoinColumn(name = "workgroups_fk", nullable = false) }, inverseJoinColumns = @JoinColumn(name = "tags_fk", nullable = false))
   private Set<Tag> tags = new HashSet<Tag>();
 
+  public WorkgroupImpl() {}
+
+  /**
+   * Alternate WorkgroupImpl constructor with default users
+   * A teacher can be in a Workgroup. In this case, the members provided as a parameter in this
+   * method must match the owners of the run.
+   *
+   * @param name workgroup name
+   * @param members set of users in this workgroup
+   * @param run the <code>Run</code> that this workgroup belongs in
+   * @param period <code>Group</code> that this workgroup belongs in
+   * @return the created <code>Workgroup</code>
+   */
+  public WorkgroupImpl(String name, Set<User> members, Run run, Group period) {
+    this.getGroup().setName(name);
+    for (User member : members) {
+      this.addMember(member);
+    }
+    this.setRun(run);
+    this.setPeriod(period);
+    if ((run.getOwner() != null && members.size() == 1
+        && run.getOwner().equals(members.iterator().next()))
+        || (members.size() > 0 && run.getSharedowners() != null && run.getSharedowners().containsAll(members))) {
+          this.setTeacherWorkgroup(true);
+    }
+  }
+
   public Set<User> getMembers() {
     return this.group.getMembers();
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupController.java
@@ -1,0 +1,64 @@
+package org.wise.portal.presentation.web.controllers.teacher.management;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.group.GroupService;
+import org.wise.portal.service.run.RunService;
+import org.wise.portal.service.user.UserService;
+import org.wise.portal.service.workgroup.WorkgroupService;
+
+@Secured({ "ROLE_TEACHER" })
+@RestController
+public class CreateWorkgroupController {
+
+  @Autowired
+  private GroupService groupService;
+
+  @Autowired
+  private RunService runService;
+
+  @Autowired
+  private WorkgroupService workgroupService;
+
+  @Autowired
+  private UserService userService;
+
+  @PostMapping("/api/teacher/run/{runId}/workgroup/create/{periodId}")
+  long createWorkgroup(Authentication auth, @PathVariable Long runId,
+      @PathVariable Long periodId, @RequestBody List<Long> userIds) throws ObjectNotFoundException {
+    Run run = runService.retrieveById(runId);
+    if (runService.hasWritePermission(auth, run)) {
+      HashSet<User> newGroupMembers = new HashSet<User>();
+      for (Long userId : userIds) {
+        User user = userService.retrieveById(userId);
+        List<Workgroup> workgroups = workgroupService.getWorkgroupListByRunAndUser(run, user);
+        if (workgroups.size() > 0) {
+          Workgroup workgroup = workgroups.get(0); // student can be in only one workgroup per run
+          workgroupService.removeMembers(workgroup, Collections.singleton(user));
+        }
+        newGroupMembers.add(user);
+      }
+      Group period = groupService.retrieveById(periodId);
+      Workgroup newWorkgroup =
+          workgroupService.createWorkgroup("Student", newGroupMembers, run, period);
+      return newWorkgroup.getId();
+    } else {
+      throw new AccessDeniedException("User does not have permission to change period");
+    }
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIController.java
@@ -1,6 +1,6 @@
 package org.wise.portal.presentation.web.controllers.teacher.run;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.domain.impl.ChangeWorkgroupParameters;
-import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.user.UserService;
 import org.wise.portal.service.workgroup.WorkgroupService;
 
@@ -25,14 +24,19 @@ public class WorkgroupMembershipAPIController {
 
   @PostMapping("/api/teacher/run/{runId}/workgroup/move-user/{userId}")
   protected void moveUserBetweenWorkgroups(@PathVariable Long runId, @PathVariable Long userId,
-      @RequestBody ObjectNode postedParams) throws Exception {
+      @RequestBody JsonNode postedParams) throws Exception {
     ChangeWorkgroupParameters params = new ChangeWorkgroupParameters();
     params.setRunId(runId);
     params.setStudent(userService.retrieveById(userId));
-    Workgroup fromWorkgroup = workgroupService.retrieveById(postedParams.get("workgroupIdFrom").asLong());
-    params.setWorkgroupFrom(fromWorkgroup);
-    params.setWorkgroupTo(workgroupService.retrieveById(postedParams.get("workgroupIdTo").asLong()));
-    params.setPeriodId(fromWorkgroup.getPeriod().getId());
+    Long fromWorkgroupId = postedParams.get("workgroupIdFrom").asLong();
+    if (fromWorkgroupId > 0) {
+      params.setWorkgroupFrom(workgroupService.retrieveById(fromWorkgroupId));
+    }
+    Long toWorkgroupId = postedParams.get("workgroupIdTo").asLong();
+    if (toWorkgroupId > 0) {
+      params.setWorkgroupTo(workgroupService.retrieveById(toWorkgroupId));
+    }
+    params.setPeriodId(postedParams.get("periodId").asLong());
     workgroupService.updateWorkgroupMembership(params);
   }
 }

--- a/src/main/java/org/wise/portal/service/workgroup/impl/WorkgroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/workgroup/impl/WorkgroupServiceImpl.java
@@ -71,39 +71,10 @@ public class WorkgroupServiceImpl implements WorkgroupService {
 
   @Transactional()
   public Workgroup createWorkgroup(String name, Set<User> members, Run run, Group period) {
-    Workgroup workgroup = createWorkgroup(members, run, period);
+    Workgroup workgroup = new WorkgroupImpl(name, members, run, period);
     groupDao.save(workgroup.getGroup());
     workgroupDao.save(workgroup);
     aclService.addPermission(workgroup, BasePermission.ADMINISTRATION);
-    return workgroup;
-  }
-
-  /**
-   * A helper method to create a <code>Workgroup</code> given parameters.
-   *
-   * A teacher can be in a Workgroup. In this case, the members provided as a parameter in this
-   * method must match the owners of the run.
-   *
-   * @param members
-   *                  set of users in this workgroup
-   * @param run
-   *                  the <code>Run</code> that this workgroup belongs in
-   * @param period
-   *                  <code>Group</code> that this workgroup belongs in
-   * @return the created <code>Workgroup</code>
-   */
-  private Workgroup createWorkgroup(Set<User> members, Run run, Group period) {
-    Workgroup workgroup = new WorkgroupImpl();
-    for (User member : members) {
-      workgroup.addMember(member);
-    }
-    workgroup.setRun(run);
-    workgroup.setPeriod(period);
-    if ((run.getOwner() != null && members.size() == 1
-        && run.getOwner().equals(members.iterator().next()))
-        || (run.getSharedowners() != null && run.getSharedowners().containsAll(members))) {
-      workgroup.setTeacherWorkgroup(true);
-    }
     return workgroup;
   }
 

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -47,6 +47,12 @@ public class APIControllerTest {
 
   protected final String STUDENT_USERNAME = "SpongeBobS0101";
 
+  protected final String STUDENT2_FIRSTNAME = "Patrick";
+
+  protected final String STUDENT2_LASTNAME = "Starr";
+
+  protected final String STUDENT2_USERNAME = "PatrickS0101";
+
   protected final String STUDENT_PASSWORD = "studentPass";
 
   protected final String STUDENT1_GOOGLE_ID = "google-user-12345";
@@ -65,13 +71,15 @@ public class APIControllerTest {
 
   protected Long student1Id = 94678L;
 
+  protected Long student2Id = 94679L;
+
   protected Long teacher1Id = 94210L;
 
-  protected User student1, teacher1, teacher2, admin1;
+  protected User student1, student2, teacher1, teacher2, admin1;
 
   protected Authentication studentAuth, teacherAuth, adminAuth;
 
-  protected StudentUserDetails student1UserDetails;
+  protected StudentUserDetails student1UserDetails, student2UserDetails;
 
   protected TeacherUserDetails teacher1UserDetails, admin1UserDetails;
 
@@ -95,7 +103,7 @@ public class APIControllerTest {
 
   protected List<Tag> run1Tags;
 
-  protected Workgroup workgroup1, teacher1Run1Workgroup;
+  protected Workgroup workgroup1, workgroup2, teacher1Run1Workgroup;
 
   protected Project project1, project2, project3;
 
@@ -143,6 +151,18 @@ public class APIControllerTest {
     student1UserDetails.setAuthorities(new GrantedAuthority[] { studentAuthority });
     student1UserDetails.setGoogleUserId(STUDENT1_GOOGLE_ID);
     student1.setUserDetails(student1UserDetails);
+    student2 = new UserImpl();
+    student2.setId(student2Id);
+    PersistentGrantedAuthority studentAuthority2 = new PersistentGrantedAuthority();
+    studentAuthority2.setAuthority(UserDetailsService.STUDENT_ROLE);
+    student2UserDetails = new StudentUserDetails();
+    student2UserDetails.setFirstname(STUDENT2_FIRSTNAME);
+    student2UserDetails.setLastname(STUDENT2_LASTNAME);
+    student2UserDetails.setUsername(STUDENT2_USERNAME);
+    student2UserDetails.setGender(Gender.FEMALE);
+    student2UserDetails.setNumberOfLogins(10);
+    student2UserDetails.setAuthorities(new GrantedAuthority[] { studentAuthority2 });
+    student2.setUserDetails(student2UserDetails);
     Object credentials = null;
     studentAuth = new TestingAuthenticationToken(student1UserDetails, credentials);
     teacher1 = new UserImpl();
@@ -193,6 +213,10 @@ public class APIControllerTest {
     workgroup1.addMember(student1);
     workgroup1.setPeriod(run1Period1);
     workgroup1.setRun(run1);
+    workgroup2 = new WorkgroupImpl();
+    workgroup2.addMember(student2);
+    workgroup2.setPeriod(run1Period1);
+    workgroup2.setRun(run1);
     teacher1Run1Workgroup = new WorkgroupImpl();
     teacher1Run1Workgroup.addMember(teacher1);
     teacher1Run1Workgroup.setRun(run1);
@@ -237,6 +261,7 @@ public class APIControllerTest {
   @After
   public void tearDown() {
     student1 = null;
+    student2 = null;
     teacher1 = null;
     teacher2 = null;
     run1 = null;

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupControllerTest.java
@@ -1,0 +1,64 @@
+package org.wise.portal.presentation.web.controllers.teacher.management;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+@RunWith(EasyMockRunner.class)
+public class CreateWorkgroupControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private CreateWorkgroupController controller = new CreateWorkgroupController();
+
+  @Test
+  public void createWorkgroup_NoWritePermission_ThrowAccessDenied() throws ObjectNotFoundException {
+    expect(runService.retrieveById(runId3)).andReturn(run3);
+    expect(runService.hasWritePermission(teacherAuth, run3)).andReturn(false);
+    replay(runService);
+    try {
+      List<Long> userIds = Stream.of(2L).collect(Collectors.toList());
+      controller.createWorkgroup(teacherAuth, runId3, run1Period1.getId(), userIds);
+      fail("AccessDeniedException expected but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verify(runService);
+  }
+
+  @Test
+  public void createWorkgroup_UserInWorkgroup_CallRemoveMembers() throws ObjectNotFoundException {
+    expect(runService.retrieveById(runId1)).andReturn(run1);
+    expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(true);
+    expect(userService.retrieveById(student1.getId())).andReturn(student1);
+    expect(workgroupService.getWorkgroupListByRunAndUser(run1, student1))
+      .andReturn(Stream.of(workgroup1).collect(Collectors.toList()));
+    workgroupService.removeMembers(workgroup1, Collections.singleton(student1));
+    expectLastCall();
+    expect(groupService.retrieveById(run1Period1.getId())).andReturn(run1Period1);
+    Workgroup newWorkgroup = new WorkgroupImpl();
+    newWorkgroup.setId(2L);
+    expect(workgroupService.createWorkgroup(isA(String.class), isA(HashSet.class), isA(Run.class), isA(Group.class)))
+      .andReturn(newWorkgroup);
+    replay(runService, userService, workgroupService, groupService);
+    List<Long> userIds = Stream.of(student1.getId()).collect(Collectors.toList());
+    controller.createWorkgroup(teacherAuth, runId1, run1Period1.getId(), userIds);
+    verify(runService, userService, workgroupService, groupService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIControllerTest.java
@@ -1,0 +1,36 @@
+package org.wise.portal.presentation.web.controllers.teacher.run;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.easymock.EasyMock.*;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.domain.impl.ChangeWorkgroupParameters;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+
+@RunWith(EasyMockRunner.class)
+public class WorkgroupMembershipAPIControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private WorkgroupMembershipAPIController controller = new WorkgroupMembershipAPIController();
+
+  @Test
+  public void moveUserBetweenWorkgroups_allParamsSet_updateMembership() throws Exception {
+    String paramString = "{\"workgroupIdFrom\":\"1\",\"workgroupIdTo\":\"2\",\"periodId\":\"1\"}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode postedParams = objectMapper.readTree(paramString);
+    expect(userService.retrieveById(student1Id)).andReturn(student1);
+    expect(workgroupService.retrieveById(1L)).andReturn(workgroup1);
+    expect(workgroupService.retrieveById(2L)).andReturn(workgroup2);
+    expect(workgroupService.updateWorkgroupMembership(isA(ChangeWorkgroupParameters.class)))
+      .andReturn(new WorkgroupImpl());
+    replay(userService, workgroupService);
+    controller.moveUserBetweenWorkgroups(runId1, student1Id, postedParams);
+    verify(userService, workgroupService);
+  }
+}


### PR DESCRIPTION
## Changes
- Added new endpoint for creating a new team with at least one member
- Add unassigned students in run config

## Test creating a new team
- POST to /api/teacher/run/{runId}/workgroup/create/{periodId} with an array of userId's as request data ```[1,2,3]```. It will create a new team with the members and return the id of the new team. 
- If the user is already in a team, she will be removed from the team and placed in a new team.

## Test getting unassigned students in run config
- Make a GET request to http://localhost:81/api/config/classroomMonitor/{runId}. In the response, the classmateUserInfos field should contain unassigned student id's. They appear in a block without a workgroupId.

Closes #27 