### PR TITLE
feat(Peer Interaction): Add service method to get PeerGroupActivity for component

### DIFF
--- a/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
@@ -37,13 +37,18 @@ import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import org.json.JSONException;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.run.impl.RunImpl;
 
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * @author Hiroki Terashima
+ */
 @Entity
 @Table(name = "peer_group_activities", indexes = {
   @Index(columnList = "runId", name = "peer_group_activities_run_id_index")
@@ -72,11 +77,25 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
   private String logic;
 
   @Column
-  private Integer logicThresholdCount = 0;
+  private int logicThresholdCount = 0;
 
   @Column
-  private Integer logicThresholdPercent = 0;
+  private int logicThresholdPercent = 0;
 
   @Column
-  private Integer maxMembershipCount = 2;
+  private int maxMembershipCount = 2;
+
+  public PeerGroupActivityImpl() {
+  }
+
+  public PeerGroupActivityImpl(Run run, String nodeId, ProjectComponent component)
+      throws JSONException {
+    this.run = run;
+    this.nodeId = nodeId;
+    this.componentId = component.getId();
+    this.logic = component.getString("logic");
+    this.logicThresholdCount = component.getInt("logicThresholdCount");
+    this.logicThresholdPercent = component.getInt("logicThresholdPercent");
+    this.maxMembershipCount = component.getInt("maxMembershipCount");
+  }
 }

--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
@@ -21,19 +21,36 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.domain.peergroupactivity;
+package org.wise.portal.domain.project.impl;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import lombok.Getter;
 
 /**
- * A class that defines location of peer group activities and how to group workgroups together
+ * ProjectComponent defines activities that students work on,
+ * like MultipleChoice, OpenResponse, etc.
+ *
  * @author Hiroki Terashima
  */
-public interface PeerGroupActivity {
+public class ProjectComponent {
 
-  String getLogic();
+  JSONObject componentJSON;
 
-  int getLogicThresholdCount();
+  @Getter
+  String id;
 
-  int getLogicThresholdPercent();
+  public ProjectComponent(JSONObject componentJSON) throws JSONException {
+    this.componentJSON = componentJSON;
+    this.id = componentJSON.getString("id");
+  }
 
-  int getMaxMembershipCount();
+  public String getString(String key) throws JSONException {
+    return this.componentJSON.getString(key);
+  }
+
+  public int getInt(String key) throws JSONException {
+    return this.componentJSON.getInt(key);
+  }
 }

--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectContent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectContent.java
@@ -21,19 +21,39 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.domain.peergroupactivity;
+package org.wise.portal.domain.project.impl;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
- * A class that defines location of peer group activities and how to group workgroups together
+ * A class that stores the entire content for a project.
  * @author Hiroki Terashima
  */
-public interface PeerGroupActivity {
+public class ProjectContent {
 
-  String getLogic();
+  JSONObject projectJSON;
 
-  int getLogicThresholdCount();
+  public ProjectContent(JSONObject projectJSON) {
+    this.projectJSON = projectJSON;
+  }
 
-  int getLogicThresholdPercent();
+  public ProjectNode getNode(String nodeId) throws JSONException {
+    JSONArray nodes = this.projectJSON.getJSONArray("nodes");
+    for (int i = 0; i < nodes.length(); i++) {
+      JSONObject node = nodes.getJSONObject(i);
+      if (node.getString("id").equals(nodeId)) {
+        return new ProjectNode(node);
+      }
+    }
+    return null;
+  }
 
-  int getMaxMembershipCount();
+  public ProjectComponent getComponent(String nodeId, String componentId) throws JSONException {
+    ProjectNode node = getNode(nodeId);
+    return node != null ? node.getComponent(componentId) : null;
+  }
 }
+
+

--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectNode.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectNode.java
@@ -21,19 +21,34 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.domain.peergroupactivity;
+package org.wise.portal.domain.project.impl;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
- * A class that defines location of peer group activities and how to group workgroups together
+ * ProjectNode stores a list of <code>ProjectComponent</code> and is used to organize
+ * the structure of a Project's content.
+ *
  * @author Hiroki Terashima
  */
-public interface PeerGroupActivity {
+public class ProjectNode {
 
-  String getLogic();
+  JSONObject nodeJSON;
 
-  int getLogicThresholdCount();
+  public ProjectNode(JSONObject nodeJSON) {
+    this.nodeJSON = nodeJSON;
+  }
 
-  int getLogicThresholdPercent();
-
-  int getMaxMembershipCount();
+  public ProjectComponent getComponent(String componentId) throws JSONException {
+    JSONArray components = nodeJSON.getJSONArray("components");
+    for (int c = 0; c < components.length(); c++) {
+      JSONObject component = components.getJSONObject(c);
+      if (component.getString("id").equals(componentId)) {
+        return new ProjectComponent(component);
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityNotFoundException.java
+++ b/src/main/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityNotFoundException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Copyright (c) 2007-2021 Regents of the University of California (Regents).
  * Created by WISE, Graduate School of Education, University of California, Berkeley.
  *
  * This software is distributed under the GNU General Public License, v3,
@@ -21,19 +21,16 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.domain.peergroupactivity;
+package org.wise.portal.service.peergroupactivity;
 
 /**
- * A class that defines location of peer group activities and how to group workgroups together
+ * A checked exception that is thrown when the PeerGroupActivity does not exist in
+ * the data store and the curriculum content
+ *
  * @author Hiroki Terashima
  */
-public interface PeerGroupActivity {
+public class PeerGroupActivityNotFoundException extends Exception {
 
-  String getLogic();
+  private static final long serialVersionUID = 1L;
 
-  int getLogicThresholdCount();
-
-  int getLogicThresholdPercent();
-
-  int getMaxMembershipCount();
 }

--- a/src/main/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityService.java
+++ b/src/main/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityService.java
@@ -21,19 +21,26 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.domain.peergroupactivity;
+package org.wise.portal.service.peergroupactivity;
+
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.run.Run;
 
 /**
- * A class that defines location of peer group activities and how to group workgroups together
  * @author Hiroki Terashima
  */
-public interface PeerGroupActivity {
+public interface PeerGroupActivityService {
 
-  String getLogic();
-
-  int getLogicThresholdCount();
-
-  int getLogicThresholdPercent();
-
-  int getMaxMembershipCount();
+  /**
+   * Retrieves PeerGroupActivity from the database or curriculum unit for the specified component
+   *
+   * @param run
+   * @param nodeId
+   * @param componentId
+   * @return PeerGroupActivity
+   * @throws PeerGroupActivityNotFoundException if PeerGroupActivity is not found in the
+   *   database or curriculum unit for the specified component
+   */
+  PeerGroupActivity getByComponent(Run run, String nodeId, String componentId) throws
+      PeerGroupActivityNotFoundException;
 }

--- a/src/main/java/org/wise/portal/service/peergroupactivity/impl/PeerGroupActivityServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroupactivity/impl/PeerGroupActivityServiceImpl.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroupactivity.impl;
+
+import java.io.File;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.wise.portal.dao.peergroupactivity.PeerGroupActivityDao;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.project.impl.ProjectContent;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
+
+/**
+ * @author Hiroki Terashima
+ */
+public class PeerGroupActivityServiceImpl implements PeerGroupActivityService {
+
+  @Autowired
+  private PeerGroupActivityDao<PeerGroupActivity> peerGroupActivityDao;
+
+  @Autowired
+  protected Environment appProperties;
+
+  @Override
+  public PeerGroupActivity getByComponent(Run run, String nodeId, String componentId)
+      throws PeerGroupActivityNotFoundException {
+    PeerGroupActivity activity = peerGroupActivityDao.getByComponent(run, nodeId, componentId);
+    if (activity == null) {
+      activity = getPeerGroupActivityFromUnit(run, nodeId, componentId);
+      peerGroupActivityDao.save(activity);
+    }
+    return activity;
+  }
+
+  private PeerGroupActivity getPeerGroupActivityFromUnit(Run run, String nodeId,
+      String componentId) throws PeerGroupActivityNotFoundException {
+    try {
+      String projectFilePath = appProperties.getProperty("curriculum_base_dir") +
+          run.getProject().getModulePath();
+      String projectString = FileUtils.readFileToString(new File(projectFilePath));
+      JSONObject projectJSON = new JSONObject(projectString);
+      ProjectContent projectContent = new ProjectContent(projectJSON);
+      ProjectComponent component = projectContent.getComponent(nodeId, componentId);
+      if (component != null) {
+        return new PeerGroupActivityImpl(run, nodeId, component);
+      }
+    } catch (Exception e) {
+    }
+    throw new PeerGroupActivityNotFoundException();
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityServiceImplTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroupactivity;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+import static org.powermock.api.easymock.PowerMock.verifyAll;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.env.Environment;
+import org.wise.portal.dao.peergroupactivity.PeerGroupActivityDao;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.domain.project.Project;
+import org.wise.portal.domain.project.impl.ProjectImpl;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
+import org.wise.portal.service.peergroupactivity.impl.PeerGroupActivityServiceImpl;
+
+/**
+ * @author Hiroki Terashima
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
+@PrepareForTest(FileUtils.class)
+public class PeerGroupActivityServiceImplTest {
+
+  @TestSubject
+  private PeerGroupActivityService service = new PeerGroupActivityServiceImpl();
+
+  @Mock
+  private PeerGroupActivityDao<PeerGroupActivity> peerGroupActivityDao;
+
+  @Mock
+  private Environment appProperties;
+
+  private Run run = new RunImpl();
+
+  private String nodeId = "node1";
+
+  private String componentIdWithPGActivity = "component1";
+
+  private String componentIdWithoutPGActivity = "component2";
+
+  private String logic = "[{“name”: “maximizeSimilarIdeas”, “nodeId”: “node1”, “componentId”: “xyz”}]";
+
+  private int logicThresholdCount = 10;
+
+  private int logicThresholdPercent = 50;
+
+  private int maxMembershipCount = 2;
+
+  private String projectJSONString = "{\"nodes\":[{\"id\":\"" + nodeId + "\"," +
+      "\"components\":[" +
+      "{\"id\":\"" + componentIdWithPGActivity + "\",\"logic\":\"" + logic + "\"," +
+      "\"logicThresholdCount\":\"" + logicThresholdCount + "\"," +
+      "\"logicThresholdPercent\":\"" + logicThresholdPercent + "\"," +
+      "\"maxMembershipCount\":\"" + maxMembershipCount + "\"" +
+      "}, {\"id\":\"" + componentIdWithoutPGActivity + "\"}]}]}";
+
+  @Before
+  public void setUp() {
+    PowerMock.mockStatic(FileUtils.class);
+    Project project = new ProjectImpl();
+    project.setModulePath("/1/project.json");
+    run.setProject(project);
+  }
+
+  @Test
+  public void getByComponent_foundInDB_ReturnPeerGroupActivity() throws
+      PeerGroupActivityNotFoundException {
+    PeerGroupActivity peerGroupActivity = new PeerGroupActivityImpl();
+    expect(peerGroupActivityDao.getByComponent(run, nodeId,
+        componentIdWithPGActivity)).andReturn(peerGroupActivity);
+    replay(peerGroupActivityDao);
+    assertEquals(peerGroupActivity, service.getByComponent(run, nodeId,
+        componentIdWithPGActivity));
+    verify(peerGroupActivityDao);
+  }
+
+  @Test
+  public void getByComponent_notInDBButInContent_ReturnPeerGroupActivity() throws
+      IOException, PeerGroupActivityNotFoundException {
+    expect(peerGroupActivityDao.getByComponent(run, nodeId,
+        componentIdWithPGActivity)).andReturn(null);
+    expect(appProperties.getProperty("curriculum_base_dir")).andReturn("/var/curriculum");
+    expect(FileUtils.readFileToString(isA(File.class))).andReturn(projectJSONString);
+    peerGroupActivityDao.save(isA(PeerGroupActivity.class));
+    expectLastCall();
+    replayAll();
+    PeerGroupActivity activity = service.getByComponent(run, nodeId,
+        componentIdWithPGActivity);
+    assertEquals(logic, activity.getLogic());
+    assertEquals(logicThresholdCount, activity.getLogicThresholdCount());
+    assertEquals(logicThresholdPercent, activity.getLogicThresholdPercent());
+    assertEquals(maxMembershipCount, activity.getMaxMembershipCount());
+    verifyAll();
+  }
+
+  @Test
+  public void getByComponent_notInDBAndNotInContent_ThrowException() throws IOException {
+    expect(peerGroupActivityDao.getByComponent(run, nodeId, componentIdWithoutPGActivity))
+        .andReturn(null);
+    expect(appProperties.getProperty("curriculum_base_dir")).andReturn("/var/curriculum");
+    expect(FileUtils.readFileToString(isA(File.class))).andReturn(projectJSONString);
+    replayAll();
+    try {
+      service.getByComponent(run, nodeId, componentIdWithoutPGActivity);
+      fail("PeerGroupActivityNotFoundException expected to be thrown, but was not thrown");
+    } catch (PeerGroupActivityNotFoundException e) {
+    }
+    verifyAll();
+  }
+}


### PR DESCRIPTION
## Changes
- Add PeerGroupActivityService and getByComponent() method to return PeerGroupActivity for a specific component
  - if found in the database (i.e. it was parsed before), return it
  - if not found in the db but found in the unit content, parse the unit content, save to db, and return it
  - if not found in the db or content, throw PeerGroupActivityNotFoundException
- Add supporting classes (ProjectContent, ProjectNode, ProjectComponent) to parse the project JSON

## Test
- Code and tests look ok, no glaring issues

Closes #40 