### PR TITLE
feat(Peer Group): Add service method to get/create PeerGroup

### DIFF
--- a/src/main/java/org/wise/portal/dao/work/StudentWorkDao.java
+++ b/src/main/java/org/wise/portal/dao/work/StudentWorkDao.java
@@ -41,4 +41,11 @@ public interface StudentWorkDao<T extends StudentWork> extends SimpleDao<T> {
   List<StudentWork> getStudentWorkListByParams(Integer id, Run run, Group period,
       Workgroup workgroup, Boolean isAutoSave, Boolean isSubmit, String nodeId, String componentId,
       String componentType, List<JSONObject> components);
+
+  List<StudentWork> getWorkForComponentByWorkgroup(Workgroup workgroup, String nodeId,
+      String componentId);
+
+  List<StudentWork> getWorkForComponentByPeriod(Run run, Group period, String nodeId,
+      String componentId);
+
 }

--- a/src/main/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDao.java
+++ b/src/main/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDao.java
@@ -86,6 +86,39 @@ public class HibernateStudentWorkDao extends AbstractHibernateDao<StudentWork>
     return (List<StudentWork>) query.getResultList();
   }
 
+  @Override
+  public List<StudentWork> getWorkForComponentByPeriod(Run run, Group period, String nodeId,
+      String componentId) {
+    CriteriaBuilder cb = getCriteriaBuilder();
+    CriteriaQuery<StudentWork> cq = cb.createQuery(StudentWork.class);
+    Root<StudentWork> studentWorkRoot = cq.from(StudentWork.class);
+    List<Predicate> predicates = new ArrayList<Predicate>();
+    predicates.add(cb.equal(studentWorkRoot.get("run"), run));
+    predicates.add(cb.equal(studentWorkRoot.get("period"), period));
+    predicates.add(cb.equal(studentWorkRoot.get("nodeId"), nodeId));
+    predicates.add(cb.equal(studentWorkRoot.get("componentId"), componentId));
+    cq.select(studentWorkRoot).where(predicates.toArray(new Predicate[predicates.size()]))
+    .orderBy(cb.asc(studentWorkRoot.get("serverSaveTime")));
+    TypedQuery<StudentWork> query = entityManager.createQuery(cq);
+    return (List<StudentWork>) query.getResultList();
+  }
+
+  @Override
+  public List<StudentWork> getWorkForComponentByWorkgroup(Workgroup workgroup, String nodeId,
+      String componentId) {
+    CriteriaBuilder cb = getCriteriaBuilder();
+    CriteriaQuery<StudentWork> cq = cb.createQuery(StudentWork.class);
+    Root<StudentWork> studentWorkRoot = cq.from(StudentWork.class);
+    List<Predicate> predicates = new ArrayList<Predicate>();
+    predicates.add(cb.equal(studentWorkRoot.get("workgroup"), workgroup));
+    predicates.add(cb.equal(studentWorkRoot.get("nodeId"), nodeId));
+    predicates.add(cb.equal(studentWorkRoot.get("componentId"), componentId));
+    cq.select(studentWorkRoot).where(predicates.toArray(new Predicate[predicates.size()]))
+    .orderBy(cb.asc(studentWorkRoot.get("serverSaveTime")));
+    TypedQuery<StudentWork> query = entityManager.createQuery(cq);
+    return (List<StudentWork>) query.getResultList();
+  }
+
   private List<Predicate> getStudentWorkListByParamsPredicates(CriteriaBuilder cb,
       Root<StudentWork> studentWorkRoot, Integer id, Run run, Group period, Workgroup workgroup,
       Boolean isAutoSave, Boolean isSubmit, String nodeId, String componentId, String componentType,

--- a/src/main/java/org/wise/portal/domain/peergroup/PeerGroup.java
+++ b/src/main/java/org/wise/portal/domain/peergroup/PeerGroup.java
@@ -23,9 +23,13 @@
  */
 package org.wise.portal.domain.peergroup;
 
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+
 /**
  * An interface that defines a group of workgroups
  * @author Hiroki Terashima
  */
 public interface PeerGroup {
+
+  PeerGroupActivity getPeerGroupActivity();
 }

--- a/src/main/java/org/wise/portal/domain/peergroup/impl/PeerGroupImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroup/impl/PeerGroupImpl.java
@@ -71,4 +71,11 @@ public class PeerGroupImpl implements PeerGroup {
       joinColumns = { @JoinColumn(name = "peer_group_fk", nullable = false)},
       inverseJoinColumns = @JoinColumn(name = "workgroup_fk", nullable = false))
   private Set<Workgroup> members = new HashSet<Workgroup>();
+
+  public PeerGroupImpl() {}
+
+  public PeerGroupImpl(PeerGroupActivity activity, Set<Workgroup> members) {
+    this.peerGroupActivity = activity;
+    this.members = members;
+  }
 }

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
@@ -23,13 +23,26 @@
  */
 package org.wise.portal.domain.peergroupactivity;
 
+import org.json.JSONException;
+import org.wise.portal.domain.run.Run;
+
 /**
  * A class that defines location of peer group activities and how to group workgroups together
  * @author Hiroki Terashima
  */
 public interface PeerGroupActivity {
 
+  void setRun(Run run);
+
+  Long getId();
+
+  Run getRun();
+
   String getLogic();
+
+  String getLogicNodeId() throws JSONException;
+
+  String getLogicComponentId() throws JSONException;
 
   int getLogicThresholdCount();
 

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
@@ -37,7 +37,9 @@ import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.run.Run;
@@ -77,10 +79,10 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
   private String logic;
 
   @Column
-  private int logicThresholdCount = 0;
+  private int logicThresholdCount;
 
   @Column
-  private int logicThresholdPercent = 0;
+  private int logicThresholdPercent;
 
   @Column
   private int maxMembershipCount = 2;
@@ -97,5 +99,17 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
     this.logicThresholdCount = component.getInt("logicThresholdCount");
     this.logicThresholdPercent = component.getInt("logicThresholdPercent");
     this.maxMembershipCount = component.getInt("maxMembershipCount");
+  }
+
+  public String getLogicNodeId() throws JSONException {
+    return getFirstLogicJSON().getString("nodeId");
+  }
+
+  public String getLogicComponentId() throws JSONException {
+    return getFirstLogicJSON().getString("componentId");
+  }
+
+  private JSONObject getFirstLogicJSON() throws JSONException {
+    return new JSONArray(this.logic).getJSONObject(0);
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupActivityThresholdNotSatisfiedException.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupActivityThresholdNotSatisfiedException.java
@@ -21,27 +21,15 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.dao.peergroup;
-
-import java.util.List;
-import org.wise.portal.dao.SimpleDao;
-import org.wise.portal.domain.peergroup.PeerGroup;
-import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
-import org.wise.portal.domain.run.Run;
-import org.wise.portal.domain.workgroup.Workgroup;
+package org.wise.portal.service.peergroup;
 
 /**
+ * A checked exception that is thrown when the PeerGroup is not ready to be formed yet
+ * because a threshold has not been met
+ *
  * @author Hiroki Terashima
  */
-public interface PeerGroupDao<T extends PeerGroup> extends SimpleDao<T> {
+public class PeerGroupActivityThresholdNotSatisfiedException extends Exception {
 
-  PeerGroup getByWorkgroupAndActivity(Workgroup workgroup, PeerGroupActivity activity);
-
-  List<PeerGroup> getListByRun(Run run);
-
-  List<PeerGroup> getListByComponent(Run run, String nodeId, String componentId);
-
-  List<PeerGroup> getListByWorkgroup(Workgroup workgroup);
-
-  List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity);
+  private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupCreationException.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupCreationException.java
@@ -21,27 +21,15 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.dao.peergroup;
-
-import java.util.List;
-import org.wise.portal.dao.SimpleDao;
-import org.wise.portal.domain.peergroup.PeerGroup;
-import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
-import org.wise.portal.domain.run.Run;
-import org.wise.portal.domain.workgroup.Workgroup;
+package org.wise.portal.service.peergroup;
 
 /**
+ * A checked exception that is thrown while creating a PeerGroup, for example not being able to
+ * find the members to group together
+ *
  * @author Hiroki Terashima
  */
-public interface PeerGroupDao<T extends PeerGroup> extends SimpleDao<T> {
+public class PeerGroupCreationException extends Exception {
 
-  PeerGroup getByWorkgroupAndActivity(Workgroup workgroup, PeerGroupActivity activity);
-
-  List<PeerGroup> getListByRun(Run run);
-
-  List<PeerGroup> getListByComponent(Run run, String nodeId, String componentId);
-
-  List<PeerGroup> getListByWorkgroup(Workgroup workgroup);
-
-  List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity);
+  private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
@@ -21,27 +21,29 @@
  * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
  * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.wise.portal.dao.peergroup;
+package org.wise.portal.service.peergroup;
 
-import java.util.List;
-import org.wise.portal.dao.SimpleDao;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
-import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 
 /**
  * @author Hiroki Terashima
  */
-public interface PeerGroupDao<T extends PeerGroup> extends SimpleDao<T> {
+public interface PeerGroupService {
 
-  PeerGroup getByWorkgroupAndActivity(Workgroup workgroup, PeerGroupActivity activity);
-
-  List<PeerGroup> getListByRun(Run run);
-
-  List<PeerGroup> getListByComponent(Run run, String nodeId, String componentId);
-
-  List<PeerGroup> getListByWorkgroup(Workgroup workgroup);
-
-  List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity);
+  /**
+   * Gets a PeerGroup for the specified workgroup and PeerGroupActivity if a PeerGroup
+   * does not exist, create one.
+   *
+   * @param workgroup Workgroup to get/create the PeerGroup for
+   * @param activity PeerGroupActivity to get/create the PeerGroup for
+   * @return PeerGroup for the specified workgroup and PeerGroupActivity
+   * @throws PeerGroupActivityThresholdNotSatisfiedException the PeerGroup cannot be created due to
+   * threshold not being met
+   * @throws PeerGroupCreationException the PeerGroup cannot be created for other reasons
+   * like an error occurred while grouping members
+   */
+  PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
+      throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException;
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroup.impl;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.json.JSONException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.dao.work.StudentWorkDao;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupActivityThresholdNotSatisfiedException;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.portal.service.run.RunService;
+import org.wise.vle.domain.work.StudentWork;
+
+/**
+ * @author Hiroki Terashima
+ */
+public class PeerGroupServiceImpl implements PeerGroupService {
+
+  @Autowired
+  private PeerGroupDao<PeerGroup> peerGroupDao;
+
+  @Autowired
+  private RunService runService;
+
+  @Autowired
+  private StudentWorkDao<StudentWork> studentWorkDao;
+
+  @Override
+  public PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
+      throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException {
+    PeerGroup peerGroup = peerGroupDao.getByWorkgroupAndActivity(workgroup, activity);
+    return peerGroup != null ? peerGroup : this.createPeerGroup(workgroup, activity);
+  }
+
+  private PeerGroup createPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
+      throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException {
+    if (canCreatePeerGroup(workgroup, activity)) {
+      PeerGroup peerGroup = new PeerGroupImpl(activity, getPeerGroupMembers(workgroup, activity));
+      this.peerGroupDao.save(peerGroup);
+      return peerGroup;
+    } else {
+      throw new PeerGroupActivityThresholdNotSatisfiedException();
+    }
+  }
+
+  private boolean canCreatePeerGroup(Workgroup workgroup, PeerGroupActivity activity) {
+    return hasWorkForPeerGroupLogicActivity(workgroup, activity) && thresholdSatisfied(activity,
+        workgroup.getPeriod());
+  }
+
+  private boolean hasWorkForPeerGroupLogicActivity(Workgroup workgroup, PeerGroupActivity activity) {
+    try {
+      return studentWorkDao.getWorkForComponentByWorkgroup(workgroup, activity.getLogicNodeId(),
+          activity.getLogicComponentId()).size() > 0;
+    } catch (JSONException e) {
+      return false;
+    }
+  }
+
+  private Set<Workgroup> getPeerGroupMembers(Workgroup workgroup, PeerGroupActivity activity)
+      throws PeerGroupCreationException {
+    Set<Workgroup> members = new HashSet<Workgroup>();
+    members.add(workgroup);
+    try {
+      List<StudentWork> logicComponentStudentWorkByWorkgroupNotInPeerGroup =
+          getLogicComponentStudentWorkByWorkgroupNotInPeerGroup(workgroup, activity);
+      for (StudentWork work : logicComponentStudentWorkByWorkgroupNotInPeerGroup) {
+        members.add(work.getWorkgroup());
+        if (members.size() == activity.getMaxMembershipCount()) {
+          break;
+        }
+      }
+    } catch (JSONException e) {
+      throw new PeerGroupCreationException();
+    }
+    return members;
+  }
+
+  private List<StudentWork> getLogicComponentStudentWorkByWorkgroupNotInPeerGroup(
+      Workgroup workgroup, PeerGroupActivity activity) throws JSONException {
+    List<Workgroup> workgroupsInPeerGroup = peerGroupDao.getWorkgroupsInPeerGroup(activity);
+    List<StudentWork> logicComponentStudentWork = getLogicComponentStudentWorkForPeriod(activity,
+        workgroup.getPeriod());
+    logicComponentStudentWork.removeIf(work -> workgroupsInPeerGroup.contains(work.getWorkgroup()));
+    return logicComponentStudentWork;
+  }
+
+  private boolean thresholdSatisfied(PeerGroupActivity activity, Group period) {
+    int numWorkgroupsInPeriod = runService.getWorkgroups(activity.getRun().getId(), period.getId())
+        .size();
+    int logicComponentCompletionCount = getLogicComponentCompletionCount(activity, period);
+    int logicComponentCompletionPercent =
+        (logicComponentCompletionCount / numWorkgroupsInPeriod) * 100;
+    return logicComponentCompletionCount >= activity.getLogicThresholdCount() ||
+        logicComponentCompletionPercent >= activity.getLogicThresholdPercent();
+  }
+
+  private int getLogicComponentCompletionCount(PeerGroupActivity activity, Group period) {
+    try {
+      return getLogicComponentStudentWorkForPeriod(activity, period).size();
+    } catch (JSONException e) {
+    }
+    return 0;
+  }
+
+  private List<StudentWork> getLogicComponentStudentWorkForPeriod(PeerGroupActivity activity,
+      Group period) throws JSONException {
+    List<StudentWork> logicComponentStudentWorkForPeriod = studentWorkDao
+        .getWorkForComponentByPeriod(activity.getRun(), period,
+        activity.getLogicNodeId(), activity.getLogicComponentId());
+    logicComponentStudentWorkForPeriod.removeIf(work -> !work.getIsSubmit());
+    return logicComponentStudentWorkForPeriod;
+  }
+}

--- a/src/main/java/org/wise/portal/service/run/RunService.java
+++ b/src/main/java/org/wise/portal/service/run/RunService.java
@@ -43,7 +43,7 @@ import org.wise.portal.presentation.web.response.SharedOwner;
 
 /**
  * A service for working with <code>Run</code> objects
- * 
+ *
  * @author Laurel Williams
  * @author Hiroki Terashima
  */
@@ -51,7 +51,7 @@ public interface RunService {
 
   /**
    * Creates a new <code>Run</code> object in the local data store.
-   * 
+   *
    * @param runParameters
    *                        The object that encapsulate parameters for creating a run
    * @return the run created.
@@ -64,7 +64,7 @@ public interface RunService {
   /**
    * Ends this run. The side effect is that the run's endtime gets set. A Run that has ended is no
    * longer eligible for classroom run. If the run is already ended, nothing happens.
-   * 
+   *
    * @param run
    *              the <code>Run</code> to end
    */
@@ -73,7 +73,7 @@ public interface RunService {
   /**
    * Restarts this run. The side effect is that the run's endtime gets set to null. The run
    * continues to be available for students to access.
-   * 
+   *
    * @param run
    *              the <code>Run</code> to restart
    */
@@ -82,7 +82,7 @@ public interface RunService {
   /**
    * Starts this run. The side effect is that the run's endtime gets set to null. A Run that has
    * started becomes eligible for classroom run. If the run is already started, nothing happens.
-   * 
+   *
    * @param run
    *              the <code>Run</code> to start
    */
@@ -90,7 +90,7 @@ public interface RunService {
 
   /**
    * Retrieves a list of <code>Run</code>
-   * 
+   *
    * @return <code>List</code> of <code>Run</code>
    */
   @Secured({ "ROLE_USER", "AFTER_ACL_COLLECTION_READ" })
@@ -98,7 +98,7 @@ public interface RunService {
 
   /**
    * Retrieves a list of <code>Run</code> that the specified user owns
-   * 
+   *
    * @return <code>List</code> of <code>Run</code>
    */
   @Secured({ "ROLE_USER", "AFTER_ACL_COLLECTION_READ" })
@@ -106,7 +106,7 @@ public interface RunService {
 
   /**
    * Retrieves a list of <code>Run</code> that the specified user is an shared-owner
-   * 
+   *
    * @return <code>List</code> of <code>Run</code>
    */
   @Secured({ "ROLE_USER", "AFTER_ACL_COLLECTION_READ" })
@@ -114,7 +114,7 @@ public interface RunService {
 
   /**
    * Retrieves a list of all <code>Runs</code>. Only adminstrators may invoke this method.
-   * 
+   *
    * @return <code>List</code> of <code>Run</code>
    */
   @Secured({ "ROLE_ADMINISTRATOR", "ROLE_RESEARCHER" })
@@ -122,7 +122,7 @@ public interface RunService {
 
   /**
    * Retrieves a list of <code>Run</code> that the given user is associated with
-   * 
+   *
    * @param user
    *               <code>User</code> that is associated with 0 or more runs
    * @return list of <code>Run</code> that the user is associated with
@@ -249,7 +249,7 @@ public interface RunService {
 
   /**
    * Gets all of the Workgroups that are associated with this run
-   * 
+   *
    * @return set of Workgroups for that are in this run
    * @throws ObjectNotFoundException
    *                                   when runId cannot be used to find an existing run
@@ -258,7 +258,7 @@ public interface RunService {
 
   /**
    * Gets all of the Workgroups that are associated with this run
-   * 
+   *
    * @return set of Workgroups for that are in this run
    * @throws ObjectNotFoundException
    *                                   when runId cannot be used to find an existing run
@@ -267,11 +267,11 @@ public interface RunService {
    * @param periodId
    *                   periodId to which all returned workgroups belong
    */
-  List<Workgroup> getWorkgroups(Long runId, Long periodId) throws ObjectNotFoundException;
+  List<Workgroup> getWorkgroups(Long runId, Long periodId);
 
   /**
    * Sets whether the run is paused
-   * 
+   *
    * @param runId
    *                   the id of the run
    * @param isPaused
@@ -282,7 +282,7 @@ public interface RunService {
 
   /**
    * Sets whether idea manager is enabled for this run or not.
-   * 
+   *
    * @param runId
    * @param isEnabled
    * @throws ObjectNotFoundException
@@ -291,7 +291,7 @@ public interface RunService {
 
   /**
    * Sets whether student asset uploader is enabled for this run or not.
-   * 
+   *
    * @param runId
    * @param isEnabled
    * @throws ObjectNotFoundException
@@ -300,7 +300,7 @@ public interface RunService {
 
   /**
    * Sets whether real time is enabled for this run
-   * 
+   *
    * @param runId
    * @param isEnabled
    * @throws ObjectNotFoundException
@@ -309,7 +309,7 @@ public interface RunService {
 
   /**
    * Update private run notes for this run
-   * 
+   *
    * @param runId
    * @param privateNotes
    *                       String private notes
@@ -319,7 +319,7 @@ public interface RunService {
 
   /**
    * Update survey for the specified run
-   * 
+   *
    * @param runId
    * @param survey
    *                 String survey
@@ -329,7 +329,7 @@ public interface RunService {
 
   /**
    * Given a <code>Long</code> runId, changes the archiveReminderTime to be 30 days from today.
-   * 
+   *
    * @param runId
    * @throws <code>ObjectNotFoundException</code>
    */
@@ -338,7 +338,7 @@ public interface RunService {
   /**
    * Given a <code>Long</code> projectId, returns the <code>Integer</code> number of runs associated
    * with that id.
-   * 
+   *
    * @param id
    * @return <code>Integer</code>
    */
@@ -347,7 +347,7 @@ public interface RunService {
   /**
    * Given a <code>Long</code> projectId, returns a <code>List<Run></code> list of runs associated
    * with that id.
-   * 
+   *
    * @param projectId
    * @return <code>Integer</code>
    */
@@ -355,7 +355,7 @@ public interface RunService {
 
   /**
    * Sets run extras
-   * 
+   *
    * @param run
    * @param extras
    * @throws Exception
@@ -365,7 +365,7 @@ public interface RunService {
   /**
    * Returns <code>boolean</code> true iff the given <code>User</code> user has the read permission
    * for the given <code>Run</code> run.
-   * 
+   *
    * @param authentication
    * @param run
    * @return boolean
@@ -375,7 +375,7 @@ public interface RunService {
   /**
    * Returns <code>boolean</code> true iff the given <code>User</code> user has the write permission
    * for the given <code>Run</code> run.
-   * 
+   *
    * @param authentication
    * @param run
    * @return boolean
@@ -385,7 +385,7 @@ public interface RunService {
   /**
    * Returns <code>boolean</code> true if the given <code>User</code> user has the given
    * <code>Permission</code> permission for the given <code>Run</code> run, returns false otherwise.
-   * 
+   *
    * @param run
    * @param user
    * @param permission
@@ -396,7 +396,7 @@ public interface RunService {
   /**
    * Returns <code>boolean</code> true if the run with the given <code>runId</code> does not have
    * any student workgroups that contain more than 1 user, returns false otherwise.
-   * 
+   *
    * @param runId
    * @return boolean
    */
@@ -405,7 +405,7 @@ public interface RunService {
   /**
    * Returns a <code>List<Run></code> list of runs that were run within the given
    * <code>String</code> period. Valid periods are "today","week" and "month".
-   * 
+   *
    * @param period
    * @return List<Run> - run list
    */
@@ -413,7 +413,7 @@ public interface RunService {
 
   /**
    * Returns a <code>List<Run></code> list of runs ordered descending by how active they are.
-   * 
+   *
    * @return List<Run> - list of runs descending by activity
    */
   List<Run> getRunsByActivity();
@@ -421,7 +421,7 @@ public interface RunService {
   /**
    * Returns a <code>List<Run></code> list of runs that have a run title similar to the the
    * specified run title.
-   * 
+   *
    * @param runTitle
    * @return List<Run> - list of runs with the run title similar to the param
    */
@@ -430,7 +430,7 @@ public interface RunService {
   /**
    * Updates the given <code>Run</code> run's statistics which are currently the last time run and
    * the number of times run.
-   * 
+   *
    * @param runId
    *                - the id of the run whose statistics should be updated.
    */
@@ -439,7 +439,7 @@ public interface RunService {
   /**
    * Update the name of the run with the given <code>Long</code> to that of the given
    * <code>String</code> name.
-   * 
+   *
    * @param runId
    *                id of the run
    * @param name
@@ -450,7 +450,7 @@ public interface RunService {
   /**
    * Creates and adds a period with the given <code>String</code> name to the run with the given
    * <code>Long</code> runId.
-   * 
+   *
    * @param runId
    *                id of the run
    * @param name

--- a/src/test/java/org/wise/portal/dao/WISEHibernateTest.java
+++ b/src/test/java/org/wise/portal/dao/WISEHibernateTest.java
@@ -27,6 +27,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.Before;
 import org.wise.portal.domain.authentication.Gender;
@@ -37,6 +38,10 @@ import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.junit.AbstractTransactionalDbTests;
 
+/**
+ * @author Geoffrey Kwan
+ * @author Hiroki Terashima
+ */
 public abstract class WISEHibernateTest extends AbstractTransactionalDbTests {
 
   protected User student1, student2;
@@ -49,9 +54,9 @@ public abstract class WISEHibernateTest extends AbstractTransactionalDbTests {
 
   protected Workgroup workgroup1, workgroup2, workgroup3;
 
-  protected Run run1, run2;
+  protected Run run1, run2, run3;
 
-  protected Group period1;
+  protected Group run1Period1, run1Period2, run2Period1;
 
   protected Component component1, component2, componentNotExists;
 
@@ -72,10 +77,17 @@ public abstract class WISEHibernateTest extends AbstractTransactionalDbTests {
         Schoollevel.COLLEGE, "1234567890");
     run1 = createProjectAndRun(getNextAvailableProjectId(), projectName, teacher, startTime, "Panda123");
     run2 = createProjectAndRun(getNextAvailableProjectId(), projectName, teacher, startTime, "Rhino456");
-    period1 = createPeriod("Run 1 Period 1");
-    workgroup1 = createWorkgroup(workgroup1Members, run1, period1);
-    workgroup2 = createWorkgroup(workgroup2Members, run1, period1);
-    workgroup3 = createWorkgroup(workgroup3Members, run2, createPeriod("Run 2 Period 1"));
+    run3 = createProjectAndRun(getNextAvailableProjectId(), projectName, teacher, startTime, "Rhino789");
+    run1Period1 = createPeriod("Run 1 Period 1");
+    run1Period2 = createPeriod("Run 1 Period 2");
+    run2Period1 = createPeriod("Run 2 Period 1");
+    Set<Group> periods = new TreeSet<Group>();
+    periods.add(run1Period1);
+    periods.add(run1Period2);
+    run1.setPeriods(periods);
+    workgroup1 = createWorkgroup(workgroup1Members, run1, run1Period1);
+    workgroup2 = createWorkgroup(workgroup2Members, run1, run1Period1);
+    workgroup3 = createWorkgroup(workgroup3Members, run2, run2Period1);
     component1 = new Component(run1, "node1", "component1");
     component2 = new Component(run1, "node2", "component2");
     componentNotExists = new Component(run1, "nodeX", "componentX");

--- a/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2019 Regents of the University of California (Regents).
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
  * Created by WISE, Graduate School of Education, University of California, Berkeley.
  *
  * This software is distributed under the GNU General Public License, v3,
@@ -27,11 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
-import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,26 +35,18 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.wise.portal.dao.WISEHibernateTest;
 import org.wise.portal.dao.work.StudentWorkDao;
-import org.wise.portal.domain.authentication.Gender;
-import org.wise.portal.domain.authentication.Schoollevel;
-import org.wise.portal.domain.group.Group;
-import org.wise.portal.domain.run.Run;
-import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.workgroup.Workgroup;
-import org.wise.portal.junit.AbstractTransactionalDbTests;
 import org.wise.vle.domain.work.StudentWork;
 
 /**
  * @author Geoffrey Kwan
+ * @author Hiroki Terashima
  */
 @SpringBootTest
 @RunWith(SpringRunner.class)
-public class HibernateStudentWorkDaoTest extends AbstractTransactionalDbTests {
-
-  Run run;
-  Group period1;
-  Workgroup workgroup1, workgroup2;
+public class HibernateStudentWorkDaoTest extends WISEHibernateTest {
 
   @Autowired
   private StudentWorkDao<StudentWork> studentWorkDao;
@@ -66,55 +54,25 @@ public class HibernateStudentWorkDaoTest extends AbstractTransactionalDbTests {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    Long id = getNextAvailableProjectId();
-    String projectName = "How to be a Fry Cook";
-    Date startTime = Calendar.getInstance().getTime();
-    String runCode = "Panda123";
-    User teacher = createTeacherUser("Mrs", "Puff", "MrsPuff", "Mrs. Puff", "boat", "Bikini Bottom",
-        "Water State", "Pacific Ocean", "mrspuff@bikinibottom.com", "Boating School",
-        Schoollevel.COLLEGE, "1234567890");
-    run = createProjectAndRun(id, projectName, teacher, startTime, runCode);
-    period1 = createPeriod("Period 1");
-    Set<Group> periods = new TreeSet<Group>();
-    periods.add(period1);
-    run.setPeriods(periods);
-    User student1 = createStudentUser("Spongebob", "Squarepants", "SpongebobS0101", "burger", 1, 1,
-        Gender.MALE);
-    Set<User> members1 = new HashSet<User>();
-    members1.add(student1);
-    workgroup1 = createWorkgroup(members1, run, period1);
-    User student2 = createStudentUser("Patrick", "Star", "PatrickS0101", "rock", 1, 1, Gender.MALE);
-    Set<User> members2 = new HashSet<User>();
-    members2.add(student2);
-    workgroup2 = createWorkgroup(members2, run, period1);
+    createStudentWork(workgroup1, "node1", "component1", "studentWork1");
+    createStudentWork(workgroup1, "node2", "component2", "studentWork2");
+    createStudentWork(workgroup2, "node1", "component1", "studentWork3");
+    createStudentWork(workgroup3, "node1", "component1", "studentWork4");
   }
 
   @Test
-  public void getStudentWorkListByParams_WithRunThatHasNoStudentWork_ShouldReturnNoStudentWork() {
-    List<StudentWork> studentWorkList = studentWorkDao.getStudentWorkListByParams(null, run, null,
-        null, null, null, null, null, null, null);
-    assertEquals(0, studentWorkList.size());
-  }
-
-  @Test
-  public void getStudentWorkListByParams_WithRunThatHasStudentWork_ShouldReturnStudentWork() {
-    createStudentWork(workgroup1, "node1", "studentWork1");
-    createStudentWork(workgroup1, "node2", "studentWork2");
-    createStudentWork(workgroup2, "node1", "studentWork3");
-    List<StudentWork> studentWorkList = studentWorkDao.getStudentWorkListByParams(null, run, null,
-        null, null, null, null, null, null, null);
-    assertEquals(3, studentWorkList.size());
-    assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
-    assertEquals("studentWork2", studentWorkList.get(1).getStudentData());
-    assertEquals("studentWork3", studentWorkList.get(2).getStudentData());
+  public void getStudentWorkListByParams_ByRun_ShouldReturnStudentWorkByRun() {
+    assertEquals(3, studentWorkDao.getStudentWorkListByParams(null, run1, null, null, null, null,
+        null, null, null, null).size());
+    assertEquals(1, studentWorkDao.getStudentWorkListByParams(null, run2, null, null, null, null,
+        null, null, null, null).size());
+    assertEquals(0, studentWorkDao.getStudentWorkListByParams(null, run3, null, null, null, null,
+        null, null, null, null).size());
   }
 
   @Test
   public void getStudentWorkListByParams_ByWorkgroup_ShouldReturnStudentWork() {
-    createStudentWork(workgroup1, "node1", "studentWork1");
-    createStudentWork(workgroup1, "node2", "studentWork2");
-    createStudentWork(workgroup2, "node1", "studentWork3");
-    List<StudentWork> studentWorkList = studentWorkDao.getStudentWorkListByParams(null, run, null,
+    List<StudentWork> studentWorkList = studentWorkDao.getStudentWorkListByParams(null, run1, null,
         workgroup1, null, null, null, null, null, null);
     assertEquals(2, studentWorkList.size());
     assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
@@ -123,25 +81,41 @@ public class HibernateStudentWorkDaoTest extends AbstractTransactionalDbTests {
 
   @Test
   public void getStudentWorkListByParams_ByNodeId_ShouldReturnStudentWork() {
-    createStudentWork(workgroup1, "node1", "studentWork1");
-    createStudentWork(workgroup1, "node2", "studentWork2");
-    createStudentWork(workgroup2, "node1", "studentWork3");
-    List<StudentWork> studentWorkList = studentWorkDao.getStudentWorkListByParams(null, run, null,
+    List<StudentWork> studentWorkList = studentWorkDao.getStudentWorkListByParams(null, run1, null,
         null, null, null, "node1", null, null, null);
     assertEquals(2, studentWorkList.size());
     assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
     assertEquals("studentWork3", studentWorkList.get(1).getStudentData());
   }
 
-  private StudentWork createStudentWork(Workgroup workgroup, String nodeId, String studentData) {
+  @Test
+  public void getWorkForComponentByPeriod_ShouldReturnStudentWork() {
+    List<StudentWork> studentWorkList = studentWorkDao.getWorkForComponentByPeriod(run1,
+        run1Period1, "node1", "component1");
+    assertEquals(2, studentWorkList.size());
+    assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
+    assertEquals("studentWork3", studentWorkList.get(1).getStudentData());
+  }
+
+  @Test
+  public void getWorkForComponentByWorkgroup_ShouldReturnStudentWork() {
+    List<StudentWork> studentWorkList = studentWorkDao.getWorkForComponentByWorkgroup(workgroup1,
+        "node1", "component1");
+    assertEquals(1, studentWorkList.size());
+    assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
+  }
+
+  private StudentWork createStudentWork(Workgroup workgroup, String nodeId, String componentId,
+      String studentData) {
     StudentWork studentWork = new StudentWork();
     Calendar now = Calendar.getInstance();
     Timestamp timestamp = new Timestamp(now.getTimeInMillis());
     studentWork.setClientSaveTime(timestamp);
     studentWork.setServerSaveTime(timestamp);
-    studentWork.setRun(run);
-    studentWork.setPeriod(period1);
+    studentWork.setRun(workgroup.getRun());
+    studentWork.setPeriod(workgroup.getPeriod());
     studentWork.setNodeId(nodeId);
+    studentWork.setComponentId(componentId);
     studentWork.setWorkgroup(workgroup);
     studentWork.setIsAutoSave(false);
     studentWork.setIsSubmit(false);

--- a/src/test/java/org/wise/portal/service/WISEServiceTest.java
+++ b/src/test/java/org/wise/portal/service/WISEServiceTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.wise.portal.dao.Component;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.group.impl.PersistentGroup;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
+import org.wise.vle.domain.work.StudentWork;
+
+/**
+ * @author Hiroki Terashima
+ */
+public class WISEServiceTest {
+
+  protected Run run1;
+
+  protected Long run1Id = 1L;
+
+  protected Group run1Period1;
+
+  protected List<Workgroup> period1Workgroups;
+
+  protected Workgroup run1Workgroup1, run1Workgroup2, run1Workgroup3;
+
+  protected Component run1Component1, run1Component2;
+
+  protected String run1Node1Id = "run1Node1";
+
+  protected String run1Component1Id = "run1Component1";
+
+  protected String run1Node2Id = "run1Node2";
+
+  protected String run1Component2Id = "run1Component2";
+
+  protected User student1, student2, student3;
+
+  protected StudentWork componentWorkSubmit1, componentWorkSubmit2, componentWorkNonSubmit1;
+
+  @Before
+  public void setUp() throws Exception {
+    run1Period1 = new PersistentGroup();
+    run1Period1.setId(run1Id);
+    run1Workgroup1 = createWorkgroupInPeriod(1L, run1Period1, student1);
+    run1Workgroup2 = createWorkgroupInPeriod(2L, run1Period1, student2);
+    run1Workgroup3 = createWorkgroupInPeriod(3L, run1Period1, student3);
+    run1 = new RunImpl();
+    run1.setId(run1Id);
+    run1Component1 = new Component(run1, run1Node1Id, run1Component1Id);
+    run1Component2 = new Component(run1, run1Node2Id, run1Component2Id);
+    period1Workgroups = Arrays.asList(run1Workgroup1, run1Workgroup2, run1Workgroup3);
+    componentWorkSubmit1 = createComponentWork(run1Workgroup1, true);
+    componentWorkSubmit2 = createComponentWork(run1Workgroup2, true);
+    componentWorkNonSubmit1 = createComponentWork(run1Workgroup1, false);
+  }
+
+  private Workgroup createWorkgroupInPeriod(Long id, Group period, User member) {
+    Workgroup workgroup = new WorkgroupImpl();
+    workgroup.setId(id);
+    workgroup.setPeriod(period);
+    Set<User> members = new HashSet<User>();
+    members.add(member);
+    workgroup.setMembers(members);
+    workgroup.getGroup().setName("Group " + id);
+    return workgroup;
+  }
+
+  private StudentWork createComponentWork(Workgroup workgroup, boolean isSubmit) {
+    StudentWork work = new StudentWork();
+    work.setWorkgroup(workgroup);
+    work.setIsSubmit(isSubmit);
+    return work;
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroup.impl;
+
+import static org.junit.Assert.*;
+import static org.easymock.EasyMock.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.dao.peergroupactivity.PeerGroupActivityDao;
+import org.wise.portal.dao.work.StudentWorkDao;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.WISEServiceTest;
+import org.wise.portal.service.peergroup.PeerGroupActivityThresholdNotSatisfiedException;
+import org.wise.portal.service.run.RunService;
+import org.wise.vle.domain.work.StudentWork;
+
+/**
+ * @author Hiroki Terashima
+ */
+@RunWith(EasyMockRunner.class)
+public class PeerGroupServiceImplTest extends WISEServiceTest {
+
+  @TestSubject
+  private PeerGroupServiceImpl service = new PeerGroupServiceImpl();
+
+  @Mock
+  private PeerGroupDao<PeerGroup> peerGroupDao;
+
+  @Mock
+  private PeerGroupActivityDao<PeerGroupActivity> peerGroupActivityDao;
+
+  @Mock
+  private StudentWorkDao<StudentWork> studentWorkDao;
+
+  @Mock
+  private RunService runService;
+
+  PeerGroupActivity activity;
+
+  PeerGroup peerGroup;
+
+  ProjectComponent peerGroupActivityComponent;
+
+  String logic = "[{\"name\": \"maximizeDifferentIdeas\"," +
+      "\"nodeId\": \"" + run1Node1Id + "\", \"componentId\": \"" + run1Component1Id + "\"}]";
+
+  int logicThresholdCount = 2;
+
+  int logicThresholdPercent = 50;
+
+  int maxMembershipCount = 2;
+
+  String peerGroupActivityComponentString =
+      "{\"id\":\"" + run1Component2Id + "\"," +
+      "\"logic\":" + logic + "," +
+      "\"logicThresholdCount\":" + logicThresholdCount + "," +
+      "\"logicThresholdPercent\":" + logicThresholdPercent + "," +
+      "\"maxMembershipCount\":" + maxMembershipCount + "}";
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    activity = createPeerGroupActivity();
+    peerGroup = new PeerGroupImpl();
+  }
+
+  private PeerGroupActivity createPeerGroupActivity() throws JSONException {
+    return new PeerGroupActivityImpl(run1, run1Component2.nodeId,
+        new ProjectComponent(new JSONObject(peerGroupActivityComponentString)));
+  }
+
+  @Test
+  public void getPeerGroup_PeerGroupInDB_ReturnPeerGroup() throws Exception {
+    expectPeerGroupFromDB(run1Workgroup1, activity, peerGroup);
+    replayAll();
+    assertNotNull(service.getPeerGroup(run1Workgroup1, activity));
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_PeerGroupNotInDBAndNoWorkForLogicComponent_ThrowException()
+      throws Exception {
+    expectPeerGroupFromDB(run1Workgroup1, activity, null);
+    expectWorkForComponentByWorkgroup(run1Workgroup1, activity, Arrays.asList());
+    replayAll();
+    try {
+      service.getPeerGroup(run1Workgroup1, activity);
+      fail("PeerGroupActivityThresholdNotSatisfiedException expected, but wasn't thrown");
+    } catch (PeerGroupActivityThresholdNotSatisfiedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_PeerGroupNotInDBAndLogicThresholdNotSatisfied_ThrowException()
+      throws Exception {
+    expectPeerGroupFromDB(run1Workgroup1, activity, null);
+    expectWorkForComponentByWorkgroup(run1Workgroup1, activity,
+        Arrays.asList(componentWorkSubmit1));
+    expect(runService.getWorkgroups(run1Id, run1Period1.getId())).andReturn(period1Workgroups);
+    expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
+      run1Component1Id)).andReturn(Arrays.asList());
+    replayAll();
+    try {
+      service.getPeerGroup(run1Workgroup1, activity);
+      fail("PeerGroupActivityThresholdNotSatisfiedException expected, but wasn't thrown");
+    } catch (PeerGroupActivityThresholdNotSatisfiedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test(timeout = 250)
+  public void getPeerGroup_PeerGroupNotInDBAndLogicThresholdSatisfied_CreateAndReturnPeerGroup()
+      throws Exception {
+    expectPeerGroupFromDB(run1Workgroup1, activity, null);
+    expectWorkForComponentByWorkgroup(run1Workgroup1, activity,
+        Arrays.asList(componentWorkSubmit1));
+    expect(runService.getWorkgroups(run1Id, run1Period1.getId())).andReturn(period1Workgroups);
+    expect(peerGroupDao.getWorkgroupsInPeerGroup(activity)).andReturn(Arrays.asList());
+    List<StudentWork> workForLogicComponent = createStudentWorkList(componentWorkSubmit1,
+        componentWorkSubmit2, componentWorkNonSubmit1);
+    expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
+        run1Component1Id)).andReturn(workForLogicComponent).times(2);
+    peerGroupDao.save(isA(PeerGroupImpl.class));
+    expectLastCall();
+    replayAll();
+    assertNotNull(service.getPeerGroup(run1Workgroup1, activity));
+    verifyAll();
+  }
+
+  private List<StudentWork> createStudentWorkList(StudentWork... componentWorks) {
+    List<StudentWork> list = new ArrayList<StudentWork>();
+    for (StudentWork work : componentWorks) {
+      list.add(work);
+    }
+    return list;
+  }
+
+  private void expectPeerGroupFromDB(Workgroup workgroup, PeerGroupActivity activity,
+      PeerGroup peerGroup) {
+    expect(peerGroupDao.getByWorkgroupAndActivity(workgroup, activity)).andReturn(peerGroup);
+  }
+
+  private void expectWorkForComponentByWorkgroup(Workgroup workgroup,
+      PeerGroupActivity activity, List<StudentWork> expectedWork) throws JSONException {
+    expect(studentWorkDao.getWorkForComponentByWorkgroup(workgroup, activity.getLogicNodeId(),
+        activity.getLogicComponentId())).andReturn(expectedWork);
+  }
+
+  private void verifyAll() {
+    verify(peerGroupDao, runService, studentWorkDao);
+  }
+
+  private void replayAll() {
+    replay(peerGroupDao, runService, studentWorkDao);
+  }
+}


### PR DESCRIPTION
## Changes
- Add PeerGroupService and getPeerGroup() method to return a PeerGroup for a specified Workgroup and PeerGroupActivity.
  - If found in the database (i.e. it was created before), return it
  - If not found in the db, try to create and return it
    - if threshold is not met, throw PeerGroupActivityThresholdNotSatisfiedException
    - if there is some other error while grouping students, throw PeerGroupCreationException
- Assumes PeerGrouping logic looks at the same nodeId/componentId. In the future, this will expand to allow looking at multiple nodeId/componentId.
- The logic only supports finding the first available member who have submitted the nodeId/componentId to group. More logic (similar/different ideas) will be added later
- Extracted common hibernate/service test methods to parent

## Test
- Code and tests look ok, no glaring issues

Closes #42