### PR TITLE
feat(Peer Group): Add endpoint for getting Peer Group

### DIFF
--- a/src/main/java/org/wise/portal/domain/group/impl/PersistentGroup.java
+++ b/src/main/java/org/wise/portal/domain/group/impl/PersistentGroup.java
@@ -41,6 +41,7 @@ import javax.persistence.Version;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Cascade;
+import org.hibernate.proxy.HibernateProxy;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.user.impl.UserImpl;
@@ -132,9 +133,16 @@ public class PersistentGroup implements Group {
       return true;
     if (obj == null)
       return false;
-    if (getClass() != obj.getClass())
+    if (obj instanceof HibernateProxy) {
+      if (getClass() != (( HibernateProxy) obj).getHibernateLazyInitializer().getImplementation().getClass()) {
+        return false;
+      }
+    } else if (getClass() != obj.getClass())
       return false;
     final PersistentGroup other = (PersistentGroup) obj;
+    if (this.getId() != null && this.getId().equals(other.getId())) {
+      return true;
+    }
     if (name == null) {
       if (other.name != null)
         return false;

--- a/src/main/java/org/wise/portal/domain/peergroup/PeerGroup.java
+++ b/src/main/java/org/wise/portal/domain/peergroup/PeerGroup.java
@@ -23,7 +23,10 @@
  */
 package org.wise.portal.domain.peergroup;
 
+import java.util.Set;
+
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.workgroup.Workgroup;
 
 /**
  * An interface that defines a group of workgroups
@@ -32,4 +35,10 @@ import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 public interface PeerGroup {
 
   PeerGroupActivity getPeerGroupActivity();
+
+  Set<Workgroup> getMembers();
+
+  void setMembers(Set<Workgroup> members);
+
+  public void addMember(Workgroup workgroup);
 }

--- a/src/main/java/org/wise/portal/domain/peergroup/impl/PeerGroupImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroup/impl/PeerGroupImpl.java
@@ -78,4 +78,8 @@ public class PeerGroupImpl implements PeerGroup {
     this.peerGroupActivity = activity;
     this.members = members;
   }
+
+  public void addMember(Workgroup workgroup) {
+    this.members.add(workgroup);
+  }
 }

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
@@ -32,21 +32,25 @@ import org.wise.portal.domain.run.Run;
  */
 public interface PeerGroupActivity {
 
-  void setRun(Run run);
+  String getComponentId();
 
   Long getId();
 
-  Run getRun();
-
   String getLogic();
 
-  String getLogicNodeId() throws JSONException;
-
   String getLogicComponentId() throws JSONException;
+
+  String getLogicNodeId() throws JSONException;
 
   int getLogicThresholdCount();
 
   int getLogicThresholdPercent();
 
   int getMaxMembershipCount();
+
+  String getNodeId();
+
+  Run getRun();
+
+  void setRun(Run run);
 }

--- a/src/main/java/org/wise/portal/domain/workgroup/impl/WorkgroupImpl.java
+++ b/src/main/java/org/wise/portal/domain/workgroup/impl/WorkgroupImpl.java
@@ -44,6 +44,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.group.impl.PersistentGroup;
+import org.hibernate.proxy.HibernateProxy;
 import org.wise.portal.domain.Tag;
 import org.wise.portal.domain.impl.TagImpl;
 import org.wise.portal.domain.run.Run;
@@ -179,9 +180,16 @@ public class WorkgroupImpl implements Workgroup, Comparable<WorkgroupImpl> {
       return true;
     if (obj == null)
       return false;
-    if (getClass() != obj.getClass())
+    if (obj instanceof HibernateProxy) {
+      if (getClass() != (( HibernateProxy) obj).getHibernateLazyInitializer().getImplementation().getClass()) {
+        return false;
+      }
+    } else if (getClass() != obj.getClass())
       return false;
     final WorkgroupImpl other = (WorkgroupImpl) obj;
+    if (this.getId() != null && this.getId().equals(other.getId())) {
+      return true;
+    }
     if (group == null) {
       if (other.group != null)
         return false;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -1,0 +1,70 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.PeerGroupActivityThresholdNotSatisfiedException;
+import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
+import org.wise.portal.service.run.RunService;
+import org.wise.portal.service.user.UserService;
+import org.wise.portal.service.workgroup.WorkgroupService;
+
+@RestController
+@Secured("ROLE_USER")
+@RequestMapping("/api/peer-group")
+public class PeerGroupAPIController {
+
+  @Autowired
+  private RunService runService;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private WorkgroupService workgroupService;
+
+  @Autowired
+  private PeerGroupService peerGroupService;
+
+  @Autowired
+  private PeerGroupActivityService peerGroupActivityService;
+
+  @GetMapping("/run/{runId}/workgroup/{workgroupId}/node-id/{nodeId}/component-id/{componentId}")
+  PeerGroup getPeerGroup(@PathVariable Long runId, @PathVariable Long workgroupId,
+      @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
+      throws ObjectNotFoundException, PeerGroupActivityNotFoundException,
+      PeerGroupCreationException {
+    Run run = runService.retrieveById(runId);
+    Workgroup workgroup = workgroupService.retrieveById(workgroupId);
+    User user = userService.retrieveUserByUsername(auth.getName());
+    if (workgroupService.isUserInWorkgroupForRun(user, run, workgroup)) {
+      return getPeerGroup(run, nodeId, componentId, workgroup);
+    } else {
+      throw new AccessDeniedException("Not permitted");
+    }
+  }
+
+  private PeerGroup getPeerGroup(Run run, String nodeId, String componentId, Workgroup workgroup)
+      throws PeerGroupActivityNotFoundException, PeerGroupCreationException {
+    PeerGroupActivity activity = peerGroupActivityService.getByComponent(run, nodeId, componentId);
+    try {
+      return peerGroupService.getPeerGroup(workgroup, activity);
+    } catch (PeerGroupActivityThresholdNotSatisfiedException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -1,3 +1,26 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.wise.portal.presentation.web.controllers.peergroup;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +70,7 @@ public class PeerGroupAPIController {
   PeerGroup getPeerGroup(@PathVariable Long runId, @PathVariable Long workgroupId,
       @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
       throws ObjectNotFoundException, PeerGroupActivityNotFoundException,
-      PeerGroupCreationException {
+      PeerGroupCreationException, PeerGroupActivityThresholdNotSatisfiedException {
     Run run = runService.retrieveById(runId);
     Workgroup workgroup = workgroupService.retrieveById(workgroupId);
     User user = userService.retrieveUserByUsername(auth.getName());
@@ -59,12 +82,9 @@ public class PeerGroupAPIController {
   }
 
   private PeerGroup getPeerGroup(Run run, String nodeId, String componentId, Workgroup workgroup)
-      throws PeerGroupActivityNotFoundException, PeerGroupCreationException {
+      throws PeerGroupActivityNotFoundException, PeerGroupCreationException,
+      PeerGroupActivityThresholdNotSatisfiedException {
     PeerGroupActivity activity = peerGroupActivityService.getByComponent(run, nodeId, componentId);
-    try {
-      return peerGroupService.getPeerGroup(workgroup, activity);
-    } catch (PeerGroupActivityThresholdNotSatisfiedException e) {
-      return null;
-    }
+    return peerGroupService.getPeerGroup(workgroup, activity);
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupActivityThresholdNotSatisfiedException.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupActivityThresholdNotSatisfiedException.java
@@ -23,13 +23,21 @@
  */
 package org.wise.portal.service.peergroup;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 /**
  * A checked exception that is thrown when the PeerGroup is not ready to be formed yet
  * because a threshold has not been met
  *
  * @author Hiroki Terashima
  */
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class PeerGroupActivityThresholdNotSatisfiedException extends Exception {
 
   private static final long serialVersionUID = 1L;
+
+  public PeerGroupActivityThresholdNotSatisfiedException() {
+    super("PeerGroupActivityThresholdNotSatisfied");
+  }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupCreationException.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupCreationException.java
@@ -23,17 +23,21 @@
  */
 package org.wise.portal.service.peergroup;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 /**
  * A checked exception that is thrown while creating a PeerGroup, for example not being able to
  * find the members to group together
  *
  * @author Hiroki Terashima
  */
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class PeerGroupCreationException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
   public PeerGroupCreationException() {
-    super("WorkgroupCountThreshold not satisfied");
+    super("PeerGroupWaitingForClassmates");
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupThresholdService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupThresholdService.java
@@ -47,5 +47,5 @@ public interface PeerGroupThresholdService {
    * @param period Group subset of workgroups in the run to test for PeerGroup members
    * @return boolean
    */
-  public boolean isWorkgroupCountThresholdSatisfied(PeerGroupActivity activity, Group period);
+  public boolean canCreatePeerGroup(PeerGroupActivity activity, Group period);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupThresholdService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupThresholdService.java
@@ -23,17 +23,29 @@
  */
 package org.wise.portal.service.peergroup;
 
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+
 /**
- * A checked exception that is thrown while creating a PeerGroup, for example not being able to
- * find the members to group together
- *
  * @author Hiroki Terashima
  */
-public class PeerGroupCreationException extends Exception {
+public interface PeerGroupThresholdService {
 
-  private static final long serialVersionUID = 1L;
+  /**
+   * Returns true iff the completion threshold has been satisfied to start creating PeerGroup.
+   * Completion threshold includes minimum workgroups completed count and percentage
+   * @param activity PeerGroupActivity for which to test for PeerGroup members
+   * @param period Group subset of workgroups in the run to test for PeerGroup members
+   * @return boolean
+   */
+  public boolean isCompletionThresholdSatisfied(PeerGroupActivity activity, Group period);
 
-  public PeerGroupCreationException() {
-    super("WorkgroupCountThreshold not satisfied");
-  }
+  /**
+   * Returns true iff this workgroup is the last workgroup to be in a PeerGroup (last one left), or
+   * there are at least two workgroups who have completed the logic step but are not in a PeerGroup
+   * @param activity PeerGroupActivity for which to test for PeerGroup members
+   * @param period Group subset of workgroups in the run to test for PeerGroup members
+   * @return boolean
+   */
+  public boolean isWorkgroupCountThresholdSatisfied(PeerGroupActivity activity, Group period);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -71,8 +71,7 @@ public class PeerGroupServiceImpl implements PeerGroupService {
       throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException {
     if (!isCompletionThresholdSatisfied(activity, workgroup)) {
       throw new PeerGroupActivityThresholdNotSatisfiedException();
-    } else if (!peerGroupThresholdService.isWorkgroupCountThresholdSatisfied(activity,
-        workgroup.getPeriod())) {
+    } else if (!peerGroupThresholdService.canCreatePeerGroup(activity, workgroup.getPeriod())) {
       throw new PeerGroupCreationException();
     } else {
       PeerGroup peerGroup = new PeerGroupImpl(activity, getPeerGroupMembers(workgroup, activity));

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroup.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.dao.work.StudentWorkDao;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.PeerGroupThresholdService;
+import org.wise.portal.service.run.RunService;
+import org.wise.vle.domain.work.StudentWork;
+
+/**
+ * @author Hiroki Terashima
+ */
+@Service
+public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService {
+
+  @Autowired
+  private RunService runService;
+
+  @Autowired
+  private PeerGroupDao<PeerGroup> peerGroupDao;
+
+  @Autowired
+  private StudentWorkDao<StudentWork> studentWorkDao;
+
+  public boolean isCompletionThresholdSatisfied(PeerGroupActivity activity, Group period) {
+    float logicComponentCompletionCount = getLogicComponentCompletionCount(activity, period);
+    float logicComponentCompletionPercent =
+        (logicComponentCompletionCount / getNumWorkgroupsInPeriod(activity, period)) * 100;
+    return logicComponentCompletionCount >= 2 &&
+        (logicComponentCompletionCount >= activity.getLogicThresholdCount() ||
+        logicComponentCompletionPercent >= activity.getLogicThresholdPercent());
+  }
+
+  public boolean isWorkgroupCountThresholdSatisfied(PeerGroupActivity activity, Group period) {
+    int numWorkgroupsInPeerGroup = getNumWorkgroupsInPeerGroup(activity, period);
+    int numWorkgroupsNotInPeerGroup = getNumWorkgroupsInPeriod(activity, period) -
+        numWorkgroupsInPeerGroup;
+    int numWorkgroupsCompletedLogicComponentButNotInPeerGroup =
+        getLogicComponentCompletionCount(activity, period) - numWorkgroupsInPeerGroup;
+    return numWorkgroupsNotInPeerGroup == 1 ||
+        numWorkgroupsCompletedLogicComponentButNotInPeerGroup >= 2;
+  }
+
+  private int getNumWorkgroupsInPeriod(PeerGroupActivity activity, Group period) {
+    return runService.getWorkgroups(activity.getRun().getId(), period.getId()).size();
+  }
+
+  private int getLogicComponentCompletionCount(PeerGroupActivity activity, Group period) {
+    try {
+      return getLogicComponentStudentWorkForPeriod(activity, period).size();
+    } catch (JSONException e) {
+    }
+    return 0;
+  }
+
+  private List<StudentWork> getLogicComponentStudentWorkForPeriod(PeerGroupActivity activity,
+      Group period) throws JSONException {
+    List<StudentWork> logicComponentStudentWorkForPeriod = studentWorkDao
+        .getWorkForComponentByPeriod(activity.getRun(), period,
+        activity.getLogicNodeId(), activity.getLogicComponentId());
+    Collections.reverse(logicComponentStudentWorkForPeriod);
+    List<Workgroup> workgroups = new ArrayList<Workgroup>();
+    List<StudentWork> studentWorkUniqueWorkgroups = new ArrayList<StudentWork>();
+    for (StudentWork studentWork : logicComponentStudentWorkForPeriod) {
+      if (studentWork.getIsSubmit() && !workgroups.contains(studentWork.getWorkgroup())) {
+        studentWorkUniqueWorkgroups.add(studentWork);
+        workgroups.add(studentWork.getWorkgroup());
+      }
+    }
+    return studentWorkUniqueWorkgroups;
+  }
+
+  private int getNumWorkgroupsInPeerGroup(PeerGroupActivity activity, Group period) {
+    int numWorkgroupsInPeerGroup = 0;
+    try {
+      List<PeerGroup> peerGroups = peerGroupDao.getListByComponent(activity.getRun(),
+          activity.getLogicNodeId(), activity.getLogicComponentId());
+      for (PeerGroup peerGroup : peerGroups) {
+        for (Workgroup workgroup : peerGroup.getMembers()) {
+          if (workgroup.getPeriod().equals(period)) {
+            numWorkgroupsInPeerGroup++;
+          }
+        }
+      }
+    } catch (JSONException e) {
+    }
+    return numWorkgroupsInPeerGroup;
+  }
+}

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
@@ -64,7 +64,7 @@ public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService 
         logicComponentCompletionPercent >= activity.getLogicThresholdPercent());
   }
 
-  public boolean isWorkgroupCountThresholdSatisfied(PeerGroupActivity activity, Group period) {
+  public boolean canCreatePeerGroup(PeerGroupActivity activity, Group period) {
     int numWorkgroupsInPeerGroup = getNumWorkgroupsInPeerGroup(activity, period);
     int numWorkgroupsNotInPeerGroup = getNumWorkgroupsInPeriod(activity, period) -
         numWorkgroupsInPeerGroup;
@@ -105,17 +105,14 @@ public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService 
 
   private int getNumWorkgroupsInPeerGroup(PeerGroupActivity activity, Group period) {
     int numWorkgroupsInPeerGroup = 0;
-    try {
-      List<PeerGroup> peerGroups = peerGroupDao.getListByComponent(activity.getRun(),
-          activity.getLogicNodeId(), activity.getLogicComponentId());
-      for (PeerGroup peerGroup : peerGroups) {
-        for (Workgroup workgroup : peerGroup.getMembers()) {
-          if (workgroup.getPeriod().equals(period)) {
-            numWorkgroupsInPeerGroup++;
-          }
+    List<PeerGroup> peerGroups = peerGroupDao.getListByComponent(activity.getRun(),
+        activity.getNodeId(), activity.getComponentId());
+    for (PeerGroup peerGroup : peerGroups) {
+      for (Workgroup workgroup : peerGroup.getMembers()) {
+        if (workgroup.getPeriod().equals(period)) {
+          numWorkgroupsInPeerGroup++;
         }
       }
-    } catch (JSONException e) {
     }
     return numWorkgroupsInPeerGroup;
   }

--- a/src/main/java/org/wise/portal/service/peergroupactivity/impl/PeerGroupActivityServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroupactivity/impl/PeerGroupActivityServiceImpl.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
 import org.wise.portal.dao.peergroupactivity.PeerGroupActivityDao;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
@@ -41,6 +42,7 @@ import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 /**
  * @author Hiroki Terashima
  */
+@Service
 public class PeerGroupActivityServiceImpl implements PeerGroupActivityService {
 
   @Autowired

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -103,6 +103,8 @@ public class APIControllerTest {
 
   protected List<Tag> run1Tags;
 
+  protected Long workgroup1Id = 1L;
+
   protected Workgroup workgroup1, workgroup2, teacher1Run1Workgroup;
 
   protected Project project1, project2, project3;
@@ -210,6 +212,7 @@ public class APIControllerTest {
     run1.setProject(project1);
     run1.setLastRun(new Date());
     workgroup1 = new WorkgroupImpl();
+    workgroup1.setId(workgroup1Id);
     workgroup1.addMember(student1);
     workgroup1.setPeriod(run1Period1);
     workgroup1.setRun(run1);

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
@@ -1,9 +1,7 @@
 package org.wise.portal.presentation.web.controllers.peergroup;
 
 import static org.easymock.EasyMock.*;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
@@ -76,12 +74,15 @@ public class PeerGroupAPIControllerTest extends APIControllerTest {
   }
 
   @Test
-  public void getPeerGroup_PeerGroupThresholdNotMet_ReturnNull() throws Exception {
+  public void getPeerGroup_PeerGroupThresholdNotMet_ThrowException() throws Exception {
     expectWorkgroupAssociatedWithRunAndActivityFound();
     expectPeerGroupThresholdNotSatisifed();
     replayAll();
-    assertNull(controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id,
-        studentAuth));
+    try {
+      controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id, studentAuth);
+      fail("Expected PeerGroupCreationException, but was not thrown");
+    } catch (PeerGroupActivityThresholdNotSatisfiedException e) {
+    }
     verifyAll();
   }
 

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
@@ -1,0 +1,157 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.service.peergroup.PeerGroupActivityThresholdNotSatisfiedException;
+import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
+
+@RunWith(EasyMockRunner.class)
+public class PeerGroupAPIControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private PeerGroupAPIController controller = new PeerGroupAPIController();
+
+  @Mock
+  private PeerGroupService peerGroupService;
+
+  @Mock
+  private PeerGroupActivityService peerGroupActivityService;
+
+  private String run1Node1Id = "run1Node1";
+
+  private String run1Component1Id = "run1Component1";
+
+  private PeerGroupActivity peerGroupActivity;
+
+  private PeerGroup peerGroup;
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    peerGroupActivity = new PeerGroupActivityImpl();
+    peerGroup = new PeerGroupImpl();
+  }
+
+  @Test
+  public void getPeerGroup_WorkgroupNotAssociatedWithRun_AccessDenied() throws Exception {
+    expectWorkgroupAssociatedWithRun(false);
+    replayAll();
+    try {
+      controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id, studentAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_PeerGroupActivityNotFound_ThrowException() throws Exception {
+    expectWorkgroupAssociatedWithRun(true);
+    expectPeerGroupActivityFound(false);
+    replayAll();
+    try {
+      controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id, studentAuth);
+      fail("Expected PeerGroupActivityNotFoundException, but was not thrown");
+    } catch (PeerGroupActivityNotFoundException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_PeerGroupThresholdNotMet_ReturnNull() throws Exception {
+    expectWorkgroupAssociatedWithRunAndActivityFound();
+    expectPeerGroupThresholdNotSatisifed();
+    replayAll();
+    assertNull(controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id,
+        studentAuth));
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_ErrorCreatingPeerGroup_ThrowException() throws Exception {
+    expectWorkgroupAssociatedWithRunAndActivityFound();
+    expectPeerGroupCreationException();
+    replayAll();
+    try {
+      controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id, studentAuth);
+      fail("Expected PeerGroupCreationException, but was not thrown");
+    } catch (PeerGroupCreationException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_FoundExistingGroupOrGroupCreated_ReturnGroup() throws Exception {
+    expectWorkgroupAssociatedWithRunAndActivityFound();
+    expectPeerGroupCreated();
+    replayAll();
+    assertNotNull(controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id,
+        studentAuth));
+    verifyAll();
+  }
+
+  private void expectWorkgroupAssociatedWithRunAndActivityFound() throws Exception,
+      PeerGroupActivityNotFoundException {
+    expectWorkgroupAssociatedWithRun(true);
+    expectPeerGroupActivityFound(true);
+  }
+
+  private void expectWorkgroupAssociatedWithRun(boolean isAssociated) throws Exception {
+    expect(runService.retrieveById(runId1)).andReturn(run1);
+    expect(workgroupService.retrieveById(workgroup1Id)).andReturn(workgroup1);
+    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student1);
+    expect(workgroupService.isUserInWorkgroupForRun(student1, run1, workgroup1))
+        .andReturn(isAssociated);
+  }
+
+  private void expectPeerGroupActivityFound(boolean isFound)
+      throws PeerGroupActivityNotFoundException {
+    if (isFound) {
+      expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
+          .andReturn(peerGroupActivity);
+    } else {
+      expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
+          .andThrow(new PeerGroupActivityNotFoundException());
+    }
+  }
+
+  private void expectPeerGroupThresholdNotSatisifed() throws Exception {
+    expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity))
+        .andThrow(new PeerGroupActivityThresholdNotSatisfiedException());
+  }
+
+  private void expectPeerGroupCreationException() throws Exception {
+    expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity))
+        .andThrow(new PeerGroupCreationException());
+  }
+
+  private void expectPeerGroupCreated() throws Exception {
+    expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity)).andReturn(peerGroup);
+  }
+
+  private void verifyAll() {
+    verify(peerGroupActivityService, peerGroupService, runService, userService, workgroupService);
+  }
+
+  private void replayAll() {
+    replay(peerGroupActivityService, peerGroupService, runService, userService, workgroupService);
+  }
+}

--- a/src/test/java/org/wise/portal/service/WISEServiceTest.java
+++ b/src/test/java/org/wise/portal/service/WISEServiceTest.java
@@ -23,7 +23,7 @@
  */
 package org.wise.portal.service;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -50,9 +50,8 @@ public class WISEServiceTest {
 
   protected Group run1Period1;
 
-  protected List<Workgroup> period1Workgroups;
-
-  protected Workgroup run1Workgroup1, run1Workgroup2, run1Workgroup3;
+  protected Workgroup run1Workgroup1, run1Workgroup2, run1Workgroup3, run1Workgroup4,
+      run1Workgroup5;
 
   protected Component run1Component1, run1Component2;
 
@@ -64,7 +63,7 @@ public class WISEServiceTest {
 
   protected String run1Component2Id = "run1Component2";
 
-  protected User student1, student2, student3;
+  protected User student1, student2, student3, student4, student5;
 
   protected StudentWork componentWorkSubmit1, componentWorkSubmit2, componentWorkNonSubmit1;
 
@@ -75,11 +74,12 @@ public class WISEServiceTest {
     run1Workgroup1 = createWorkgroupInPeriod(1L, run1Period1, student1);
     run1Workgroup2 = createWorkgroupInPeriod(2L, run1Period1, student2);
     run1Workgroup3 = createWorkgroupInPeriod(3L, run1Period1, student3);
+    run1Workgroup4 = createWorkgroupInPeriod(4L, run1Period1, student4);
+    run1Workgroup5 = createWorkgroupInPeriod(5L, run1Period1, student5);
     run1 = new RunImpl();
     run1.setId(run1Id);
     run1Component1 = new Component(run1, run1Node1Id, run1Component1Id);
     run1Component2 = new Component(run1, run1Node2Id, run1Component2Id);
-    period1Workgroups = Arrays.asList(run1Workgroup1, run1Workgroup2, run1Workgroup3);
     componentWorkSubmit1 = createComponentWork(run1Workgroup1, true);
     componentWorkSubmit2 = createComponentWork(run1Workgroup2, true);
     componentWorkNonSubmit1 = createComponentWork(run1Workgroup1, false);
@@ -101,5 +101,13 @@ public class WISEServiceTest {
     work.setWorkgroup(workgroup);
     work.setIsSubmit(isSubmit);
     return work;
+  }
+
+  protected List<StudentWork> createStudentWorkList(StudentWork... componentWorks) {
+    List<StudentWork> list = new ArrayList<StudentWork>();
+    for (StudentWork work : componentWorks) {
+      list.add(work);
+    }
+    return list;
   }
 }

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -160,7 +160,7 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
   }
 
   private void expectWorkgroupCountThresholdSatisfied(boolean isSatisfied) {
-    expect(peerGroupThresholdService.isWorkgroupCountThresholdSatisfied(activity, run1Period1))
+    expect(peerGroupThresholdService.canCreatePeerGroup(activity, run1Period1))
         .andReturn(isSatisfied);
   }
 

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroup.impl;
+
+import org.json.JSONObject;
+import org.wise.portal.dao.Component;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.service.WISEServiceTest;
+
+/**
+ * @author Hiroki Terashima
+ */
+public class PeerGroupServiceTestHelper extends WISEServiceTest {
+
+  String logic = "[{\"name\": \"maximizeDifferentIdeas\"," +
+      "\"nodeId\": \"" + run1Node1Id + "\", \"componentId\": \"" + run1Component1Id + "\"}]";
+
+  int logicThresholdCount = 3;
+
+  int logicThresholdPercent = 50;
+
+  int maxMembershipCount = 2;
+
+  String peerGroupActivityComponentString =
+      "{\"id\":\"" + run1Component2Id + "\"," +
+      "\"logic\":" + logic + "," +
+      "\"logicThresholdCount\":" + logicThresholdCount + "," +
+      "\"logicThresholdPercent\":" + logicThresholdPercent + "," +
+      "\"maxMembershipCount\":" + maxMembershipCount + "}";
+
+  PeerGroupActivity activity;
+
+  PeerGroup peerGroup1, peerGroup2, peerGroup3;
+
+  public PeerGroupServiceTestHelper(Run run, Component component) throws Exception {
+    super.setUp();
+    activity = new PeerGroupActivityImpl(run, component.nodeId,
+        new ProjectComponent(new JSONObject(peerGroupActivityComponentString)));
+    peerGroup1 = new PeerGroupImpl();
+    peerGroup1.addMember(run1Workgroup1);
+    peerGroup1.addMember(run1Workgroup2);
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.TestSubject;
-import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,49 +99,43 @@ public class PeerGroupThresholdServiceTest extends WISEServiceTest {
   }
 
   @Test
-  public void isWorkgroupCountThresholdSatisfied_OneWorkgroupNotInPeerGroup_ReturnTrue() {
+  public void canCreatePeerGroup_OneWorkgroupNotInPeerGroup_ReturnTrue() {
     expectTwoWorkgroupsInPeerGroup();
     expectThreeWorkgroupsInPeriod();
     expectTwoWorkgroupsCompletedLogicComponent();
     replayAll();
-    assertTrue(service.isWorkgroupCountThresholdSatisfied(activity, run1Period1));
+    assertTrue(service.canCreatePeerGroup(activity, run1Period1));
     verifyAll();
   }
 
   @Test
-  public void isWorkgroupCountThresholdSatisfied_TwoCompletedWorkgroupsButNotInPeerGroup_ReturnTrue() {
+  public void canCreatePeerGroup_TwoCompletedWorkgroupsButNotInPeerGroup_ReturnTrue() {
     expectNoWorkgroupsInPeerGroup();
     expectThreeWorkgroupsInPeriod();
     expectTwoWorkgroupsCompletedLogicComponent();
     replayAll();
-    assertTrue(service.isWorkgroupCountThresholdSatisfied(activity, run1Period1));
+    assertTrue(service.canCreatePeerGroup(activity, run1Period1));
     verifyAll();
   }
 
   @Test
-  public void isWorkgroupCountThresholdSatisfied_NoThresholdMet_ReturnFalse() {
+  public void canCreatePeerGroup_NoThresholdMet_ReturnFalse() {
     expectNoWorkgroupsInPeerGroup();
     expectThreeWorkgroupsInPeriod();
     expectOneWorkgroupsCompletedLogicComponent();
     replayAll();
-    assertFalse(service.isWorkgroupCountThresholdSatisfied(activity, run1Period1));
+    assertFalse(service.canCreatePeerGroup(activity, run1Period1));
     verifyAll();
   }
 
   private void expectNoWorkgroupsInPeerGroup() {
-    try {
-      expect(peerGroupDao.getListByComponent(run1, activity.getLogicNodeId(),
-          activity.getLogicComponentId())).andReturn(Arrays.asList());
-    } catch (JSONException e) {
-    }
+    expect(peerGroupDao.getListByComponent(run1, activity.getNodeId(), activity.getComponentId()))
+        .andReturn(Arrays.asList());
   }
 
   private void expectTwoWorkgroupsInPeerGroup() {
-    try {
-      expect(peerGroupDao.getListByComponent(run1, activity.getLogicNodeId(),
-          activity.getLogicComponentId())).andReturn(Arrays.asList(testHelper.peerGroup1));
-    } catch (JSONException e) {
-    }
+    expect(peerGroupDao.getListByComponent(run1, activity.getNodeId(), activity.getComponentId()))
+        .andReturn(Arrays.asList(testHelper.peerGroup1));
   }
 
   private void expectOneWorkgroupsCompletedLogicComponent() {
@@ -154,9 +147,9 @@ public class PeerGroupThresholdServiceTest extends WISEServiceTest {
         componentWorkNonSubmit1));
   }
 
-  private void expectWorkForLogicComponent(List<StudentWork> workForLogicComponent) {
+  private void expectWorkForLogicComponent(List<StudentWork> expectedWork) {
     expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
-        run1Component1Id)).andReturn(workForLogicComponent);
+        run1Component1Id)).andReturn(expectedWork);
   }
 
   private void expectThreeWorkgroupsInPeriod() {

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2008-2021 Regents of the University of California (Regents).
+ * Created by WISE, Graduate School of Education, University of California, Berkeley.
+ *
+ * This software is distributed under the GNU General Public License, v3,
+ * or (at your option) any later version.
+ *
+ * Permission is hereby granted, without written agreement and without license
+ * or royalty fees, to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, provided that the above copyright notice and
+ * the following two paragraphs appear in all copies of this software.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+ * HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+ * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ * REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.wise.portal.service.peergroup.impl;
+
+import static org.junit.Assert.*;
+import static org.easymock.EasyMock.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.dao.work.StudentWorkDao;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.service.WISEServiceTest;
+import org.wise.portal.service.run.RunService;
+import org.wise.vle.domain.work.StudentWork;
+
+/**
+ * @author Hiroki Terashima
+ */
+@RunWith(EasyMockRunner.class)
+public class PeerGroupThresholdServiceTest extends WISEServiceTest {
+
+  @TestSubject
+  private PeerGroupThresholdServiceImpl service = new PeerGroupThresholdServiceImpl();
+
+  @Mock
+  private RunService runService;
+
+  @Mock
+  private PeerGroupDao<PeerGroup> peerGroupDao;
+
+  @Mock
+  private StudentWorkDao<StudentWork> studentWorkDao;
+
+  PeerGroupActivity activity;
+
+  PeerGroupServiceTestHelper testHelper;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    testHelper = new PeerGroupServiceTestHelper(run1, run1Component2);
+    activity = testHelper.activity;
+  }
+
+  @Test
+  public void isCompletionThresholdSatisfied_LessThan2Complete_ReturnFalse() {
+    expectCompletionCountOne();
+    expectThreeWorkgroupsInPeriod();
+    replayAll();
+    assertFalse(service.isCompletionThresholdSatisfied(activity, run1Period1));
+    verifyAll();
+  }
+
+  @Test
+  public void isCompletionThresholdSatisfied_ThresholdCountAndPercentNotMet_ReturnFalse() {
+    expectCompletionCountTwo();
+    expectFiveWorkgroupsInPeriod();
+    replayAll();
+    assertFalse(service.isCompletionThresholdSatisfied(activity, run1Period1));
+    verifyAll();
+  }
+
+  @Test
+  public void isCompletionThresholdSatisfied_AllThresholdsSatisfied_ReturnTrue() {
+    expectCompletionCountTwo();
+    expectThreeWorkgroupsInPeriod();
+    replayAll();
+    assertTrue(service.isCompletionThresholdSatisfied(activity, run1Period1));
+    verifyAll();
+  }
+
+  @Test
+  public void isWorkgroupCountThresholdSatisfied_OneWorkgroupNotInPeerGroup_ReturnTrue() {
+    expectTwoWorkgroupsInPeerGroup();
+    expectThreeWorkgroupsInPeriod();
+    expectTwoWorkgroupsCompletedLogicComponent();
+    replayAll();
+    assertTrue(service.isWorkgroupCountThresholdSatisfied(activity, run1Period1));
+    verifyAll();
+  }
+
+  @Test
+  public void isWorkgroupCountThresholdSatisfied_TwoCompletedWorkgroupsButNotInPeerGroup_ReturnTrue() {
+    expectNoWorkgroupsInPeerGroup();
+    expectThreeWorkgroupsInPeriod();
+    expectTwoWorkgroupsCompletedLogicComponent();
+    replayAll();
+    assertTrue(service.isWorkgroupCountThresholdSatisfied(activity, run1Period1));
+    verifyAll();
+  }
+
+  @Test
+  public void isWorkgroupCountThresholdSatisfied_NoThresholdMet_ReturnFalse() {
+    expectNoWorkgroupsInPeerGroup();
+    expectThreeWorkgroupsInPeriod();
+    expectOneWorkgroupsCompletedLogicComponent();
+    replayAll();
+    assertFalse(service.isWorkgroupCountThresholdSatisfied(activity, run1Period1));
+    verifyAll();
+  }
+
+  private void expectNoWorkgroupsInPeerGroup() {
+    try {
+      expect(peerGroupDao.getListByComponent(run1, activity.getLogicNodeId(),
+          activity.getLogicComponentId())).andReturn(Arrays.asList());
+    } catch (JSONException e) {
+    }
+  }
+
+  private void expectTwoWorkgroupsInPeerGroup() {
+    try {
+      expect(peerGroupDao.getListByComponent(run1, activity.getLogicNodeId(),
+          activity.getLogicComponentId())).andReturn(Arrays.asList(testHelper.peerGroup1));
+    } catch (JSONException e) {
+    }
+  }
+
+  private void expectOneWorkgroupsCompletedLogicComponent() {
+    expectWorkForLogicComponent(createStudentWorkList(componentWorkSubmit1));
+  }
+
+  private void expectTwoWorkgroupsCompletedLogicComponent() {
+    expectWorkForLogicComponent(createStudentWorkList(componentWorkSubmit1, componentWorkSubmit2,
+        componentWorkNonSubmit1));
+  }
+
+  private void expectWorkForLogicComponent(List<StudentWork> workForLogicComponent) {
+    expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
+        run1Component1Id)).andReturn(workForLogicComponent);
+  }
+
+  private void expectThreeWorkgroupsInPeriod() {
+    expect(runService.getWorkgroups(run1Id, run1Period1.getId())).andReturn(Arrays.asList(
+        run1Workgroup1, run1Workgroup2, run1Workgroup3));
+  }
+
+  private void expectFiveWorkgroupsInPeriod() {
+    expect(runService.getWorkgroups(run1Id, run1Period1.getId())).andReturn(Arrays.asList(
+        run1Workgroup1, run1Workgroup2, run1Workgroup3, run1Workgroup4, run1Workgroup5));
+  }
+
+  private void expectCompletionCountOne() {
+    expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
+        run1Component1Id)).andReturn(createStudentWorkList(componentWorkSubmit1));
+  }
+
+  private void expectCompletionCountTwo() {
+    expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
+        run1Component1Id)).andReturn(createStudentWorkList(componentWorkSubmit1,
+        componentWorkSubmit2, componentWorkNonSubmit1));
+  }
+
+  private void verifyAll() {
+    verify(peerGroupDao, runService, studentWorkDao);
+  }
+
+  private void replayAll() {
+    replay(peerGroupDao, runService, studentWorkDao);
+  }
+}


### PR DESCRIPTION
Method: GET
URL: /api/peer-group/run/{runId}/workgroup/{workgroupId}/node-id/{nodeId}/component-id/{componentId}
Return a PeerGroup if it can be found or created
Return null if it can't be created (e.g. when a threshold was not met)
Throw Exception if there was some other kind of error

## Prep
- add Dialog Guidance activity to a run
- add PeerChat activity to a run. The component content's logic's nodeId/componentId should point to the DG activity:
```
{
    "id": "e3zlopgkxy",
    "type": "PeerChat",
    "prompt": "",
    "logic": [
        {
            "name": "maximizeSimilarIdeas",
            "nodeId": "node2", <- point to DG
            "componentId": "hyj2hefyuk" <- point to DG
        }
    ],
    "logicThresholdCount": 3,
    "logicThresholdPercent": 50,
    "maxMembershipCount": 2,
    "showSaveButton": false,
    "showSubmitButton": false,
    "starterSentence": null,
    "isStudentAttachmentEnabled": false
}
```

## Test
- make a GET request to the above URL under various situations:
  - only one workgroup in run, completed DialogGuidance activity => should not create PeerGroup, return null
  - multiple workgroups in run, only one completed DG activity => should not create PeerGroup, return null b.c. threshold not met
  - multiple workgroups in run, multiple completed DG activity => should create PeerGroup

The logic to pair is the first available. As soon as the threshold is met and there are possible pairings available, it will create the PeerGroup.

Closes #44