### PR TITLE
feat(Peer Chat): Add endpoint for getting StudentWork for peer group

### DIFF
--- a/src/main/java/org/wise/portal/dao/work/StudentWorkDao.java
+++ b/src/main/java/org/wise/portal/dao/work/StudentWorkDao.java
@@ -31,6 +31,7 @@ import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.vle.domain.work.StudentWork;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Domain Access Object for StudentWork
@@ -43,6 +44,9 @@ public interface StudentWorkDao<T extends StudentWork> extends SimpleDao<T> {
       String componentType, List<JSONObject> components);
 
   List<StudentWork> getWorkForComponentByWorkgroup(Workgroup workgroup, String nodeId,
+      String componentId);
+
+  List<StudentWork> getWorkForComponentByWorkgroups(Set<Workgroup> workgroups, String nodeId,
       String componentId);
 
   List<StudentWork> getWorkForComponentByPeriod(Run run, Group period, String nodeId,

--- a/src/main/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDao.java
+++ b/src/main/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDao.java
@@ -25,6 +25,7 @@ package org.wise.portal.dao.work.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -111,6 +112,22 @@ public class HibernateStudentWorkDao extends AbstractHibernateDao<StudentWork>
     Root<StudentWork> studentWorkRoot = cq.from(StudentWork.class);
     List<Predicate> predicates = new ArrayList<Predicate>();
     predicates.add(cb.equal(studentWorkRoot.get("workgroup"), workgroup));
+    predicates.add(cb.equal(studentWorkRoot.get("nodeId"), nodeId));
+    predicates.add(cb.equal(studentWorkRoot.get("componentId"), componentId));
+    cq.select(studentWorkRoot).where(predicates.toArray(new Predicate[predicates.size()]))
+    .orderBy(cb.asc(studentWorkRoot.get("serverSaveTime")));
+    TypedQuery<StudentWork> query = entityManager.createQuery(cq);
+    return (List<StudentWork>) query.getResultList();
+  }
+
+  @Override
+  public List<StudentWork> getWorkForComponentByWorkgroups(Set<Workgroup> workgroups, String nodeId,
+      String componentId) {
+    CriteriaBuilder cb = getCriteriaBuilder();
+    CriteriaQuery<StudentWork> cq = cb.createQuery(StudentWork.class);
+    Root<StudentWork> studentWorkRoot = cq.from(StudentWork.class);
+    List<Predicate> predicates = new ArrayList<Predicate>();
+    predicates.add(cb.in(studentWorkRoot.get("workgroup")).value(workgroups));
     predicates.add(cb.equal(studentWorkRoot.get("nodeId"), nodeId));
     predicates.add(cb.equal(studentWorkRoot.get("componentId"), componentId));
     cq.select(studentWorkRoot).where(predicates.toArray(new Predicate[predicates.size()]))

--- a/src/main/java/org/wise/portal/domain/peergroup/PeerGroup.java
+++ b/src/main/java/org/wise/portal/domain/peergroup/PeerGroup.java
@@ -26,6 +26,7 @@ package org.wise.portal.domain.peergroup;
 import java.util.Set;
 
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.workgroup.Workgroup;
 
 /**
@@ -41,4 +42,6 @@ public interface PeerGroup {
   void setMembers(Set<Workgroup> members);
 
   public void addMember(Workgroup workgroup);
+
+  boolean isMember(User user);
 }

--- a/src/main/java/org/wise/portal/domain/peergroup/impl/PeerGroupImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroup/impl/PeerGroupImpl.java
@@ -41,6 +41,7 @@ import javax.persistence.Table;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 
@@ -81,5 +82,15 @@ public class PeerGroupImpl implements PeerGroup {
 
   public void addMember(Workgroup workgroup) {
     this.members.add(workgroup);
+  }
+
+  @Override
+  public boolean isMember(User user) {
+    for (Workgroup workgroup : members) {
+      if (workgroup.getMembers().contains(user)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -23,6 +23,8 @@
  */
 package org.wise.portal.presentation.web.controllers.peergroup;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
@@ -45,6 +47,7 @@ import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.run.RunService;
 import org.wise.portal.service.user.UserService;
 import org.wise.portal.service.workgroup.WorkgroupService;
+import org.wise.vle.domain.work.StudentWork;
 
 @RestController
 @Secured("ROLE_USER")
@@ -66,7 +69,7 @@ public class PeerGroupAPIController {
   @Autowired
   private PeerGroupActivityService peerGroupActivityService;
 
-  @GetMapping("/run/{runId}/workgroup/{workgroupId}/node-id/{nodeId}/component-id/{componentId}")
+  @GetMapping("/{runId}/{workgroupId}/{nodeId}/{componentId}")
   PeerGroup getPeerGroup(@PathVariable Long runId, @PathVariable Long workgroupId,
       @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
       throws ObjectNotFoundException, PeerGroupActivityNotFoundException,
@@ -86,5 +89,21 @@ public class PeerGroupAPIController {
       PeerGroupActivityThresholdNotSatisfiedException {
     PeerGroupActivity activity = peerGroupActivityService.getByComponent(run, nodeId, componentId);
     return peerGroupService.getPeerGroup(workgroup, activity);
+  }
+
+  @GetMapping("/{peerGroupId}/student-work")
+  List<StudentWork> getPeerGroupWork(@PathVariable Long peerGroupId, Authentication auth)
+      throws ObjectNotFoundException {
+    PeerGroup peerGroup = peerGroupService.getById(peerGroupId);
+    if (isUserInPeerGroup(peerGroup, auth)) {
+      return peerGroupService.getStudentWork(peerGroup);
+    } else {
+      throw new AccessDeniedException("Not permitted");
+    }
+  }
+
+  private boolean isUserInPeerGroup(PeerGroup peerGroup, Authentication auth) {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    return peerGroup.isMember(user);
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
@@ -23,14 +23,26 @@
  */
 package org.wise.portal.service.peergroup;
 
+import java.util.List;
+
+import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.vle.domain.work.StudentWork;
 
 /**
  * @author Hiroki Terashima
  */
 public interface PeerGroupService {
+
+  /**
+   * Gets the PeerGroup with the specified id
+   * @param id Long PeerGroup's id
+   * @return matched PeerGroup
+   * @throws ObjectNotFoundException when PeerGroup with the given id is not found
+   */
+  public PeerGroup getById(Long id) throws ObjectNotFoundException;
 
   /**
    * Gets a PeerGroup for the specified workgroup and PeerGroupActivity if a PeerGroup
@@ -46,4 +58,11 @@ public interface PeerGroupService {
    */
   PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
       throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException;
+
+  /**
+   * Gets StudentWork for the PeerGroup's activity from all the members in the PeerGroup
+   * @param peerGroup group of workgroups in the PeerGroup
+   * @return List of StudentWork by members in the PeerGroup for the activity
+   */
+  public List<StudentWork> getStudentWork(PeerGroup peerGroup);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.json.JSONException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.dao.peergroup.PeerGroupDao;
 import org.wise.portal.dao.work.StudentWorkDao;
 import org.wise.portal.domain.group.Group;
@@ -59,6 +60,10 @@ public class PeerGroupServiceImpl implements PeerGroupService {
 
   @Autowired
   private StudentWorkDao<StudentWork> studentWorkDao;
+
+  public PeerGroup getById(Long id) throws ObjectNotFoundException {
+    return peerGroupDao.getById(id);
+  }
 
   @Override
   public PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
@@ -138,5 +143,12 @@ public class PeerGroupServiceImpl implements PeerGroupService {
       }
     }
     return studentWorkUniqueWorkgroups;
+  }
+
+  @Override
+  public List<StudentWork> getStudentWork(PeerGroup peerGroup) {
+    return studentWorkDao.getWorkForComponentByWorkgroups(peerGroup.getMembers(),
+        peerGroup.getPeerGroupActivity().getNodeId(),
+        peerGroup.getPeerGroupActivity().getComponentId());
   }
 }

--- a/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
@@ -27,7 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -103,6 +105,18 @@ public class HibernateStudentWorkDaoTest extends WISEHibernateTest {
         "node1", "component1");
     assertEquals(1, studentWorkList.size());
     assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
+  }
+
+  @Test
+  public void getWorkForComponentByWorkgroups_ShouldReturnStudentWork() {
+    Set<Workgroup> workgroups = new HashSet<Workgroup>();
+    workgroups.add(workgroup1);
+    workgroups.add(workgroup2);
+    List<StudentWork> studentWorkList = studentWorkDao.getWorkForComponentByWorkgroups(workgroups,
+        "node1", "component1");
+    assertEquals(2, studentWorkList.size());
+    assertEquals("studentWork1", studentWorkList.get(0).getStudentData());
+    assertEquals("studentWork3", studentWorkList.get(1).getStudentData());
   }
 
   private StudentWork createStudentWork(Workgroup workgroup, String nodeId, String componentId,

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -82,7 +82,7 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
     super.setUp();
     PeerGroupServiceTestHelper testHelper = new PeerGroupServiceTestHelper(run1, run1Component2);
     activity = testHelper.activity;
-    peerGroup = new PeerGroupImpl();
+    peerGroup = testHelper.peerGroup1;
   }
 
   @Test
@@ -153,6 +153,22 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
     replayAll();
     assertNotNull(service.getPeerGroup(run1Workgroup1, activity));
     verifyAll();
+  }
+
+  @Test
+  public void getStudentWork_PeerGroupExist_ReturnStudentWorkList() {
+    expectGetWorkForComponentByWorkgroups();
+    replayAll();
+    assertEquals(service.getStudentWork(peerGroup).size(), 3);
+    verifyAll();
+  }
+
+  private void expectGetWorkForComponentByWorkgroups() {
+    expect(studentWorkDao.getWorkForComponentByWorkgroups(peerGroup.getMembers(),
+        peerGroup.getPeerGroupActivity().getNodeId(),
+        peerGroup.getPeerGroupActivity().getComponentId())).andReturn(
+        createStudentWorkList(componentWorkSubmit1, componentWorkSubmit2,
+        componentWorkNonSubmit1));
   }
 
   private void expectWorkgroupsInPeerGroup(List<Object> asList) {

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
@@ -23,6 +23,9 @@
  */
 package org.wise.portal.service.peergroup.impl;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.json.JSONObject;
 import org.wise.portal.dao.Component;
 import org.wise.portal.domain.peergroup.PeerGroup;
@@ -31,6 +34,7 @@ import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
 import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.WISEServiceTest;
 
 /**
@@ -62,8 +66,9 @@ public class PeerGroupServiceTestHelper extends WISEServiceTest {
     super.setUp();
     activity = new PeerGroupActivityImpl(run, component.nodeId,
         new ProjectComponent(new JSONObject(peerGroupActivityComponentString)));
-    peerGroup1 = new PeerGroupImpl();
-    peerGroup1.addMember(run1Workgroup1);
-    peerGroup1.addMember(run1Workgroup2);
+    Set<Workgroup> members = new HashSet<Workgroup>();
+    members.add(run1Workgroup1);
+    members.add(run1Workgroup2);
+    peerGroup1 = new PeerGroupImpl(activity, members);
   }
 }


### PR DESCRIPTION
## Changes
- Add endpoint to get StudentWork for PeerGroup
- Change URL to get PeerGroup to ```/{runId}/{workgroupId}/{nodeId}/{componentId}```

## Test
- Make request to get StudentWork: ```/api/peer-group/{peerGroupId}/student-work```
   - when peerGroupId is not found or user is not in the given PeerGroup, it should throw an exception
   - otherwise, it should get a list of StudentWork by members in the PeerGroup

Closes #47