### PR TITLE
feat(Peer Group): Add teacher endpoint to get work for peer group

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -23,8 +23,6 @@
  */
 package org.wise.portal.presentation.web.controllers.peergroup;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
@@ -47,7 +45,6 @@ import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.run.RunService;
 import org.wise.portal.service.user.UserService;
 import org.wise.portal.service.workgroup.WorkgroupService;
-import org.wise.vle.domain.work.StudentWork;
 
 @RestController
 @Secured("ROLE_USER")
@@ -89,21 +86,5 @@ public class PeerGroupAPIController {
       PeerGroupActivityThresholdNotSatisfiedException {
     PeerGroupActivity activity = peerGroupActivityService.getByComponent(run, nodeId, componentId);
     return peerGroupService.getPeerGroup(workgroup, activity);
-  }
-
-  @GetMapping("/{peerGroupId}/student-work")
-  List<StudentWork> getPeerGroupWork(@PathVariable Long peerGroupId, Authentication auth)
-      throws ObjectNotFoundException {
-    PeerGroup peerGroup = peerGroupService.getById(peerGroupId);
-    if (isUserInPeerGroup(peerGroup, auth)) {
-      return peerGroupService.getStudentWork(peerGroup);
-    } else {
-      throw new AccessDeniedException("Not permitted");
-    }
-  }
-
-  private boolean isUserInPeerGroup(PeerGroup peerGroup, Authentication auth) {
-    User user = userService.retrieveUserByUsername(auth.getName());
-    return peerGroup.isMember(user);
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIController.java
@@ -1,0 +1,46 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.portal.service.user.UserService;
+import org.wise.vle.domain.work.StudentWork;
+
+@RestController
+@Secured("ROLE_USER")
+@RequestMapping("/api/peer-group")
+public class PeerGroupWorkAPIController {
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private PeerGroupService peerGroupService;
+
+  @GetMapping("/{peerGroupId}/student-work")
+  List<StudentWork> getPeerGroupWork(@PathVariable Long peerGroupId, Authentication auth)
+      throws ObjectNotFoundException {
+    PeerGroup peerGroup = peerGroupService.getById(peerGroupId);
+    if (isUserInPeerGroup(peerGroup, auth)) {
+      return peerGroupService.getStudentWork(peerGroup);
+    } else {
+      throw new AccessDeniedException("Not permitted");
+    }
+  }
+
+  private boolean isUserInPeerGroup(PeerGroup peerGroup, Authentication auth) {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    return peerGroup.isMember(user);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupAPIControllerTest.java
@@ -1,0 +1,65 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import static org.easymock.EasyMock.*;
+
+import org.easymock.Mock;
+import org.junit.Before;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
+
+public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTest {
+
+  @Mock
+  protected PeerGroupService peerGroupService;
+
+  @Mock
+  protected PeerGroupActivityService peerGroupActivityService;
+
+  protected String run1Node1Id = "run1Node1";
+
+  protected String run1Component1Id = "run1Component1";
+
+  protected PeerGroupActivity peerGroupActivity;
+
+  protected PeerGroup peerGroup1;
+
+  protected Long peerGroup1Id = 1L;
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    peerGroupActivity = new PeerGroupActivityImpl();
+    peerGroup1 = new PeerGroupImpl();
+    peerGroup1.addMember(workgroup1);
+  }
+
+  protected void expectPeerGroupActivityFound() throws PeerGroupActivityNotFoundException {
+    expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
+        .andReturn(peerGroupActivity);
+  }
+
+  protected void expectPeerGroupActivityNotFound() throws PeerGroupActivityNotFoundException {
+    expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
+        .andThrow(new PeerGroupActivityNotFoundException());
+  }
+
+  protected void expectPeerGroupCreationException() throws Exception {
+    expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity))
+        .andThrow(new PeerGroupCreationException());
+  }
+
+  protected void verifyAll() {
+    verify(peerGroupActivityService, peerGroupService, runService, userService, workgroupService);
+  }
+
+  protected void replayAll() {
+    replay(peerGroupActivityService, peerGroupService, runService, userService, workgroupService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
@@ -4,50 +4,19 @@ import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
 import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
 import org.easymock.TestSubject;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.security.access.AccessDeniedException;
-import org.wise.portal.domain.peergroup.PeerGroup;
-import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
-import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
-import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
-import org.wise.portal.presentation.web.controllers.APIControllerTest;
 import org.wise.portal.service.peergroup.PeerGroupActivityThresholdNotSatisfiedException;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
-import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
-import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 
 @RunWith(EasyMockRunner.class)
-public class PeerGroupAPIControllerTest extends APIControllerTest {
+public class PeerGroupAPIControllerTest extends AbstractPeerGroupAPIControllerTest {
 
   @TestSubject
   private PeerGroupAPIController controller = new PeerGroupAPIController();
-
-  @Mock
-  private PeerGroupService peerGroupService;
-
-  @Mock
-  private PeerGroupActivityService peerGroupActivityService;
-
-  private String run1Node1Id = "run1Node1";
-
-  private String run1Component1Id = "run1Component1";
-
-  private PeerGroupActivity peerGroupActivity;
-
-  private PeerGroup peerGroup1;
-
-  @Before
-  public void setUp() {
-    super.setUp();
-    peerGroupActivity = new PeerGroupActivityImpl();
-    peerGroup1 = new PeerGroupImpl();
-    peerGroup1.addMember(workgroup1);
-  }
 
   @Test
   public void getPeerGroup_WorkgroupNotAssociatedWithRun_AccessDenied() throws Exception {
@@ -64,7 +33,7 @@ public class PeerGroupAPIControllerTest extends APIControllerTest {
   @Test
   public void getPeerGroup_PeerGroupActivityNotFound_ThrowException() throws Exception {
     expectWorkgroupAssociatedWithRun(true);
-    expectPeerGroupActivityFound(false);
+    expectPeerGroupActivityNotFound();
     replayAll();
     try {
       controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id, studentAuth);
@@ -113,7 +82,7 @@ public class PeerGroupAPIControllerTest extends APIControllerTest {
   private void expectWorkgroupAssociatedWithRunAndActivityFound() throws Exception,
       PeerGroupActivityNotFoundException {
     expectWorkgroupAssociatedWithRun(true);
-    expectPeerGroupActivityFound(true);
+    expectPeerGroupActivityFound();
   }
 
   private void expectWorkgroupAssociatedWithRun(boolean isAssociated) throws Exception {
@@ -124,36 +93,12 @@ public class PeerGroupAPIControllerTest extends APIControllerTest {
         .andReturn(isAssociated);
   }
 
-  private void expectPeerGroupActivityFound(boolean isFound)
-      throws PeerGroupActivityNotFoundException {
-    if (isFound) {
-      expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
-          .andReturn(peerGroupActivity);
-    } else {
-      expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
-          .andThrow(new PeerGroupActivityNotFoundException());
-    }
-  }
-
   private void expectPeerGroupThresholdNotSatisifed() throws Exception {
     expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity))
         .andThrow(new PeerGroupActivityThresholdNotSatisfiedException());
   }
 
-  private void expectPeerGroupCreationException() throws Exception {
-    expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity))
-        .andThrow(new PeerGroupCreationException());
-  }
-
   private void expectPeerGroupCreated() throws Exception {
     expect(peerGroupService.getPeerGroup(workgroup1, peerGroupActivity)).andReturn(peerGroup1);
-  }
-
-  private void verifyAll() {
-    verify(peerGroupActivityService, peerGroupService, runService, userService, workgroupService);
-  }
-
-  private void replayAll() {
-    replay(peerGroupActivityService, peerGroupService, runService, userService, workgroupService);
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
@@ -3,9 +3,6 @@ package org.wise.portal.presentation.web.controllers.peergroup;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.TestSubject;
@@ -13,7 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.security.access.AccessDeniedException;
-import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
@@ -24,7 +20,6 @@ import org.wise.portal.service.peergroup.PeerGroupCreationException;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
-import org.wise.vle.domain.work.StudentWork;
 
 @RunWith(EasyMockRunner.class)
 public class PeerGroupAPIControllerTest extends APIControllerTest {
@@ -45,10 +40,6 @@ public class PeerGroupAPIControllerTest extends APIControllerTest {
   private PeerGroupActivity peerGroupActivity;
 
   private PeerGroup peerGroup1;
-
-  private Long peerGroup1Id = 1L;
-
-  private List<StudentWork> peerGroup1StudentWork = new ArrayList<StudentWork>();
 
   @Before
   public void setUp() {
@@ -117,66 +108,6 @@ public class PeerGroupAPIControllerTest extends APIControllerTest {
     assertNotNull(controller.getPeerGroup(runId1, workgroup1Id, run1Node1Id, run1Component1Id,
         studentAuth));
     verifyAll();
-  }
-
-  @Test
-  public void getPeerGroupWork_NonExistingPeerGroupId_ThrowObjectNotFound() {
-    expectPeerGroupIdNotExist();
-    replayAll();
-    try {
-      controller.getPeerGroupWork(peerGroup1Id, studentAuth);
-      fail("Expected ObjectNotFoundException, but was not thrown");
-    } catch (ObjectNotFoundException e) {
-    }
-    verifyAll();
-  }
-
-  @Test
-  public void getPeerGroupWork_UserNotInPeerGroup_ThrowAccessDenied()
-      throws ObjectNotFoundException {
-    expectPeerGroup();
-    expectUserNotInPeerGroup();
-    replayAll();
-    try {
-      controller.getPeerGroupWork(peerGroup1Id, studentAuth);
-      fail("Expected AccessDeniedException, but was not thrown");
-    } catch (AccessDeniedException e) {
-    }
-    verifyAll();
-  }
-
-  @Test
-  public void getPeerGroupWork_UserInPeerGroup_ReturnStudentWork() throws ObjectNotFoundException {
-    expectPeerGroup();
-    expectUserInPeerGroup();
-    expectGetStudentWork();
-    replayAll();
-    assertNotNull(controller.getPeerGroupWork(peerGroup1Id, studentAuth));
-    verifyAll();
-  }
-
-  private void expectGetStudentWork() {
-    expect(peerGroupService.getStudentWork(peerGroup1)).andReturn(peerGroup1StudentWork);
-  }
-
-  private void expectUserNotInPeerGroup() {
-    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student2);
-  }
-
-  private void expectUserInPeerGroup() {
-    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student1);
-  }
-
-  private void expectPeerGroup() throws ObjectNotFoundException {
-    expect(peerGroupService.getById(peerGroup1Id)).andReturn(peerGroup1);
-  }
-
-  private void expectPeerGroupIdNotExist() {
-    try {
-      expect(peerGroupService.getById(peerGroup1Id)).andThrow(new ObjectNotFoundException(
-          peerGroup1Id, PeerGroup.class));
-    } catch (ObjectNotFoundException e) {
-    }
   }
 
   private void expectWorkgroupAssociatedWithRunAndActivityFound() throws Exception,

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIControllerTest.java
@@ -1,0 +1,112 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.vle.domain.work.StudentWork;
+
+@RunWith(EasyMockRunner.class)
+public class PeerGroupWorkAPIControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private PeerGroupWorkAPIController controller = new PeerGroupWorkAPIController();
+
+  @Mock
+  private PeerGroupService peerGroupService;
+
+  private Long peerGroup1Id = 1L;
+
+  private PeerGroup peerGroup1;
+
+  private List<StudentWork> peerGroup1StudentWork = new ArrayList<StudentWork>();
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    peerGroup1 = new PeerGroupImpl();
+    peerGroup1.addMember(workgroup1);
+  }
+
+  @Test
+  public void getPeerGroupWork_NonExistingPeerGroupId_ThrowObjectNotFound() {
+    expectPeerGroupIdNotExist();
+    replayAll();
+    try {
+      controller.getPeerGroupWork(peerGroup1Id, studentAuth);
+      fail("Expected ObjectNotFoundException, but was not thrown");
+    } catch (ObjectNotFoundException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroupWork_UserNotInPeerGroup_ThrowAccessDenied()
+      throws ObjectNotFoundException {
+    expectPeerGroup();
+    expectUserNotInPeerGroup();
+    replayAll();
+    try {
+      controller.getPeerGroupWork(peerGroup1Id, studentAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroupWork_UserInPeerGroup_ReturnStudentWork() throws ObjectNotFoundException {
+    expectPeerGroup();
+    expectUserInPeerGroup();
+    expectGetStudentWork();
+    replayAll();
+    assertNotNull(controller.getPeerGroupWork(peerGroup1Id, studentAuth));
+    verifyAll();
+  }
+
+  private void expectGetStudentWork() {
+    expect(peerGroupService.getStudentWork(peerGroup1)).andReturn(peerGroup1StudentWork);
+  }
+
+  private void expectUserNotInPeerGroup() {
+    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student2);
+  }
+
+  private void expectUserInPeerGroup() {
+    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student1);
+  }
+
+  private void expectPeerGroup() throws ObjectNotFoundException {
+    expect(peerGroupService.getById(peerGroup1Id)).andReturn(peerGroup1);
+  }
+
+  private void expectPeerGroupIdNotExist() {
+    try {
+      expect(peerGroupService.getById(peerGroup1Id)).andThrow(new ObjectNotFoundException(
+          peerGroup1Id, PeerGroup.class));
+    } catch (ObjectNotFoundException e) {
+    }
+  }
+
+  private void verifyAll() {
+    verify(peerGroupService, runService, userService, workgroupService);
+  }
+
+  private void replayAll() {
+    replay(peerGroupService, runService, userService, workgroupService);
+  }
+}


### PR DESCRIPTION
## Changes
- Add endpoint for teacher to get StudentWork for PeerGroup at  /api/peer-group/{runId}/{workgroupId}/{nodeId}/{componentId}/student-work
- Add PeerGroupWorkAPIController 
- Extracted common test methods to AbstractPeerGroupControllerTest

## Note
- runId + nodeId + componentId should point to a specific PeerGroupActivity
- runId + workgroupId + nodeId + componentId should point to a specific PeerGroup for the PeerGroupActivity

## Test
- As a teacher with access to read student work, make request to get StudentWork: ``` /api/peer-group/{runId}/{workgroupId}/{nodeId}/{componentId}/student-work```
   - when you are not a teacher, or do not have read permissions for the run, it should throw AccessDeniedException
   - when you request a workgroupId/nodeId/componentId that doesn't point to a PeerGroupActivity or PeerGroup, it should throw an Exception
   - otherwise, it should get a list of StudentWork by members in the specified PeerGroup

Closes #49 