### PR TITLE
feat(Peer Group): Make PeerGroup with remaining students

### DIFF
--- a/src/main/java/org/wise/portal/dao/peergroup/PeerGroupDao.java
+++ b/src/main/java/org/wise/portal/dao/peergroup/PeerGroupDao.java
@@ -25,6 +25,7 @@ package org.wise.portal.dao.peergroup;
 
 import java.util.List;
 import org.wise.portal.dao.SimpleDao;
+import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.run.Run;
@@ -43,5 +44,5 @@ public interface PeerGroupDao<T extends PeerGroup> extends SimpleDao<T> {
 
   List<PeerGroup> getListByWorkgroup(Workgroup workgroup);
 
-  List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity);
+  List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity, Group period);
 }

--- a/src/main/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDao.java
+++ b/src/main/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDao.java
@@ -39,6 +39,7 @@ import org.hibernate.Session;
 import org.springframework.stereotype.Repository;
 import org.wise.portal.dao.impl.AbstractHibernateDao;
 import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
@@ -130,13 +131,14 @@ public class HibernatePeerGroupDao extends AbstractHibernateDao<PeerGroup>
 
   @Override
   @SuppressWarnings("unchecked")
-  public List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity) {
+  public List<Workgroup> getWorkgroupsInPeerGroup(PeerGroupActivity activity, Group period) {
     CriteriaBuilder cb = getCriteriaBuilder();
     CriteriaQuery<WorkgroupImpl> cq = cb.createQuery(WorkgroupImpl.class);
     Root<PeerGroupImpl> peerGroupImplRoot = cq.from(PeerGroupImpl.class);
     Root<WorkgroupImpl> workgroupImplRoot = cq.from(WorkgroupImpl.class);
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.equal(peerGroupImplRoot.get("peerGroupActivity"), activity.getId()));
+    predicates.add(cb.equal(workgroupImplRoot.get("period"), period.getId()));
     predicates.add(cb.isMember(workgroupImplRoot.get("id"),
         peerGroupImplRoot.<Set<Workgroup>>get("members")));
     cq.select(workgroupImplRoot).where(predicates.toArray(new Predicate[predicates.size()]));

--- a/src/test/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDaoTest.java
@@ -121,7 +121,7 @@ public class HibernatePeerGroupDaoTest extends WISEHibernateTest {
 
   @Test
   public void getWorkgroupsInPeerGroup_ActivityWithPeerGroups_ReturnWorkgroupList() {
-    assertEquals(1, peerGroupDao.getWorkgroupsInPeerGroup(activity1).size());
-    assertEquals(2, peerGroupDao.getWorkgroupsInPeerGroup(activity2).size());
+    assertEquals(1, peerGroupDao.getWorkgroupsInPeerGroup(activity1, run1Period1).size());
+    assertEquals(2, peerGroupDao.getWorkgroupsInPeerGroup(activity2, run1Period1).size());
   }
 }

--- a/src/test/java/org/wise/portal/service/WISEServiceTest.java
+++ b/src/test/java/org/wise/portal/service/WISEServiceTest.java
@@ -65,29 +65,33 @@ public class WISEServiceTest {
 
   protected User student1, student2, student3, student4, student5;
 
-  protected StudentWork componentWorkSubmit1, componentWorkSubmit2, componentWorkNonSubmit1;
+  protected StudentWork componentWorkSubmit1, componentWorkSubmit2, componentWorkSubmit3,
+      componentWorkSubmit4, componentWorkNonSubmit1;
 
   @Before
   public void setUp() throws Exception {
-    run1Period1 = new PersistentGroup();
-    run1Period1.setId(run1Id);
-    run1Workgroup1 = createWorkgroupInPeriod(1L, run1Period1, student1);
-    run1Workgroup2 = createWorkgroupInPeriod(2L, run1Period1, student2);
-    run1Workgroup3 = createWorkgroupInPeriod(3L, run1Period1, student3);
-    run1Workgroup4 = createWorkgroupInPeriod(4L, run1Period1, student4);
-    run1Workgroup5 = createWorkgroupInPeriod(5L, run1Period1, student5);
     run1 = new RunImpl();
     run1.setId(run1Id);
+    run1Period1 = new PersistentGroup();
+    run1Period1.setId(run1Id);
+    run1Workgroup1 = createWorkgroupInPeriod(run1, 1L, run1Period1, student1);
+    run1Workgroup2 = createWorkgroupInPeriod(run1, 2L, run1Period1, student2);
+    run1Workgroup3 = createWorkgroupInPeriod(run1, 3L, run1Period1, student3);
+    run1Workgroup4 = createWorkgroupInPeriod(run1, 4L, run1Period1, student4);
+    run1Workgroup5 = createWorkgroupInPeriod(run1, 5L, run1Period1, student5);
     run1Component1 = new Component(run1, run1Node1Id, run1Component1Id);
     run1Component2 = new Component(run1, run1Node2Id, run1Component2Id);
     componentWorkSubmit1 = createComponentWork(run1Workgroup1, true);
     componentWorkSubmit2 = createComponentWork(run1Workgroup2, true);
+    componentWorkSubmit3 = createComponentWork(run1Workgroup3, true);
+    componentWorkSubmit4 = createComponentWork(run1Workgroup4, true);
     componentWorkNonSubmit1 = createComponentWork(run1Workgroup1, false);
   }
 
-  private Workgroup createWorkgroupInPeriod(Long id, Group period, User member) {
+  private Workgroup createWorkgroupInPeriod(Run run, Long id, Group period, User member) {
     Workgroup workgroup = new WorkgroupImpl();
     workgroup.setId(id);
+    workgroup.setRun(run);
     workgroup.setPeriod(period);
     Set<User> members = new HashSet<User>();
     members.add(member);


### PR DESCRIPTION
## Changes
- When maxMembershipCount + 1 students have not been pair yet, and everybody else have completed the logic activity, we put them all into the same peer group.
- Also updated code to ensure that we only look for workgroups in the same period when pairing students into PeerGroups.

## Test
maxMembershipCount = 2
- 4 workgroups in period, 4 completed => should create 2 pairings, two members each
- 4 workgroups in period, 3 completed => should create 1 pairing with 2 members, tell the third to wait for the fourth
- 3 workgroups in period, 3 completed => should create 1 pairing with 3 members


Closes #52