### PR TITLE
feat(Get Classmate Work): Create endpoint for classmate Summary work

### DIFF
--- a/src/main/java/org/wise/Application.java
+++ b/src/main/java/org/wise/Application.java
@@ -29,6 +29,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
@@ -37,6 +38,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableCaching
 public class Application extends SpringBootServletInitializer {
 
   Environment environment;

--- a/src/main/java/org/wise/portal/dao/annotation/wise5/AnnotationDao.java
+++ b/src/main/java/org/wise/portal/dao/annotation/wise5/AnnotationDao.java
@@ -22,5 +22,7 @@ public interface AnnotationDao<T extends Annotation> extends SimpleDao<T> {
       Workgroup fromWorkgroup, Workgroup toWorkgroup, String nodeId, String componentId,
       StudentWork studentWork, String localNotebookItemId, NotebookItem notebookItem, String type);
 
+  List<Annotation> getAnnotations(Run run, String nodeId, String componentId);
+
   List<Annotation> getAnnotations(Run run, Group period, String nodeId, String componentId);
 }

--- a/src/main/java/org/wise/portal/dao/work/StudentWorkDao.java
+++ b/src/main/java/org/wise/portal/dao/work/StudentWorkDao.java
@@ -43,5 +43,7 @@ public interface StudentWorkDao<T extends StudentWork> extends SimpleDao<T> {
       Workgroup workgroup, Boolean isAutoSave, Boolean isSubmit, String nodeId, String componentId,
       String componentType, List<JSONObject> components);
 
+  List<StudentWork> getStudentWork(Run run, String nodeId, String componentId);
+
   List<StudentWork> getStudentWork(Run run, Group period, String nodeId, String componentId);
 }

--- a/src/main/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDao.java
+++ b/src/main/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDao.java
@@ -137,6 +137,10 @@ public class HibernateStudentWorkDao extends AbstractHibernateDao<StudentWork>
     return predicates;
   }
 
+  public List<StudentWork> getStudentWork(Run run, String nodeId, String componentId) {
+    return getStudentWork(run, null, nodeId, componentId);
+  }
+
   public List<StudentWork> getStudentWork(Run run, Group period, String nodeId,
       String componentId) {
     CriteriaBuilder cb = getCriteriaBuilder();
@@ -144,13 +148,15 @@ public class HibernateStudentWorkDao extends AbstractHibernateDao<StudentWork>
     Root<StudentWork> studentWorkRoot = cq.from(StudentWork.class);
     List<Predicate> predicates = new ArrayList<>();
     Root<RunImpl> runImplRoot = cq.from(RunImpl.class);
-    Root<PersistentGroup> periodRoot = cq.from(PersistentGroup.class);
     predicates.add(cb.equal(runImplRoot.get("id"), run.getId()));
-    predicates.add(cb.equal(periodRoot.get("id"), period.getId()));
     predicates.add(cb.equal(studentWorkRoot.get("run"), runImplRoot));
-    predicates.add(cb.equal(studentWorkRoot.get("period"), periodRoot));
     predicates.add(cb.equal(studentWorkRoot.get("nodeId"), nodeId));
     predicates.add(cb.equal(studentWorkRoot.get("componentId"), componentId));
+    if (period != null) {
+      Root<PersistentGroup> periodRoot = cq.from(PersistentGroup.class);
+      predicates.add(cb.equal(periodRoot.get("id"), period.getId()));
+      predicates.add(cb.equal(studentWorkRoot.get("period"), periodRoot));
+    }
     cq.select(studentWorkRoot).where(predicates.toArray(new Predicate[predicates.size()]))
         .orderBy(cb.asc(studentWorkRoot.get("serverSaveTime")));
     TypedQuery<StudentWork> query = entityManager.createQuery(cq);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -246,6 +246,7 @@ public class AuthorAPIController {
     User user = userService.retrieveUserByUsername(auth.getName());
     if (projectService.canAuthorProject(project, user)) {
       try {
+        projectService.evictProjectContentCache(projectId);
         projectService.saveProjectContentToDisk(projectJSONString, project);
         projectService.updateMetadataAndLicenseIfNecessary(project, projectJSONString);
         projectService.saveProjectToDatabase(project, user, projectJSONString);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
@@ -24,6 +24,8 @@ import org.wise.vle.domain.work.StudentWork;
 
 public abstract class ClassmateDataController {
 
+  final String NOT_PERMITTED = "Not permitted";
+
   @Autowired
   protected GroupService groupService;
 
@@ -58,9 +60,17 @@ public abstract class ClassmateDataController {
     return projectContent.getComponent(nodeId, componentId);
   }
 
+  protected List<StudentWork> getStudentWork(Run run, String nodeId, String componentId) {
+    return vleService.getStudentWork(run, nodeId, componentId);
+  }
+
   protected List<StudentWork> getStudentWork(Run run, Group period, String nodeId,
       String componentId) {
     return vleService.getStudentWork(run, period, nodeId, componentId);
+  }
+
+  protected List<Annotation> getAnnotations(Run run, String nodeId, String componentId) {
+    return vleService.getAnnotations(run, nodeId, componentId);
   }
 
   protected List<Annotation> getAnnotations(Run run, Group period, String nodeId,

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
@@ -22,6 +22,8 @@ import org.wise.vle.domain.work.StudentWork;
 @RequestMapping("/api/classmate/discussion")
 public class ClassmateDiscussionDataController extends ClassmateDataController {
 
+  String DISCUSSION_TYPE = "Discussion";
+
   @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}")
   public List<StudentWork> getClassmateDiscussionWork(Authentication auth, @PathVariable Long runId,
       @PathVariable Long periodId, @PathVariable String nodeId, @PathVariable String componentId)
@@ -31,7 +33,7 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
       return getStudentWork(run, period, nodeId, componentId);
     } else {
-      throw new AccessDeniedException("Not permitted");
+      throw new AccessDeniedException(NOT_PERMITTED);
     }
   }
 
@@ -44,7 +46,7 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
       return getAnnotations(run, period, nodeId, componentId);
     } else {
-      throw new AccessDeniedException("Not permitted");
+      throw new AccessDeniedException(NOT_PERMITTED);
     }
   }
 
@@ -56,6 +58,6 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
 
   private boolean isDiscussionComponent(Run run, String nodeId, String componentId)
       throws IOException, JSONException, ObjectNotFoundException {
-    return isComponentType(run, nodeId, componentId, "Discussion");
+    return isComponentType(run, nodeId, componentId, DISCUSSION_TYPE);
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
@@ -1,0 +1,80 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.json.JSONException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.run.Run;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+import org.wise.vle.domain.work.StudentWork;
+
+@RestController
+@Secured("ROLE_STUDENT")
+@RequestMapping("/api/classmate/summary")
+public class ClassmateSummaryDataController extends ClassmateDataController {
+
+  final String ALL_PERIODS_SOURCE = "allPeriods";
+  final String PERIOD_SOURCE = "period";
+  final String SUMMARY_TYPE = "Summary";
+
+  @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}/{source}")
+  public List<StudentWork> getClassmateSummaryWork(Authentication auth, @PathVariable Long runId,
+      @PathVariable Long periodId, @PathVariable String nodeId, @PathVariable String componentId,
+      @PathVariable String otherNodeId, @PathVariable String otherComponentId,
+      @PathVariable String source) throws IOException, JSONException, ObjectNotFoundException {
+    Run run = runService.retrieveById(runId);
+    Group period = groupService.retrieveById(periodId);
+    if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
+      if (PERIOD_SOURCE.equals(source)) {
+        return getStudentWork(run, period, otherNodeId, otherComponentId);
+      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+        return getStudentWork(run, otherNodeId, otherComponentId);
+      }
+    }
+    throw new AccessDeniedException(NOT_PERMITTED);
+  }
+
+  @GetMapping("/annotations/{runId}/{periodId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}/{source}")
+  public List<Annotation> getClassmateSummaryAnnotations(Authentication auth,
+      @PathVariable Long runId, @PathVariable Long periodId, @PathVariable String nodeId,
+      @PathVariable String componentId, @PathVariable String otherNodeId,
+      @PathVariable String otherComponentId, @PathVariable String source)
+      throws IOException, JSONException, ObjectNotFoundException {
+    Run run = runService.retrieveById(runId);
+    Group period = groupService.retrieveById(periodId);
+    if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
+      if (PERIOD_SOURCE.equals(source)) {
+        return getAnnotations(run, period, otherNodeId, otherComponentId);
+      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+        return getAnnotations(run, otherNodeId, otherComponentId);
+      }
+    }
+    throw new AccessDeniedException(NOT_PERMITTED);
+  }
+
+  private boolean isAllowedToGetData(Authentication auth, Run run, Group period, String nodeId,
+      String componentId, String otherNodeId, String otherComponentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    return isUserInRunAndPeriod(auth, run, period)
+        && isValidSummaryComponent(run, nodeId, componentId, otherNodeId, otherComponentId);
+  }
+
+  private boolean isValidSummaryComponent(Run run, String nodeId, String componentId,
+      String otherNodeId, String otherComponentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
+    return SUMMARY_TYPE.equals(projectComponent.getString("type"))
+        && otherNodeId.equals(projectComponent.getString("summaryNodeId"))
+        && otherComponentId.equals(projectComponent.getString("summaryComponentId"));
+  }
+}

--- a/src/main/java/org/wise/portal/service/project/ProjectService.java
+++ b/src/main/java/org/wise/portal/service/project/ProjectService.java
@@ -384,4 +384,6 @@ public interface ProjectService {
       throws JSONException;
 
   String getProjectContent(Project project) throws IOException;
+
+  void evictProjectContentCache(Long projectId);
 }

--- a/src/main/java/org/wise/portal/service/vle/wise5/VLEService.java
+++ b/src/main/java/org/wise/portal/service/vle/wise5/VLEService.java
@@ -58,6 +58,8 @@ public interface VLEService {
       Integer workgroupId, Boolean isAutoSave, Boolean isSubmit, String nodeId, String componentId,
       String componentType, List<JSONObject> components, Boolean onlyGetLatest);
 
+  List<StudentWork> getStudentWork(Run run, String nodeId, String componentId);
+
   List<StudentWork> getStudentWork(Run run, Group period, String nodeId, String componentId);
 
   List<NotebookItem> getNotebookItemsExport(Run run);
@@ -116,6 +118,8 @@ public interface VLEService {
   List<Annotation> getAnnotations(Integer id, Integer runId, Integer periodId,
       Integer fromWorkgroupId, Integer toWorkgroupId, String nodeId, String componentId,
       Integer studentWorkId, String localNotebookItemId, Integer notebookItemId, String type);
+
+  List<Annotation> getAnnotations(Run run, String nodeId, String componentId);
 
   List<Annotation> getAnnotations(Run run, Group period, String nodeId, String componentId);
 

--- a/src/main/java/org/wise/portal/service/vle/wise5/impl/VLEServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/vle/wise5/impl/VLEServiceImpl.java
@@ -157,6 +157,10 @@ public class VLEServiceImpl implements VLEService {
     }
   }
 
+  public List<StudentWork> getStudentWork(Run run, String nodeId, String componentId) {
+    return studentWorkDao.getStudentWork(run, nodeId, componentId);
+  }
+
   public List<StudentWork> getStudentWork(Run run, Group period, String nodeId,
       String componentId) {
     return studentWorkDao.getStudentWork(run, period, nodeId, componentId);
@@ -532,6 +536,10 @@ public class VLEServiceImpl implements VLEService {
     }
     return annotationDao.getAnnotationsByParams(id, run, period, fromWorkgroup, toWorkgroup, nodeId,
         componentId, studentWork, localNotebookItemId, notebookItem, type);
+  }
+
+  public List<Annotation> getAnnotations(Run run, String nodeId, String componentId) {
+    return annotationDao.getAnnotations(run, nodeId, componentId);
   }
 
   public List<Annotation> getAnnotations(Run run, Group period, String nodeId, String componentId) {

--- a/src/test/java/org/wise/portal/dao/annotation/impl/HibernateAnnotationDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/annotation/impl/HibernateAnnotationDaoTest.java
@@ -1,6 +1,7 @@
 package org.wise.portal.dao.annotation.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -36,6 +37,21 @@ public class HibernateAnnotationDaoTest extends WISEHibernateTest {
   @Test
   public void getAnnotations_AnnotationsExist_ShouldReturnAnnotations() {
     createAndRetrieveAnnotations(NODE_ID1, COMPONENT_ID1, NODE_ID1, COMPONENT_ID1, 1);
+  }
+
+  @Test
+  public void getAnnotations_FromAllPeriods_ShouldReturnAnnotations() {
+    Annotation annotation1 = createAnnotation(run1, run1Period1, teacherWorkgroup1, workgroup1,
+        COMMENT_TYPE, NODE_ID1, COMPONENT_ID1, DUMMY_ANNOTATION_DATA);
+    addUserToRun(student4, run1, run1Period2);
+    Workgroup workgroup4 = addUserToRun(student4, run1, run1Period2);
+    Annotation annotation2 = createAnnotation(run1, run1Period2, teacherWorkgroup1, workgroup4,
+        COMMENT_TYPE, NODE_ID1, COMPONENT_ID1, DUMMY_ANNOTATION_DATA);
+    List<Annotation> annotations = annotationDao.getAnnotations(run1, null, NODE_ID1,
+        COMPONENT_ID1);
+    assertEquals(2, annotations.size());
+    assertTrue(annotations.contains(annotation1));
+    assertTrue(annotations.contains(annotation2));
   }
 
   private void createAndRetrieveAnnotations(String createAnnotationNodeId,

--- a/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
@@ -24,6 +24,7 @@
 package org.wise.portal.dao.work.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -113,6 +114,21 @@ public class HibernateStudentWorkDaoTest extends WISEHibernateTest {
     List<StudentWork> studentWorkList = studentWorkDao.getStudentWork(run1, run1Period1, NODE_ID2,
         COMPONENT_ID2);
     assertEquals(studentWorkList.size(), 0);
+  }
+
+  @Test
+  public void getStudentWork_FromAllPeriods_ShouldReturnWork() {
+    StudentWork studentWork1 = createStudentWork(workgroup1, NODE_ID1, COMPONENT_ID1,
+        DUMMY_STUDENT_WORK1);
+    addUserToRun(student4, run1, run1Period2);
+    Workgroup workgroup4 = addUserToRun(student4, run1, run1Period2);
+    StudentWork studentWork2 = createStudentWork(workgroup4, NODE_ID1, COMPONENT_ID1,
+        DUMMY_STUDENT_WORK1);
+    List<StudentWork> studentWorkList = studentWorkDao.getStudentWork(run1, null, NODE_ID1,
+        COMPONENT_ID1);
+    assertEquals(studentWorkList.size(), 2);
+    assertTrue(studentWorkList.contains(studentWork1));
+    assertTrue(studentWorkList.contains(studentWork2));
   }
 
   private StudentWork createStudentWork(Workgroup workgroup, String nodeId, String componentId,

--- a/src/test/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIControllerTest.java
@@ -216,6 +216,8 @@ public class AuthorAPIControllerTest extends APIControllerTest {
     Long projectId = 1L;
     expect(projectService.getById(projectId)).andReturn(project);
     expect(projectService.canAuthorProject(project, teacher1)).andReturn(true);
+    projectService.evictProjectContentCache(projectId);
+    expectLastCall();
     String projectJSONString = "{}";
     projectService.saveProjectContentToDisk(projectJSONString, project);
     expectLastCall().andThrow(new IOException());
@@ -235,6 +237,8 @@ public class AuthorAPIControllerTest extends APIControllerTest {
     Long projectId = 1L;
     expect(projectService.getById(projectId)).andReturn(project);
     expect(projectService.canAuthorProject(project, teacher1)).andReturn(true);
+    projectService.evictProjectContentCache(projectId);
+    expectLastCall();
     String projectJSONString = "{\"metadata\":{\"title\":\"New Title\"}}";
     projectService.saveProjectContentToDisk(projectJSONString, project);
     expectLastCall();
@@ -258,6 +262,8 @@ public class AuthorAPIControllerTest extends APIControllerTest {
     project.setMetadata("{\"title\":\"Old Title\"}");
     expect(projectService.getById(projectId)).andReturn(project);
     expect(projectService.canAuthorProject(project, teacher1)).andReturn(true);
+    projectService.evictProjectContentCache(projectId);
+    expectLastCall();
     String projectJSONString = "{\"metadata\":{\"title\":\"New Title\"}}";
     projectService.saveProjectContentToDisk(projectJSONString, project);
     expectLastCall();

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
@@ -1,0 +1,90 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import static org.easymock.EasyMock.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+import org.wise.vle.domain.work.StudentWork;
+
+public abstract class AbstractClassmateDataControllerTest extends APIControllerTest {
+
+  String COMPONENT_ID1 = "component1";
+  String NODE_ID1 = "node1";
+  String OPEN_RESPONSE_TYPE = "OpenResponse";
+  String SHOULD_NOT_HAVE_THROWN_EXCEPTION = "Should not have thrown an exception";
+
+  protected void expectStudentWork(List<StudentWork> studentWork) {
+    expectStudentWork(run1, run1Period1, NODE_ID1, COMPONENT_ID1, studentWork);
+  }
+
+  protected void expectStudentWork(Run run, String nodeId, String componentId,
+      List<StudentWork> studentWork) {
+    expect(vleService.getStudentWork(run, nodeId, componentId)).andReturn(studentWork);
+  }
+
+  protected void expectStudentWork(Run run, Group period, String nodeId, String componentId,
+      List<StudentWork> studentWork) {
+    expect(vleService.getStudentWork(run, period, nodeId, componentId)).andReturn(studentWork);
+  }
+
+  protected void expectAnnotations(List<Annotation> annotations) {
+    expectAnnotations(run1, run1Period1, NODE_ID1, COMPONENT_ID1, annotations);
+  }
+
+  protected void expectAnnotations(Run run, String nodeId, String componentId,
+      List<Annotation> annotations) {
+    expect(vleService.getAnnotations(run, nodeId, componentId)).andReturn(annotations);
+  }
+
+  protected void expectAnnotations(Run run, Group period, String nodeId, String componentId,
+      List<Annotation> annotations) {
+    expect(vleService.getAnnotations(run, period, nodeId, componentId)).andReturn(annotations);
+  }
+
+  protected void expectIsUserInRun(boolean isInRun)
+      throws NoSuchMethodException, ObjectNotFoundException {
+    expect(runService.retrieveById(runId1)).andReturn(run1);
+    expect(groupService.retrieveById(run1Period1Id)).andReturn(run1Period1);
+    expect(userService.retrieveUser(student1UserDetails)).andReturn(student1);
+    expect(runService.isUserInRunAndPeriod(student1, run1, run1Period1)).andReturn(isInRun);
+  }
+
+  protected void expectComponentType(String componentType)
+      throws IOException, ObjectNotFoundException {
+    expectComponentType(NODE_ID1, COMPONENT_ID1, componentType);
+  }
+
+  protected void expectComponentType(String nodeId, String componentId, String componentType)
+      throws IOException, ObjectNotFoundException {
+    String projectJSONString = new StringBuilder()
+        .append("{")
+        .append("  \"nodes\": [")
+        .append("    {")
+        .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"components\": [")
+        .append("        {")
+        .append("          \"id\": \"" + componentId + "\",")
+        .append("          \"type\": \"" + componentType + "\"")
+        .append("        }")
+        .append("      ]")
+        .append("    }")
+        .append("  ]")
+        .append("}")
+        .toString();
+    expect(projectService.getProjectContent(project1)).andReturn(projectJSONString);
+  }
+
+  protected void replayAll() {
+    replay(groupService, projectService, runService, userService, vleService);
+  }
+
+  protected void verifyAll() {
+    verify(groupService, projectService, runService, userService, vleService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataControllerTest.java
@@ -16,17 +16,13 @@ import org.junit.runner.RunWith;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.run.Run;
-import org.wise.portal.presentation.web.controllers.APIControllerTest;
 
 @RunWith(EasyMockRunner.class)
-public class ClassmateDataControllerTest extends APIControllerTest {
+public class ClassmateDataControllerTest extends AbstractClassmateDataControllerTest {
 
+  private final String COMPONENT_ID2 = "component2";
   private final String DISCUSSION_TYPE = "Discussion";
   private final String OPEN_RESPONSE_TYPE = "OpenResponse";
-
-  private String componentId1 = "component1";
-  private String componentId2 = "component2";
-  private String nodeId1 = "node1";
 
   private class ClassmateDataControllerImpl extends ClassmateDataController {
   }
@@ -64,36 +60,36 @@ public class ClassmateDataControllerTest extends APIControllerTest {
   @Test
   public void isComponentType_IsNotExpectedType_ShouldReturnFalse()
       throws IOException, JSONException, ObjectNotFoundException {
-    expectComponentType(DISCUSSION_TYPE);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, DISCUSSION_TYPE);
     replayAll();
-    assertFalse(controller.isComponentType(run1, nodeId1, componentId1, OPEN_RESPONSE_TYPE));
+    assertFalse(controller.isComponentType(run1, NODE_ID1, COMPONENT_ID1, OPEN_RESPONSE_TYPE));
     verifyAll();
   }
 
   @Test
   public void isComponentType_IsExpectedType_ShouldReturnTrue()
       throws IOException, JSONException, ObjectNotFoundException {
-    expectComponentType(DISCUSSION_TYPE);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, DISCUSSION_TYPE);
     replayAll();
-    assertTrue(controller.isComponentType(run1, nodeId1, componentId1, DISCUSSION_TYPE));
+    assertTrue(controller.isComponentType(run1, NODE_ID1, COMPONENT_ID1, DISCUSSION_TYPE));
     verifyAll();
   }
 
   @Test
   public void getProjectComponent_InvalidComponent_ShouldReturnNull()
       throws IOException, JSONException, ObjectNotFoundException {
-    expectGetProjectContent(nodeId1, componentId1, DISCUSSION_TYPE);
+    expectGetProjectContent(NODE_ID1, COMPONENT_ID1, DISCUSSION_TYPE);
     replayAll();
-    assertNull(controller.getProjectComponent(run1, nodeId1, componentId2));
+    assertNull(controller.getProjectComponent(run1, NODE_ID1, COMPONENT_ID2));
     verifyAll();
   }
 
   @Test
   public void getProjectComponent_ValidComponent_ShouldReturnNotNull()
       throws IOException, JSONException, ObjectNotFoundException {
-    expectGetProjectContent(nodeId1, componentId1, DISCUSSION_TYPE);
+    expectGetProjectContent(NODE_ID1, COMPONENT_ID1, DISCUSSION_TYPE);
     replayAll();
-    assertNotNull(controller.getProjectComponent(run1, nodeId1, componentId1));
+    assertNotNull(controller.getProjectComponent(run1, NODE_ID1, COMPONENT_ID1));
     verifyAll();
   }
 
@@ -103,25 +99,23 @@ public class ClassmateDataControllerTest extends APIControllerTest {
     expect(runService.isUserInRunAndPeriod(student1, run, period)).andReturn(isInRun);
   }
 
-  private void expectComponentType(String componentType)
-      throws IOException, ObjectNotFoundException {
-    expect(projectService.getProjectContent(project1)).andReturn(
-        "{ \"nodes\": [ { \"id\": \"node1\", \"components\": [ { \"id\": \"component1\", \"type\": \""
-            + componentType + "\" } ] } ] }");
-  }
-
   private void expectGetProjectContent(String nodeId, String componentId, String componentType)
       throws IOException {
-    expect(projectService.getProjectContent(project1))
-        .andReturn("{ \"nodes\": [ { \"id\": \"" + nodeId + "\", \"components\": [ { \"id\": \""
-            + componentId + "\", \"type\": \"" + componentType + "\" } ] } ] }");
-  }
-
-  private void replayAll() {
-    replay(groupService, projectService, runService, userService, vleService);
-  }
-
-  private void verifyAll() {
-    verify(groupService, projectService, runService, userService, vleService);
+    String projectJSONString = new StringBuilder()
+        .append("{")
+        .append("  \"nodes\": [")
+        .append("    {")
+        .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"components\": [")
+        .append("        {")
+        .append("          \"id\": \"" + componentId + "\",")
+        .append("          \"type\": \"" + componentType + "\"")
+        .append("        }")
+        .append("      ]")
+        .append("    }")
+        .append("  ]")
+        .append("}")
+        .toString();
+    expect(projectService.getProjectContent(project1)).andReturn(projectJSONString);
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataControllerTest.java
@@ -1,6 +1,5 @@
 package org.wise.portal.presentation.web.controllers.student;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -15,15 +14,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.security.access.AccessDeniedException;
 import org.wise.portal.dao.ObjectNotFoundException;
-import org.wise.portal.presentation.web.controllers.APIControllerTest;
 import org.wise.vle.domain.annotation.wise5.Annotation;
 import org.wise.vle.domain.work.StudentWork;
 
 @RunWith(EasyMockRunner.class)
-public class ClassmateDiscussionDataControllerTest extends APIControllerTest {
-
-  String nodeId = "node1";
-  String componentId = "component1";
+public class ClassmateDiscussionDataControllerTest extends AbstractClassmateDataControllerTest {
 
   @TestSubject
   private ClassmateDiscussionDataController controller = new ClassmateDiscussionDataController();
@@ -34,7 +29,7 @@ public class ClassmateDiscussionDataControllerTest extends APIControllerTest {
     expectIsUserInRun(false);
     replayAll();
     assertThrows(AccessDeniedException.class, () -> controller
-        .getClassmateDiscussionWork(studentAuth, runId1, run1Period1Id, nodeId, componentId));
+        .getClassmateDiscussionWork(studentAuth, runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1));
     verifyAll();
   }
 
@@ -42,10 +37,10 @@ public class ClassmateDiscussionDataControllerTest extends APIControllerTest {
   public void getClassmateDiscussionWork_NotDiscussionComponent_ThrowException()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     expectIsUserInRun(true);
-    expectComponentType("OpenResponse");
+    expectComponentType(OPEN_RESPONSE_TYPE);
     replayAll();
     assertThrows(AccessDeniedException.class, () -> controller
-        .getClassmateDiscussionWork(studentAuth, runId1, run1Period1Id, nodeId, componentId));
+        .getClassmateDiscussionWork(studentAuth, runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1));
     verifyAll();
   }
 
@@ -53,69 +48,36 @@ public class ClassmateDiscussionDataControllerTest extends APIControllerTest {
   public void getClassmateDiscussionWork_InRunDiscussionComponent_ReturnWork()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     expectIsUserInRun(true);
-    expectComponentType("Discussion");
+    expectComponentType(controller.DISCUSSION_TYPE);
     List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
     expectStudentWork(studentWork);
     replayAll();
     try {
       List<StudentWork> classmateDiscussionWork = controller.getClassmateDiscussionWork(studentAuth,
-          runId1, run1Period1Id, nodeId, componentId);
+          runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1);
       assertEquals(classmateDiscussionWork, studentWork);
     } catch (Exception e) {
-      fail("Should not have thrown an exception");
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
     }
     verifyAll();
-  }
-
-  private void expectStudentWork(List<StudentWork> studentWork) {
-    expect(vleService.getStudentWork(run1, run1Period1, nodeId, componentId))
-        .andReturn(studentWork);
   }
 
   @Test
   public void getClassmateDiscussionAnnotations_InRunDiscussionComponent_ReturnAnnotations()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     expectIsUserInRun(true);
-    expectComponentType("Discussion");
+    expectComponentType(controller.DISCUSSION_TYPE);
     List<Annotation> annotations = Arrays.asList(new Annotation(), new Annotation());
     expectAnnotations(annotations);
     replayAll();
     try {
       List<Annotation> classmateDiscussionAnnotations = controller
-          .getClassmateDiscussionAnnotations(studentAuth, runId1, run1Period1Id, nodeId,
-              componentId);
+          .getClassmateDiscussionAnnotations(studentAuth, runId1, run1Period1Id, NODE_ID1,
+              COMPONENT_ID1);
       assertEquals(classmateDiscussionAnnotations, annotations);
     } catch (Exception e) {
-      fail("Should not have thrown an exception");
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
     }
     verifyAll();
-  }
-
-  private void expectAnnotations(List<Annotation> annotations) {
-    expect(vleService.getAnnotations(run1, run1Period1, nodeId, componentId))
-        .andReturn(annotations);
-  }
-
-  private void expectIsUserInRun(boolean isInRun)
-      throws NoSuchMethodException, ObjectNotFoundException {
-    expect(runService.retrieveById(runId1)).andReturn(run1);
-    expect(groupService.retrieveById(run1Period1Id)).andReturn(run1Period1);
-    expect(userService.retrieveUser(student1UserDetails)).andReturn(student1);
-    expect(runService.isUserInRunAndPeriod(student1, run1, run1Period1)).andReturn(isInRun);
-  }
-
-  private void expectComponentType(String componentType)
-      throws IOException, ObjectNotFoundException {
-    expect(projectService.getProjectContent(project1)).andReturn(
-        "{ \"nodes\": [ { \"id\": \"node1\", \"components\": [ { \"id\": \"component1\", \"type\": \""
-            + componentType + "\" } ] } ] }");
-  }
-
-  private void replayAll() {
-    replay(groupService, projectService, runService, userService, vleService);
-  }
-
-  private void verifyAll() {
-    verify(groupService, projectService, runService, userService, vleService);
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
@@ -1,0 +1,164 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+import org.wise.vle.domain.work.StudentWork;
+
+@RunWith(EasyMockRunner.class)
+public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataControllerTest {
+
+  String OTHER_COMPONENT_ID = "component2";
+  String OTHER_COMPONENT_ID_NOT_ALLOWED = "component3";
+  String OTHER_NODE_ID = "node2";
+  String OTHER_NODE_ID_NOT_ALLOWED = "node3";
+
+  @TestSubject
+  private ClassmateSummaryDataController controller = new ClassmateSummaryDataController();
+
+  @Test
+  public void getClassmateSummaryWork_NotInRun_ThrowException()
+      throws NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(false);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateSummaryWork(studentAuth, runId1, run1Period1Id, NODE_ID1,
+            COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryWork_NotSummaryComponent_ThrowException()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(OPEN_RESPONSE_TYPE);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateSummaryWork(studentAuth, runId1, run1Period1Id, NODE_ID1,
+            COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryWork_InvalidOtherComponent_ThrowException()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID, controller.PERIOD_SOURCE);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateSummaryWork(studentAuth, runId1, run1Period1Id, NODE_ID1,
+            COMPONENT_ID1, OTHER_NODE_ID_NOT_ALLOWED, OTHER_COMPONENT_ID_NOT_ALLOWED,
+            controller.PERIOD_SOURCE));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryWork_InRunSummaryComponentPeriod_ReturnWork()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateSummaryWork_InRunSummaryComponent_ReturnWork(controller.PERIOD_SOURCE);
+  }
+
+  @Test
+  public void getClassmateSummaryWork_InRunSummaryComponentAllPeriods_ReturnWork()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateSummaryWork_InRunSummaryComponent_ReturnWork(controller.ALL_PERIODS_SOURCE);
+  }
+
+  private void getClassmateSummaryWork_InRunSummaryComponent_ReturnWork(String source)
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID, source);
+    List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
+    if (controller.PERIOD_SOURCE.equals(source)) {
+      expectStudentWork(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
+    } else if (controller.ALL_PERIODS_SOURCE.equals(source)) {
+      expectStudentWork(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
+    }
+    replayAll();
+    try {
+      List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWork(studentAuth,
+          runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID,
+          source);
+      assertEquals(classmateSummaryWork, studentWork);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryAnnotations_InRunSummaryComponentPeriod_ReturnAnnotations()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateSummaryAnnotations_InRunSummaryComponent_ReturnAnnotations(
+        controller.PERIOD_SOURCE);
+  }
+
+  @Test
+  public void getClassmateSummaryAnnotations_InRunSummaryComponentAllPeriods_ReturnAnnotations()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateSummaryAnnotations_InRunSummaryComponent_ReturnAnnotations(
+        controller.ALL_PERIODS_SOURCE);
+  }
+
+  private void getClassmateSummaryAnnotations_InRunSummaryComponent_ReturnAnnotations(String source)
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID, source);
+    List<Annotation> annotations = Arrays.asList(new Annotation(), new Annotation());
+    if (controller.PERIOD_SOURCE.equals(source)) {
+      expectAnnotations(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, annotations);
+    } else if (controller.ALL_PERIODS_SOURCE.equals(source)) {
+      expectAnnotations(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, annotations);
+    }
+    replayAll();
+    try {
+      List<Annotation> classmateSummaryAnnotations = controller.getClassmateSummaryAnnotations(
+          studentAuth, runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID,
+          OTHER_COMPONENT_ID, source);
+      assertEquals(classmateSummaryAnnotations, annotations);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  protected void expectComponentType(String nodeId, String componentId, String componentType,
+      String otherNodeId, String otherComponentId, String source)
+      throws IOException, ObjectNotFoundException {
+    String projectJSONString = new StringBuilder()
+        .append("{")
+        .append("  \"nodes\": [")
+        .append("    {")
+        .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"components\": [")
+        .append("        {")
+        .append("          \"id\": \"" + componentId + "\",")
+        .append("          \"type\": \"" + componentType + "\",")
+        .append("          \"summaryNodeId\": \"" + otherNodeId + "\",")
+        .append("          \"summaryComponentId\": \"" + otherComponentId + "\",")
+        .append("          \"source\": \"" + source + "\",")
+        .append("        }")
+        .append("      ]")
+        .append("    }")
+        .append("  ]")
+        .append("}")
+        .toString();
+    expect(projectService.getProjectContent(project1)).andReturn(projectJSONString);
+  }
+}


### PR DESCRIPTION
- Make sure the student can retrieve data from the other step that is referenced in the Summary component.

- Make sure the student can not retrieve data from another step if that other step is not referenced in the Summary component.
  - For example there could be a legitimate
summaryNode1, summaryComponent1, legitOtherNode, legitOtherComponent
but the student tries to retrieve
summaryNode1, summaryComponent1, notLegitOtherNode, notLegitOtherComponent

Example Summary student work endpoint for period
```
http://localhost:81/api/classmate/summary/student-work/RUN_ID/PERIOD_ID/node292/if1755lrin/node231/0k0r4jlona/period
```

Example Summary student work endpoint for all periods in run
```
http://localhost:81/api/classmate/summary/student-work/RUN_ID/PERIOD_ID/node292/if1755lrin/node231/0k0r4jlona/allPeriods
```

Example Summary annotations endpoint for period
```
http://localhost:81/api/classmate/summary/annotations/RUN_ID/PERIOD_ID/node292/if1755lrin/node231/0k0r4jlona/period
```

Example Summary annotations endpoint for all periods in run
```
http://localhost:81/api/classmate/summary/annotations/RUN_ID/PERIOD_ID/node292/if1755lrin/node231/0k0r4jlona/allPeriods
```

- Test that project content caching and cache evicting works.

You can test the caching by modifying the ProjectServiceImpl.java getProjectContent() function to add the try/catch that sleeps for 3 seconds.
```
  @Cacheable(value = "projectContent", key = "#project.getId()")
  public String getProjectContent(Project project) throws IOException {
    try {
      long time = 3000L;
      Thread.sleep(time);
    } catch (InterruptedException e) {
      throw new IllegalStateException(e);
    }
    String projectFilePath = appProperties.getProperty("curriculum_base_dir")
        + project.getModulePath();
    return FileUtils.readFileToString(new File(projectFilePath));
  }
```


You can test the automatic cache evicting after a certain amount of time by changing the Timer.ONE_DAY to Timer.ONE_MINUTE.
```
  @Scheduled(fixedRate = Timer.ONE_MINUTE)
  @CacheEvict(value = "projectContent", allEntries = true)
  public void evictAllProjectContentCache() {
  }
```

How to test caching
1. Log in as a teacher in one browser
2. Log in as a student in another browser
3. Have the student launch a run that contains a Discussion component
4. Have the teacher load the Authoring tool for that project run
5. In the student browser, manually visit the url to retrieve the classmate Discussion student work. This should take 3 seconds if you added the sleep code above.
```http://localhost:81/api/classmate/discussion/student-work/RUN_ID/PERIOD_ID/NODE_ID/COMPONENT_ID```
6. Refresh the url and it should load instantly (instead of taking 3 seconds)
```http://localhost:81/api/classmate/discussion/student-work/RUN_ID/PERIOD_ID/NODE_ID/COMPONENT_ID```
7. Wait 1 minute for the auto cache evict to run
8. Refresh the url and it should take 3 seconds to load
```http://localhost:81/api/classmate/discussion/student-work/RUN_ID/PERIOD_ID/NODE_ID/COMPONENT_ID```
10. Go to the teacher browser and make a change to the project in the Authoring Tool.
11. Go back to the student browser and refresh the url. It should take 3 seconds to load.
```http://localhost:81/api/classmate/discussion/student-work/RUN_ID/PERIOD_ID/NODE_ID/COMPONENT_ID```

Closes #55