### PR TITLE
refactor(InformationController): Pass in RunImpl run instead of Long runId

### DIFF
--- a/src/main/java/org/wise/portal/dao/run/RunRepository.java
+++ b/src/main/java/org/wise/portal/dao/run/RunRepository.java
@@ -1,0 +1,11 @@
+package org.wise.portal.dao.run;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+import org.wise.portal.domain.run.impl.RunImpl;
+
+/**
+ * @author Hiroki Terashima
+ */
+@Repository
+public interface RunRepository extends PagingAndSortingRepository<RunImpl, Long> {}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -55,6 +55,7 @@ import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.project.Project;
 import org.wise.portal.domain.project.impl.ProjectImpl;
 import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.presentation.web.filters.WISEAuthenticationProcessingFilter;
@@ -202,26 +203,24 @@ public class InformationController {
     }
   }
 
-  @RequestMapping("/config/studentRun/{runId}")
-  public void handleGetConfigWISE5StudentRun(HttpServletRequest request,
-      HttpServletResponse response, @PathVariable Long runId)
-      throws ObjectNotFoundException, IOException, JSONException {
+  @GetMapping("/config/studentRun/{runId}")
+  public void getConfigWISE5StudentRun(HttpServletRequest request, HttpServletResponse response,
+      @PathVariable("runId") RunImpl run) throws ObjectNotFoundException, IOException,
+      JSONException {
     JSONObject config = new JSONObject();
     config.put("mode", "studentRun");
-    Run run = runService.retrieveById(runId);
     getRunConfigParameters(request, config, run);
     Project project = run.getProject();
     addCommonConfigParameters(request, config, project);
     printConfigToResponse(response, config);
   }
 
-  @RequestMapping("/config/classroomMonitor/{runId}")
-  public void handleGetConfigWISE5ClassroomMonitor(HttpServletRequest request,
-      HttpServletResponse response, @PathVariable Long runId)
+  @GetMapping("/config/classroomMonitor/{runId}")
+  public void getConfigWISE5ClassroomMonitor(HttpServletRequest request,
+      HttpServletResponse response, @PathVariable("runId") RunImpl run)
       throws ObjectNotFoundException, IOException, JSONException {
     JSONObject config = new JSONObject();
     config.put("mode", "classroomMonitor");
-    Run run = runService.retrieveById(runId);
     getRunConfigParameters(request, config, run);
     User signedInUser = ControllerUtil.getSignedInUser();
     String contextPath = request.getContextPath();
@@ -229,7 +228,7 @@ public class InformationController {
       config.put("runCode", run.getRuncode());
       config.put("teacherDataURL", contextPath + "/api/teacher/data");
       config.put("runDataExportURL", contextPath + "/api/teacher/export");
-      config.put("notebookURL", contextPath + "/api/teacher/notebook/run/" + runId);
+      config.put("notebookURL", contextPath + "/api/teacher/notebook/run/" + run.getId());
     }
     Project project = run.getProject();
     if (hasRunWriteAccess(signedInUser, run)) {
@@ -788,7 +787,7 @@ public class InformationController {
    * @return Workgroup for the currently-logged in user
    * @throws ObjectNotFoundException
    */
-  private Workgroup getWorkgroup(Run run) throws ObjectNotFoundException {
+  private Workgroup getWorkgroup(Run run) {
     Workgroup workgroup = null;
     SecurityContext context = SecurityContextHolder.getContext();
     if (context.getAuthentication().getPrincipal() instanceof UserDetails) {

--- a/src/main/java/org/wise/portal/spring/impl/HibernateConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/HibernateConfig.java
@@ -59,7 +59,7 @@ public class HibernateConfig {
   @Value("${spring.jpa.hibernate.ddl-auto:none}")
   private String hibernateDDLAuto;
 
-  @Bean
+  @Bean(name = {"sessionFactory", "entityManagerFactory"})
   public LocalSessionFactoryBean sessionFactory() {
     LocalSessionFactoryBean sessionFactory = new LocalSessionFactoryBean();
     sessionFactory.setDataSource(dataSource);
@@ -68,7 +68,7 @@ public class HibernateConfig {
     return sessionFactory;
   }
 
-  @Bean
+  @Bean(name = {"hibernateTransactionManager", "transactionManager"})
   public PlatformTransactionManager hibernateTransactionManager() {
     HibernateTransactionManager transactionManager = new HibernateTransactionManager();
     transactionManager.setSessionFactory(sessionFactory().getObject());


### PR DESCRIPTION
## Changes
- Added RunRepository and new bean names to make use of Spring's DomainClassConverter. Read more about it [here](https://www.baeldung.com/spring-data-web-support#3-the-controller-layer)
- Changed getConfig endpoints for teacher CM and student Run in InformationController to take in RunImpl instead of Long. This reduces the need to write code to look up the Run object from the database. It is done automatically by the DomainClassConverter.

## Test
- Endpoints to retrieve config still work for:
   - Student Run: /api/config/studentRun/[RUN_ID]
   - Teacher CM: /api/config/classroomMonitor/[RUN_ID]
- Opening student run (VLE) and teacher grading tool (CM) still work as before; it gets the config correctly and load properly.

Closes #60