### PR TITLE
feat(Get Classmate Work): Create endpoint for Peer Chat other work

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
@@ -49,7 +49,7 @@ public abstract class ClassmateDataController {
   protected boolean isComponentType(Run run, String nodeId, String componentId,
       String expectedComponentType) throws IOException, JSONException, ObjectNotFoundException {
     ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
-    return expectedComponentType.equals(projectComponent.getString("type"));
+    return projectComponent.getString("type").equals(expectedComponentType);
   }
 
   protected ProjectComponent getProjectComponent(Run run, String nodeId, String componentId)

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataController.java
@@ -40,7 +40,7 @@ public class ClassmatePeerChatDataController extends ClassmateDataController {
     if (isAllowedToGetData(auth, peerGroup)) {
       Run run = peerGroup.getPeerGroupActivity().getRun();
       if (isValidPeerChatComponent(run, nodeId, componentId, showWorkNodeId, showWorkComponentId)) {
-        return getStudentWork(peerGroup, showWorkNodeId, showWorkComponentId);
+        return peerGroupService.getStudentWork(peerGroup, showWorkNodeId, showWorkComponentId);
       }
     }
     throw new AccessDeniedException(NOT_PERMITTED);
@@ -56,12 +56,8 @@ public class ClassmatePeerChatDataController extends ClassmateDataController {
       String showWorkNodeId, String showWorkComponentId)
       throws IOException, JSONException, ObjectNotFoundException {
     ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
-    return PEER_CHAT_TYPE.equals(projectComponent.getString("type"))
-        && showWorkNodeId.equals(projectComponent.getString("showWorkNodeId"))
-        && showWorkComponentId.equals(projectComponent.getString("showWorkComponentId"));
-  }
-
-  private List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId) {
-    return peerGroupService.getStudentWork(peerGroup, nodeId, componentId);
+    return projectComponent.getString("type").equals(PEER_CHAT_TYPE)
+        && projectComponent.getString("showWorkNodeId").equals(showWorkNodeId)
+        && projectComponent.getString("showWorkComponentId").equals(showWorkComponentId);
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataController.java
@@ -1,0 +1,67 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.json.JSONException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.authentication.impl.StudentUserDetails;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.vle.domain.work.StudentWork;
+
+@RestController
+@Secured("ROLE_STUDENT")
+@RequestMapping("/api/classmate/peer-chat")
+public class ClassmatePeerChatDataController extends ClassmateDataController {
+
+  String PEER_CHAT_TYPE = "PeerChat";
+
+  @Autowired
+  protected PeerGroupService peerGroupService;
+
+  @GetMapping("/student-work/{peerGroupId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}")
+  public List<StudentWork> getClassmatePeerChatWork(Authentication auth,
+      @PathVariable Long peerGroupId, @PathVariable String nodeId, @PathVariable String componentId,
+      @PathVariable String otherNodeId, @PathVariable String otherComponentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    PeerGroup peerGroup = peerGroupService.getById(peerGroupId);
+    if (isAllowedToGetData(auth, peerGroup)) {
+      Run run = peerGroup.getPeerGroupActivity().getRun();
+      if (isValidPeerChatComponent(run, nodeId, componentId, otherNodeId, otherComponentId)) {
+        return getStudentWork(peerGroup, otherNodeId, otherComponentId);
+      }
+    }
+    throw new AccessDeniedException(NOT_PERMITTED);
+  }
+
+  private boolean isAllowedToGetData(Authentication auth, PeerGroup peerGroup)
+      throws ObjectNotFoundException {
+    User user = userService.retrieveUser((StudentUserDetails) auth.getPrincipal());
+    return peerGroup.isMember(user);
+  }
+
+  private boolean isValidPeerChatComponent(Run run, String nodeId, String componentId,
+      String otherNodeId, String otherComponentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
+    return PEER_CHAT_TYPE.equals(projectComponent.getString("type"))
+        && otherNodeId.equals(projectComponent.getString("showWorkNodeId"))
+        && otherComponentId.equals(projectComponent.getString("showWorkComponentId"));
+  }
+
+  private List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId) {
+    return peerGroupService.getStudentWork(peerGroup, nodeId, componentId);
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataController.java
@@ -31,16 +31,16 @@ public class ClassmatePeerChatDataController extends ClassmateDataController {
   @Autowired
   protected PeerGroupService peerGroupService;
 
-  @GetMapping("/student-work/{peerGroupId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}")
+  @GetMapping("/student-work/{peerGroupId}/{nodeId}/{componentId}/{showWorkNodeId}/{showWorkComponentId}")
   public List<StudentWork> getClassmatePeerChatWork(Authentication auth,
       @PathVariable Long peerGroupId, @PathVariable String nodeId, @PathVariable String componentId,
-      @PathVariable String otherNodeId, @PathVariable String otherComponentId)
+      @PathVariable String showWorkNodeId, @PathVariable String showWorkComponentId)
       throws IOException, JSONException, ObjectNotFoundException {
     PeerGroup peerGroup = peerGroupService.getById(peerGroupId);
     if (isAllowedToGetData(auth, peerGroup)) {
       Run run = peerGroup.getPeerGroupActivity().getRun();
-      if (isValidPeerChatComponent(run, nodeId, componentId, otherNodeId, otherComponentId)) {
-        return getStudentWork(peerGroup, otherNodeId, otherComponentId);
+      if (isValidPeerChatComponent(run, nodeId, componentId, showWorkNodeId, showWorkComponentId)) {
+        return getStudentWork(peerGroup, showWorkNodeId, showWorkComponentId);
       }
     }
     throw new AccessDeniedException(NOT_PERMITTED);
@@ -53,12 +53,12 @@ public class ClassmatePeerChatDataController extends ClassmateDataController {
   }
 
   private boolean isValidPeerChatComponent(Run run, String nodeId, String componentId,
-      String otherNodeId, String otherComponentId)
+      String showWorkNodeId, String showWorkComponentId)
       throws IOException, JSONException, ObjectNotFoundException {
     ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
     return PEER_CHAT_TYPE.equals(projectComponent.getString("type"))
-        && otherNodeId.equals(projectComponent.getString("showWorkNodeId"))
-        && otherComponentId.equals(projectComponent.getString("showWorkComponentId"));
+        && showWorkNodeId.equals(projectComponent.getString("showWorkNodeId"))
+        && showWorkComponentId.equals(projectComponent.getString("showWorkComponentId"));
   }
 
   private List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
@@ -35,9 +35,9 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
     Run run = runService.retrieveById(runId);
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
-      if (PERIOD_SOURCE.equals(source)) {
+      if (source.equals(PERIOD_SOURCE)) {
         return getStudentWork(run, period, otherNodeId, otherComponentId);
-      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+      } else if (source.equals(ALL_PERIODS_SOURCE)) {
         return getStudentWork(run, otherNodeId, otherComponentId);
       }
     }
@@ -53,9 +53,9 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
     Run run = runService.retrieveById(runId);
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
-      if (PERIOD_SOURCE.equals(source)) {
+      if (source.equals(PERIOD_SOURCE)) {
         return getAnnotations(run, period, otherNodeId, otherComponentId);
-      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+      } else if (source.equals(ALL_PERIODS_SOURCE)) {
         return getAnnotations(run, otherNodeId, otherComponentId);
       }
     }
@@ -73,8 +73,8 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
       String otherNodeId, String otherComponentId)
       throws IOException, JSONException, ObjectNotFoundException {
     ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
-    return SUMMARY_TYPE.equals(projectComponent.getString("type"))
-        && otherNodeId.equals(projectComponent.getString("summaryNodeId"))
-        && otherComponentId.equals(projectComponent.getString("summaryComponentId"));
+    return projectComponent.getString("type").equals(SUMMARY_TYPE)
+        && projectComponent.getString("summaryNodeId").equals(otherNodeId)
+        && projectComponent.getString("summaryComponentId").equals(otherComponentId);
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
@@ -65,4 +65,6 @@ public interface PeerGroupService {
    * @return List of StudentWork by members in the PeerGroup for the activity
    */
   public List<StudentWork> getStudentWork(PeerGroup peerGroup);
+
+  public List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -91,8 +91,8 @@ public class PeerGroupServiceImpl implements PeerGroupService {
   }
 
   private boolean isCompletionThresholdSatisfied(PeerGroupActivity activity, Workgroup workgroup) {
-    return hasWorkForPeerGroupLogicActivity(workgroup, activity) &&
-        peerGroupThresholdService.isCompletionThresholdSatisfied(activity, workgroup.getPeriod());
+    return hasWorkForPeerGroupLogicActivity(workgroup, activity) && peerGroupThresholdService
+        .isCompletionThresholdSatisfied(activity, workgroup.getPeriod());
   }
 
   private boolean hasWorkForPeerGroupLogicActivity(Workgroup workgroup,
@@ -110,9 +110,8 @@ public class PeerGroupServiceImpl implements PeerGroupService {
     try {
       List<Workgroup> workgroupsInPeerGroup = peerGroupDao.getWorkgroupsInPeerGroup(activity,
           workgroup.getPeriod());
-      Set<Workgroup> workgroupsNotInPeerGroupAndCompletedLogicActivity =
-          getWorkgroupsNotInPeerGroupAndCompletedLogicActivity(activity, workgroup.getPeriod(),
-          workgroupsInPeerGroup);
+      Set<Workgroup> workgroupsNotInPeerGroupAndCompletedLogicActivity = getWorkgroupsNotInPeerGroupAndCompletedLogicActivity(
+          activity, workgroup.getPeriod(), workgroupsInPeerGroup);
       if (isLastOnesLeftToPair(workgroup.getRun(), workgroup.getPeriod(), workgroupsInPeerGroup,
           workgroupsNotInPeerGroupAndCompletedLogicActivity, activity.getMaxMembershipCount())) {
         return workgroupsNotInPeerGroupAndCompletedLogicActivity;
@@ -131,10 +130,10 @@ public class PeerGroupServiceImpl implements PeerGroupService {
         period.getId());
     workgroupsInPeriod.removeIf(workgroup -> workgroup.getMembers().size() == 0);
     int numWorkgroupsNotInPeerGroup = workgroupsInPeriod.size() - workgroupsInPeerGroup.size();
-    int numWorkgroupsNotInPeerGroupAndCompletedLogicActivity =
-        workgroupsNotInPeerGroupAndCompletedLogicActivity.size();
-    return numWorkgroupsNotInPeerGroup == numWorkgroupsNotInPeerGroupAndCompletedLogicActivity &&
-        (numWorkgroupsNotInPeerGroupAndCompletedLogicActivity - maxMembershipCount) <= 1;
+    int numWorkgroupsNotInPeerGroupAndCompletedLogicActivity = workgroupsNotInPeerGroupAndCompletedLogicActivity
+        .size();
+    return numWorkgroupsNotInPeerGroup == numWorkgroupsNotInPeerGroupAndCompletedLogicActivity
+        && (numWorkgroupsNotInPeerGroupAndCompletedLogicActivity - maxMembershipCount) <= 1;
   }
 
   private Set<Workgroup> getWorkgroupsInPeerGroupUpToMaxMembership(Workgroup workgroup,
@@ -167,8 +166,8 @@ public class PeerGroupServiceImpl implements PeerGroupService {
   private List<StudentWork> getLogicComponentStudentWorkForPeriod(PeerGroupActivity activity,
       Group period) throws JSONException {
     List<StudentWork> logicComponentStudentWorkForPeriod = studentWorkDao
-        .getWorkForComponentByPeriod(activity.getRun(), period,
-        activity.getLogicNodeId(), activity.getLogicComponentId());
+        .getWorkForComponentByPeriod(activity.getRun(), period, activity.getLogicNodeId(),
+            activity.getLogicComponentId());
     Collections.reverse(logicComponentStudentWorkForPeriod);
     List<Workgroup> workgroups = new ArrayList<Workgroup>();
     List<StudentWork> studentWorkUniqueWorkgroups = new ArrayList<StudentWork>();
@@ -183,8 +182,13 @@ public class PeerGroupServiceImpl implements PeerGroupService {
 
   @Override
   public List<StudentWork> getStudentWork(PeerGroup peerGroup) {
-    return studentWorkDao.getWorkForComponentByWorkgroups(peerGroup.getMembers(),
-        peerGroup.getPeerGroupActivity().getNodeId(),
+    return getStudentWork(peerGroup, peerGroup.getPeerGroupActivity().getNodeId(),
         peerGroup.getPeerGroupActivity().getComponentId());
+  }
+
+  @Override
+  public List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId) {
+    return studentWorkDao.getWorkForComponentByWorkgroups(peerGroup.getMembers(), nodeId,
+        componentId);
   }
 }

--- a/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/work/impl/HibernateStudentWorkDaoTest.java
@@ -31,8 +31,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,7 +58,7 @@ public class HibernateStudentWorkDaoTest extends WISEHibernateTest {
   @Autowired
   private StudentWorkDao<StudentWork> studentWorkDao;
 
-  @BeforeEach
+  @Before
   public void setUp() throws Exception {
     super.setUp();
     createStudentWork(workgroup1, NODE_ID1, COMPONENT_ID1, DUMMY_STUDENT_WORK1);

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -1,6 +1,6 @@
 package org.wise.portal.presentation.web.controllers;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.wise.portal.domain.Tag;
 import org.wise.portal.domain.authentication.Gender;
+import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.authentication.Schoollevel;
 import org.wise.portal.domain.authentication.impl.PersistentGrantedAuthority;
 import org.wise.portal.domain.authentication.impl.StudentUserDetails;
@@ -41,91 +42,75 @@ import org.wise.portal.service.workgroup.WorkgroupService;
 
 public abstract class APIControllerTest {
 
-  protected final String STUDENT_FIRSTNAME = "SpongeBob";
-
-  protected final String STUDENT_LASTNAME = "Squarepants";
-
-  protected final String STUDENT_USERNAME = "SpongeBobS0101";
-
-  protected final String STUDENT2_FIRSTNAME = "Patrick";
-
-  protected final String STUDENT2_LASTNAME = "Starr";
-
-  protected final String STUDENT2_USERNAME = "PatrickS0101";
-
-  protected final String STUDENT_PASSWORD = "studentPass";
-
-  protected final String STUDENT1_GOOGLE_ID = "google-user-12345";
-
-  protected final String TEACHER_FIRSTNAME = "Squidward";
-
-  protected final String TEACHER_LASTNAME = "Tentacles";
-
-  protected final String TEACHER_USERNAME = "SquidwardTentacles";
-
-  protected final String TEACHER2_USERNAME = "SandyCheeks";
-
   protected final String ADMIN_USERNAME = "MrKrabb";
-
+  protected final String RUN1_RUNCODE = "orca123";
+  protected final String RUN2_RUNCODE = "panda123";
+  protected final String RUN3_RUNCODE = "giraffe123";
+  protected final String RUN1_PERIOD1_NAME = "1";
+  protected final String RUN1_PERIOD2_NAME = "2";
+  protected final String STUDENT_FIRSTNAME = "SpongeBob";
+  protected final String STUDENT_LASTNAME = "Squarepants";
+  protected final String STUDENT_PASSWORD = "studentPass";
+  protected final String STUDENT_USERNAME = "SpongeBobS0101";
+  protected final String STUDENT1_GOOGLE_ID = "google-user-12345";
+  protected final String STUDENT2_FIRSTNAME = "Patrick";
+  protected final String STUDENT2_LASTNAME = "Starr";
+  protected final String STUDENT2_USERNAME = "PatrickS0101";
+  protected final String TEACHER_FIRSTNAME = "Squidward";
+  protected final String TEACHER_LASTNAME = "Tentacles";
+  protected final String TEACHER_USERNAME = "SquidwardTentacles";
+  protected final String TEACHER2_FIRSTNAME = "Sandy";
+  protected final String TEACHER2_LASTNAME = "Cheeks";
+  protected final String TEACHER2_USERNAME = "SandyCheeks";
   protected final String USERNAME_NOT_IN_DB = "usernameNotInDB";
 
-  protected Long student1Id = 94678L;
-
-  protected Long student2Id = 94679L;
-
-  protected Long teacher1Id = 94210L;
-
-  protected User student1, student2, teacher1, teacher2, admin1;
-
-  protected Authentication studentAuth, teacherAuth, adminAuth;
-
-  protected StudentUserDetails student1UserDetails, student2UserDetails;
-
-  protected TeacherUserDetails teacher1UserDetails, admin1UserDetails;
-
-  protected Long runId1 = 1L;
-
-  protected Long runId2 = 2L;
-
-  protected Long runId3 = 3L;
-
-  protected Long projectId1 = 1L;
-
-  protected String RUN1_RUNCODE = "orca123";
-
-  protected String RUN1_PERIOD1_NAME = "1";
-
-  protected String RUN1_PERIOD2_NAME = "2";
-
-  protected Run run1, run2, run3;
-
-  protected List<Run> runs;
-
-  protected List<Tag> run1Tags;
-
-  protected Long workgroup1Id = 1L;
-
-  protected Workgroup workgroup1, workgroup2, teacher1Run1Workgroup;
-
+  protected Authentication adminAuth, studentAuth, teacherAuth;
   protected Project project1, project2, project3;
-
+  protected Long projectId1 = 1L;
+  protected Long projectId2 = 2L;
+  protected Long projectId3 = 3L;
+  protected Run run1, run2, run3;
+  protected List<Tag> run1Tags;
   protected Group run1Period1, run1Period2, run2Period2, run3Period4;
-
   protected Long run1Period1Id = 1L;
-
   protected Long run1Period2Id = 2L;
+  protected Long run2Period2Id = 3L;
+  protected Long run3Period4Id = 4L;
+  protected Long runId1 = 1L;
+  protected Long runId2 = 2L;
+  protected Long runId3 = 3L;
+  protected List<Run> runs;
+  protected Long student1Id = 94678L;
+  protected Long student2Id = 94679L;
+  protected User student1, student2, teacher1, teacher2, admin1;
+  protected StudentUserDetails student1UserDetails, student2UserDetails;
+  protected Long teacher1Id = 94210L;
+  protected Long teacher2Id = 94211L;
+  protected TeacherUserDetails teacher1UserDetails, teacher2UserDetails, admin1UserDetails;
+  protected Workgroup workgroup1, workgroup2, teacher1Run1Workgroup;
+  protected Long workgroup1Id = 1L;
+  protected Long workgroup2Id = 2L;
 
   @Mock
-  protected HttpServletRequest request;
+  protected Environment appProperties;
 
   @Mock
   protected GroupService groupService;
 
   @Mock
-  protected UserService userService;
+  protected PortalService portalService;
+
+  @Mock
+  protected ProjectService projectService;
+
+  @Mock
+  protected HttpServletRequest request;
 
   @Mock
   protected RunService runService;
+
+  @Mock
+  protected UserService userService;
 
   @Mock
   protected VLEService vleService;
@@ -133,138 +118,69 @@ public abstract class APIControllerTest {
   @Mock
   protected WorkgroupService workgroupService;
 
-  @Mock
-  protected ProjectService projectService;
-
-  @Mock
-  protected PortalService portalService;
-
-  @Mock
-  protected Environment appProperties;
-
   @Before
   public void setUp() {
-    student1 = new UserImpl();
-    student1.setId(student1Id);
-    PersistentGrantedAuthority studentAuthority = new PersistentGrantedAuthority();
-    studentAuthority.setAuthority(UserDetailsService.STUDENT_ROLE);
-    student1UserDetails = new StudentUserDetails();
-    student1UserDetails.setFirstname(STUDENT_FIRSTNAME);
-    student1UserDetails.setLastname(STUDENT_LASTNAME);
-    student1UserDetails.setUsername(STUDENT_USERNAME);
-    student1UserDetails.setGender(Gender.FEMALE);
-    student1UserDetails.setNumberOfLogins(5);
-    student1UserDetails.setAuthorities(new GrantedAuthority[] { studentAuthority });
-    student1UserDetails.setGoogleUserId(STUDENT1_GOOGLE_ID);
-    student1.setUserDetails(student1UserDetails);
-    student2 = new UserImpl();
-    student2.setId(student2Id);
-    PersistentGrantedAuthority studentAuthority2 = new PersistentGrantedAuthority();
-    studentAuthority2.setAuthority(UserDetailsService.STUDENT_ROLE);
-    student2UserDetails = new StudentUserDetails();
-    student2UserDetails.setFirstname(STUDENT2_FIRSTNAME);
-    student2UserDetails.setLastname(STUDENT2_LASTNAME);
-    student2UserDetails.setUsername(STUDENT2_USERNAME);
-    student2UserDetails.setGender(Gender.FEMALE);
-    student2UserDetails.setNumberOfLogins(10);
-    student2UserDetails.setAuthorities(new GrantedAuthority[] { studentAuthority2 });
-    student2.setUserDetails(student2UserDetails);
-    Object credentials = null;
-    studentAuth = new TestingAuthenticationToken(student1UserDetails, credentials);
-    teacher1 = new UserImpl();
-    teacher1.setId(teacher1Id);
-    PersistentGrantedAuthority teacherAuthority = new PersistentGrantedAuthority();
-    teacherAuthority.setAuthority(UserDetailsService.TEACHER_ROLE);
-    teacher1UserDetails = new TeacherUserDetails();
-    teacher1UserDetails.setFirstname(TEACHER_FIRSTNAME);
-    teacher1UserDetails.setLastname(TEACHER_LASTNAME);
-    teacher1UserDetails.setUsername(TEACHER_USERNAME);
-    teacher1UserDetails.setSchoollevel(Schoollevel.COLLEGE);
-    teacher1UserDetails.setNumberOfLogins(5);
-    teacher1UserDetails.setAuthorities(new GrantedAuthority[] { teacherAuthority });
-    teacher1.setUserDetails(teacher1UserDetails);
-    teacherAuth = new TestingAuthenticationToken(teacher1UserDetails, credentials);
-    admin1 = new UserImpl();
-    admin1UserDetails = new TeacherUserDetails();
-    PersistentGrantedAuthority adminAuthority = new PersistentGrantedAuthority();
-    adminAuthority.setAuthority(UserDetailsService.ADMIN_ROLE);
-    admin1UserDetails.setAuthorities(new GrantedAuthority[] { adminAuthority });
-    admin1UserDetails.setUsername(ADMIN_USERNAME);
-    admin1.setUserDetails(admin1UserDetails);
-    adminAuth = new TestingAuthenticationToken(admin1UserDetails, credentials);
-    run1 = new RunImpl();
-    run1.setId(runId1);
-    run1.setOwner(teacher1);
-    run1.setStarttime(new Date());
-    run1.setMaxWorkgroupSize(3);
-    run1.setRuncode(RUN1_RUNCODE);
-    HashSet<Group> run1Periods = new HashSet<Group>();
-    run1Period1 = new PersistentGroup();
-    run1Period1.setId(run1Period1Id);
-    run1Period1.setName(RUN1_PERIOD1_NAME);
-    run1Period1.addMember(student1);
-    run1Periods.add(run1Period1);
-    run1Period2 = new PersistentGroup();
-    run1Period2.setId(run1Period2Id);
-    run1Period2.setName(RUN1_PERIOD2_NAME);
-    run1Periods.add(run1Period2);
-    run1.setPeriods(run1Periods);
-    project1 = new ProjectImpl();
-    project1.setId(projectId1);
-    project1.setModulePath("/1/project.json");
-    project1.setOwner(teacher1);
-    project1.setWISEVersion(5);
-    project1.setMaxTotalAssetsSize(15728640L);
-    run1.setProject(project1);
-    run1.setLastRun(new Date());
-    workgroup1 = new WorkgroupImpl();
-    workgroup1.setId(workgroup1Id);
-    workgroup1.addMember(student1);
-    workgroup1.setPeriod(run1Period1);
-    workgroup1.setRun(run1);
-    workgroup2 = new WorkgroupImpl();
-    workgroup2.addMember(student2);
-    workgroup2.setPeriod(run1Period1);
-    workgroup2.setRun(run1);
-    teacher1Run1Workgroup = new WorkgroupImpl();
-    teacher1Run1Workgroup.addMember(teacher1);
-    teacher1Run1Workgroup.setRun(run1);
-    teacher2 = new UserImpl();
-    TeacherUserDetails tud2 = new TeacherUserDetails();
-    tud2.setUsername(TEACHER2_USERNAME);
-    teacher2.setUserDetails(tud2);
-    runs = new ArrayList<Run>();
-    run2 = new RunImpl();
-    run2.setId(runId2);
-    run2.setOwner(teacher1);
-    run2.setStarttime(new Date());
-    HashSet<Group> run2Periods = new HashSet<Group>();
-    run2Period2 = new PersistentGroup();
-    run2Period2.setName("2");
-    run2Period2.addMember(student1);
-    run2Periods.add(run2Period2);
-    run2.setPeriods(run2Periods);
-    project2 = new ProjectImpl();
-    project2.setModulePath("/2/project.json");
-    project2.setOwner(teacher2);
-    run2.setProject(project2);
-    run3 = new RunImpl();
-    run3.setId(runId3);
-    run3.setOwner(teacher2);
-    run3.setStarttime(new Date());
-    HashSet<Group> run3Periods = new HashSet<Group>();
-    run3Period4 = new PersistentGroup();
-    run3Period4.setName("4");
-    run3Period4.addMember(student1);
-    run3Periods.add(run3Period4);
-    run3.setPeriods(run3Periods);
-    project3 = new ProjectImpl();
-    project3.setModulePath("/3/project.json");
-    project3.setOwner(teacher2);
-    run3.setProject(project3);
-    runs.add(run1);
-    runs.add(run2);
-    runs.add(run3);
+    createAdmin();
+    createTeachers();
+    createStudents();
+    createProjects();
+    createRuns();
+    createWorkgroups();
+  }
+
+  private void createStudents() {
+    student1UserDetails = createStudentUserDetails(STUDENT_FIRSTNAME, STUDENT_LASTNAME,
+        STUDENT_USERNAME, Gender.MALE, 5, STUDENT1_GOOGLE_ID);
+    student1 = createStudent(student1Id, student1UserDetails);
+    student2UserDetails = createStudentUserDetails(STUDENT2_FIRSTNAME, STUDENT2_LASTNAME,
+        STUDENT2_USERNAME, Gender.MALE, 10, null);
+    student2 = createStudent(student2Id, student2UserDetails);
+    studentAuth = createAuthentication(student1UserDetails);
+  }
+
+  private void createTeachers() {
+    teacher1UserDetails = createTeacherUserDetails(TEACHER_FIRSTNAME, TEACHER_LASTNAME,
+        TEACHER_USERNAME, Schoollevel.COLLEGE, 5);
+    teacher1 = createTeacher(teacher1Id, teacher1UserDetails);
+    teacherAuth = createAuthentication(teacher1UserDetails);
+    teacher2UserDetails = createTeacherUserDetails(TEACHER2_FIRSTNAME, TEACHER2_LASTNAME,
+        TEACHER2_USERNAME, Schoollevel.COLLEGE, 5);
+    teacher2 = createTeacher(teacher2Id, teacher2UserDetails);
+  }
+
+  private void createAdmin() {
+    admin1UserDetails = createAdminUserDetails(ADMIN_USERNAME);
+    admin1 = createAdmin(admin1UserDetails);
+    adminAuth = createAuthentication(admin1UserDetails);
+  }
+
+  private void createProjects() {
+    project1 = createProject(projectId1, "/1/project.json", teacher1, 5);
+    project2 = createProject(projectId2, "/2/project.json", teacher2, 5);
+    project3 = createProject(projectId3, "/3/project.json", teacher2, 5);
+  }
+
+  private void createRuns() {
+    run1Period1 = createPeriod(run1Period1Id, RUN1_PERIOD1_NAME, student1);
+    run1Period2 = createPeriod(run1Period2Id, RUN1_PERIOD2_NAME);
+    HashSet<Group> run1Periods = new HashSet<Group>(Arrays.asList(run1Period1, run1Period2));
+    run1 = createRun(runId1, teacher1, new Date(), new Date(), 3, RUN1_RUNCODE, project1,
+        run1Periods);
+    run2Period2 = createPeriod(run2Period2Id, "2", student1);
+    HashSet<Group> run2Periods = new HashSet<Group>(Arrays.asList(run2Period2));
+    run2 = createRun(runId2, teacher1, new Date(), new Date(), 3, RUN2_RUNCODE, project2,
+        run2Periods);
+    run3Period4 = createPeriod(run3Period4Id, "4", student1);
+    HashSet<Group> run3Periods = new HashSet<Group>(Arrays.asList(run3Period4));
+    run3 = createRun(runId3, teacher2, new Date(), new Date(), 3, RUN3_RUNCODE, project3,
+        run3Periods);
+    runs = Arrays.asList(run1, run2, run3);
+  }
+
+  private void createWorkgroups() {
+    workgroup1 = createWorkgroup(workgroup1Id, run1, run1Period1, student1);
+    workgroup2 = createWorkgroup(workgroup2Id, run1, run1Period1, student2);
+    teacher1Run1Workgroup = createTeacherWorkgroup(run1, teacher1);
   }
 
   @After
@@ -280,5 +196,125 @@ public abstract class APIControllerTest {
   }
 
   public APIControllerTest() {
+  }
+
+  protected User createStudent(Long id, StudentUserDetails studentUserDetails) {
+    User student = new UserImpl();
+    student.setId(id);
+    student.setUserDetails(studentUserDetails);
+    return student;
+  }
+
+  protected Workgroup createWorkgroup(Long id, Run run, Group period) {
+    Workgroup workgroup = new WorkgroupImpl();
+    workgroup.setId(id);
+    workgroup.setRun(run);
+    workgroup.setPeriod(period);
+    return workgroup;
+  }
+
+  protected Workgroup createWorkgroup(Long id, Run run, Group period, User student) {
+    Workgroup workgroup = createWorkgroup(id, run, period);
+    workgroup.addMember(student);
+    return workgroup;
+  }
+
+  protected Workgroup createTeacherWorkgroup(Run run, User teacher) {
+    Workgroup workgroup = new WorkgroupImpl();
+    workgroup.setRun(run);
+    workgroup.addMember(teacher);
+    return workgroup;
+  }
+
+  protected StudentUserDetails createStudentUserDetails(String firstName, String lastName,
+      String username, Gender gender, Integer numberOfLogins, String googleUserId) {
+    StudentUserDetails studentUserDetails = new StudentUserDetails();
+    studentUserDetails.setFirstname(firstName);
+    studentUserDetails.setLastname(lastName);
+    studentUserDetails.setUsername(username);
+    studentUserDetails.setGender(gender);
+    studentUserDetails.setNumberOfLogins(numberOfLogins);
+    PersistentGrantedAuthority studentAuthority = new PersistentGrantedAuthority();
+    studentAuthority.setAuthority(UserDetailsService.STUDENT_ROLE);
+    studentUserDetails.setAuthorities(new GrantedAuthority[] { studentAuthority });
+    studentUserDetails.setGoogleUserId(googleUserId);
+    return studentUserDetails;
+  }
+
+  protected User createTeacher(Long id, TeacherUserDetails teacherUserDetails) {
+    User teacher = new UserImpl();
+    teacher.setId(id);
+    teacher.setUserDetails(teacherUserDetails);
+    return teacher;
+  }
+
+  protected TeacherUserDetails createTeacherUserDetails(String firstName, String lastName,
+      String username, Schoollevel schoolLevel, Integer numberOfLogins) {
+    TeacherUserDetails teacherUserDetails = new TeacherUserDetails();
+    teacherUserDetails.setFirstname(firstName);
+    teacherUserDetails.setLastname(lastName);
+    teacherUserDetails.setUsername(username);
+    teacherUserDetails.setSchoollevel(schoolLevel);
+    teacherUserDetails.setNumberOfLogins(numberOfLogins);
+    PersistentGrantedAuthority teacherAuthority = new PersistentGrantedAuthority();
+    teacherAuthority.setAuthority(UserDetailsService.TEACHER_ROLE);
+    teacherUserDetails.setAuthorities(new GrantedAuthority[] { teacherAuthority });
+    return teacherUserDetails;
+  }
+
+  protected User createAdmin(TeacherUserDetails teacherUserDetails) {
+    User admin = new UserImpl();
+    admin.setUserDetails(teacherUserDetails);
+    return admin;
+  }
+
+  protected TeacherUserDetails createAdminUserDetails(String username) {
+    TeacherUserDetails adminUserDetails = new TeacherUserDetails();
+    PersistentGrantedAuthority adminAuthority = new PersistentGrantedAuthority();
+    adminAuthority.setAuthority(UserDetailsService.ADMIN_ROLE);
+    adminUserDetails.setAuthorities(new GrantedAuthority[] { adminAuthority });
+    adminUserDetails.setUsername(username);
+    return adminUserDetails;
+  }
+
+  protected Authentication createAuthentication(MutableUserDetails userDetails) {
+    return new TestingAuthenticationToken(userDetails, null);
+  }
+
+  protected Run createRun(Long id, User owner, Date startTime, Date lastRunTime,
+      Integer maxWorkgroupSize, String runCode, Project project, HashSet<Group> periods) {
+    Run run = new RunImpl();
+    run.setId(id);
+    run.setOwner(owner);
+    run.setStarttime(startTime);
+    run.setLastRun(lastRunTime);
+    run.setMaxWorkgroupSize(maxWorkgroupSize);
+    run.setRuncode(runCode);
+    run.setProject(project);
+    run.setPeriods(periods);
+    return run;
+  }
+
+  protected Project createProject(Long id, String modulePath, User teacher, Integer wiseVersion) {
+    Project project = new ProjectImpl();
+    project.setId(id);
+    project.setModulePath(modulePath);
+    project.setOwner(teacher);
+    project.setWISEVersion(wiseVersion);
+    project.setMaxTotalAssetsSize(15728640L);
+    return project;
+  }
+
+  protected Group createPeriod(Long id, String name) {
+    Group period = new PersistentGroup();
+    period.setId(id);
+    period.setName(name);
+    return period;
+  }
+
+  protected Group createPeriod(Long id, String name, User student) {
+    Group period = createPeriod(id, name);
+    period.addMember(student);
+    return period;
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
@@ -17,6 +17,10 @@ public abstract class AbstractClassmateDataControllerTest extends APIControllerT
   String COMPONENT_ID1 = "component1";
   String NODE_ID1 = "node1";
   String OPEN_RESPONSE_TYPE = "OpenResponse";
+  String OTHER_COMPONENT_ID = "component2";
+  String OTHER_COMPONENT_ID_NOT_ALLOWED = "component3";
+  String OTHER_NODE_ID = "node2";
+  String OTHER_NODE_ID_NOT_ALLOWED = "node3";
   String SHOULD_NOT_HAVE_THROWN_EXCEPTION = "Should not have thrown an exception";
 
   protected void expectStudentWork(List<StudentWork> studentWork) {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmatePeerChatDataControllerTest.java
@@ -1,0 +1,206 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.authentication.Gender;
+import org.wise.portal.domain.authentication.impl.StudentUserDetails;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.peergroupactivity.impl.PeerGroupActivityImpl;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
+import org.wise.portal.service.peergroup.PeerGroupService;
+import org.wise.vle.domain.work.StudentWork;
+
+@RunWith(EasyMockRunner.class)
+public class ClassmatePeerChatDataControllerTest extends AbstractClassmateDataControllerTest {
+
+  protected final Long PEER_GROUP_ID1 = 1L;
+  protected final Long PEER_GROUP_ID2 = 2L;
+  protected final String STUDENT3_FIRSTNAME = "Pearl";
+  protected final Long STUDENT3_ID = 94680L;
+  protected final String STUDENT3_LASTNAME = "Krabs";
+  protected final String STUDENT3_USERNAME = "PearlK0101";
+  protected PeerGroup peerGroup1;
+  protected PeerGroup peerGroup2;
+  protected PeerGroupActivity peerGroupActivity;
+  protected StudentUserDetails student3UserDetails;
+  protected User student3;
+  protected Workgroup workgroup3;
+
+  @Mock
+  PeerGroupService peerGroupService;
+
+  @TestSubject
+  private ClassmatePeerChatDataController controller = new ClassmatePeerChatDataController();
+
+  @Before
+  public void before() throws JSONException {
+    createPeerGroupActivity();
+    setUpPeerGroup1(peerGroupActivity);
+  }
+
+  private void createPeerGroupActivity() throws JSONException {
+    ProjectComponent component = new ProjectComponent(
+        createComponentJSONObject(COMPONENT_ID1, "PeerChat", "", 2, 50, 2));
+    peerGroupActivity = new PeerGroupActivityImpl(run1, NODE_ID1, component);
+  }
+
+  private void setUpPeerGroup1(PeerGroupActivity peerGroupActivity) {
+    Set<Workgroup> peerGroup1Members = new HashSet<Workgroup>(
+        Arrays.asList(workgroup1, workgroup2));
+    peerGroup1 = new PeerGroupImpl(peerGroupActivity, peerGroup1Members);
+  }
+
+  private void createWorkgroup3() {
+    student3UserDetails = createStudentUserDetails(STUDENT3_FIRSTNAME, STUDENT3_LASTNAME,
+        STUDENT3_USERNAME, Gender.FEMALE, 15, null);
+    student3 = createStudent(STUDENT3_ID, student3UserDetails);
+    workgroup3 = new WorkgroupImpl();
+    workgroup3.addMember(student3);
+    workgroup3.setPeriod(run1Period1);
+    workgroup3.setRun(run1);
+  }
+
+  private void setUpPeerGroup2(PeerGroupActivity peerGroupActivity) {
+    Set<Workgroup> peerGroup2Members = new HashSet<Workgroup>(Arrays.asList(workgroup3));
+    peerGroup2 = new PeerGroupImpl(peerGroupActivity, peerGroup2Members);
+  }
+
+  private JSONObject createComponentJSONObject(String componentId, String componentType,
+      String logic, Integer logicThresholdCount, Integer logicThresholdPercent,
+      Integer maxMembershipCount) throws JSONException {
+    String projectJSONString = new StringBuilder()
+        .append("{")
+        .append("  \"id\": \"" + componentId + "\",")
+        .append("  \"type\": \"" + componentType + "\",")
+        .append("  \"logic\": \"" + logic + "\",")
+        .append("  \"logicThresholdCount\": " + logicThresholdCount + ",")
+        .append("  \"logicThresholdPercent\": " + logicThresholdPercent + ",")
+        .append("  \"maxMembershipCount\": " + maxMembershipCount)
+        .append("}")
+        .toString();
+    return new JSONObject(projectJSONString);
+  }
+
+  @Test
+  public void getClassmatePeerChatWork_NotInPeerGroup_ShouldThrowException()
+      throws IOException, ObjectNotFoundException {
+    createWorkgroup3();
+    setUpPeerGroup2(peerGroupActivity);
+    expectGetPeerGroup(PEER_GROUP_ID2, peerGroup2);
+    expectRetrieveUser();
+    replayAll();
+    assertThrows(AccessDeniedException.class, () -> controller.getClassmatePeerChatWork(studentAuth,
+        PEER_GROUP_ID2, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmatePeerChatWork_InvalidPeerChatComponent_ShouldThrowException()
+      throws IOException, ObjectNotFoundException {
+    expectGetPeerGroup(PEER_GROUP_ID1, peerGroup1);
+    expectRetrieveUser();
+    expectComponentType(NODE_ID1, COMPONENT_ID1, OPEN_RESPONSE_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID);
+    replayAll();
+    assertThrows(AccessDeniedException.class, () -> controller.getClassmatePeerChatWork(studentAuth,
+        PEER_GROUP_ID1, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmatePeerChatWork_InvalidOtherComponent_ShouldThrowException()
+      throws IOException, ObjectNotFoundException {
+    expectGetPeerGroup(PEER_GROUP_ID1, peerGroup1);
+    expectRetrieveUser();
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.PEER_CHAT_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmatePeerChatWork(studentAuth, PEER_GROUP_ID1, NODE_ID1,
+            COMPONENT_ID1, OTHER_NODE_ID_NOT_ALLOWED, OTHER_COMPONENT_ID_NOT_ALLOWED));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmatePeerChatWork_ValidOtherComponent_ShouldReturnStudentWork()
+      throws IOException, JSONException, ObjectNotFoundException {
+    expectGetPeerGroup(PEER_GROUP_ID1, peerGroup1);
+    expectRetrieveUser();
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.PEER_CHAT_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID);
+    List<StudentWork> expectedStudentWork = Arrays.asList(new StudentWork(), new StudentWork());
+    expectGetStudentWork(peerGroup1, OTHER_NODE_ID, OTHER_COMPONENT_ID, expectedStudentWork);
+    replayAll();
+    List<StudentWork> actualStudentWork = controller.getClassmatePeerChatWork(studentAuth,
+        PEER_GROUP_ID1, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID);
+    assertEquals(expectedStudentWork, actualStudentWork);
+    verifyAll();
+  }
+
+  private void expectGetPeerGroup(Long peerGroupId, PeerGroup peerGroup)
+      throws ObjectNotFoundException {
+    expect(peerGroupService.getById(peerGroupId)).andReturn(peerGroup);
+  }
+
+  private void expectRetrieveUser() {
+    expect(userService.retrieveUser(student1UserDetails)).andReturn(student1);
+  }
+
+  protected void expectComponentType(String nodeId, String componentId, String componentType,
+      String otherNodeId, String otherComponentId) throws IOException, ObjectNotFoundException {
+    String projectJSONString = new StringBuilder()
+        .append("{")
+        .append("  \"nodes\": [")
+        .append("    {")
+        .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"components\": [")
+        .append("        {")
+        .append("          \"id\": \"" + componentId + "\",")
+        .append("          \"type\": \"" + componentType + "\",")
+        .append("          \"showWorkNodeId\": \"" + otherNodeId + "\",")
+        .append("          \"showWorkComponentId\": \"" + otherComponentId + "\"")
+        .append("        }")
+        .append("      ]")
+        .append("    }")
+        .append("  ]")
+        .append("}")
+        .toString();
+    expect(projectService.getProjectContent(project1)).andReturn(projectJSONString);
+  }
+
+  private void expectGetStudentWork(PeerGroup peerGroup, String nodeId, String componentId,
+      List<StudentWork> studentWork) {
+    expect(peerGroupService.getStudentWork(peerGroup, nodeId, componentId)).andReturn(studentWork);
+  }
+
+  protected void replayAll() {
+    replay(peerGroupService, projectService, userService);
+  }
+
+  protected void verifyAll() {
+    verify(peerGroupService, projectService, userService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
@@ -21,11 +21,6 @@ import org.wise.vle.domain.work.StudentWork;
 @RunWith(EasyMockRunner.class)
 public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataControllerTest {
 
-  String OTHER_COMPONENT_ID = "component2";
-  String OTHER_COMPONENT_ID_NOT_ALLOWED = "component3";
-  String OTHER_NODE_ID = "node2";
-  String OTHER_NODE_ID_NOT_ALLOWED = "node3";
-
   @TestSubject
   private ClassmateSummaryDataController controller = new ClassmateSummaryDataController();
 

--- a/src/test/java/org/wise/portal/service/WISEServiceTest.java
+++ b/src/test/java/org/wise/portal/service/WISEServiceTest.java
@@ -107,6 +107,16 @@ public class WISEServiceTest {
     return work;
   }
 
+  protected StudentWork createComponentWork(Workgroup workgroup, String nodeId, String componentId,
+      boolean isSubmit) {
+    StudentWork work = new StudentWork();
+    work.setWorkgroup(workgroup);
+    work.setNodeId(nodeId);
+    work.setComponentId(componentId);
+    work.setIsSubmit(isSubmit);
+    return work;
+  }
+
   protected List<StudentWork> createStudentWorkList(StudentWork... componentWorks) {
     List<StudentWork> list = new ArrayList<StudentWork>();
     for (StudentWork work : componentWorks) {


### PR DESCRIPTION
- Make sure the student can retrieve data from the other step that is referenced in the Peer Chat component.

- Make sure the student can not retrieve data from another step if that other step is not referenced in the Peer Chat component.
  - For example there could be a legitimate
peerChatNode1, peerChatComponent1, legitOtherNode, legitOtherComponent
but the student tries to retrieve
peerChatNode1, peerChatComponent1, notLegitOtherNode, notLegitOtherComponent (the non legit component can actually be in the project but not actually referenced in the Peer Chat component)

Example Peer Chat student work endpoint
```
http://localhost:81/api/classmate/peer-chat/student-work/PEER_GROUP_ID/PEER_CHAT_NODE_ID/PEER_CHAT_COMPONENT_ID/OTHER_NODE_ID/OTHER_COMPONENT_ID
```

Closes #62