### PR TITLE
fix(Grading Tool): Teacher can open grading tool

### DIFF
--- a/src/main/java/org/wise/portal/domain/user/impl/UserImpl.java
+++ b/src/main/java/org/wise/portal/domain/user/impl/UserImpl.java
@@ -32,6 +32,7 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 
+import org.hibernate.proxy.HibernateProxy;
 import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.authentication.impl.PersistentUserDetails;
 import org.wise.portal.domain.user.User;
@@ -106,9 +107,16 @@ public class UserImpl implements User {
       return true;
     if (obj == null)
       return false;
-    if (getClass() != obj.getClass())
+    if (obj instanceof HibernateProxy) {
+      if (getClass() != (( HibernateProxy) obj).getHibernateLazyInitializer().getImplementation().getClass()) {
+        return false;
+      }
+    } else if (getClass() != obj.getClass())
       return false;
     final UserImpl other = (UserImpl) obj;
+    if (this.getId() != null && this.getId().equals(other.getId())) {
+      return true;
+    }
     if (userDetails == null) {
       if (other.userDetails != null)
         return false;


### PR DESCRIPTION
## Changes
- The user object retrieved in the controller by DomainClassConverter
is now a HibernateProxy object due to PR #65, so I updated the User's
equal object to check for it.

## Test
You can open the CM as
- regular (non-admin) teacher, on your own run and shared runs
- admin user, on any run

Closes #68