### PR TITLE
feat(Peer-Group): Add teacher endpoint to create peer group

### DIFF
--- a/src/main/java/org/wise/portal/dao/group/GroupRepository.java
+++ b/src/main/java/org/wise/portal/dao/group/GroupRepository.java
@@ -1,0 +1,11 @@
+package org.wise.portal.dao.group;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+import org.wise.portal.domain.group.impl.PersistentGroup;
+
+/**
+ * @author Hiroki Terashima
+ */
+@Repository
+public interface GroupRepository extends PagingAndSortingRepository<PersistentGroup, Long> {}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
@@ -1,0 +1,46 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.domain.group.impl.PersistentGroup;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.run.impl.RunImpl;
+import org.wise.portal.service.peergroup.PeerGroupCreateService;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
+import org.wise.portal.service.run.RunService;
+
+@RestController
+@Secured("ROLE_TEACHER")
+@RequestMapping("/api/peer-group/create")
+public class PeerGroupCreateController {
+
+  @Autowired
+  private PeerGroupActivityService peerGroupActivityService;
+
+  @Autowired
+  private PeerGroupCreateService peerGroupCreateService;
+
+  @Autowired
+  private RunService runService;
+
+  @PostMapping("/{runId}/{periodId}/{nodeId}/{componentId}")
+  PeerGroup create(@PathVariable("runId") RunImpl run,
+      @PathVariable("periodId") PersistentGroup period, @PathVariable String nodeId,
+      @PathVariable String componentId, Authentication auth)
+      throws PeerGroupActivityNotFoundException {
+    if (runService.hasWritePermission(auth, run)) {
+      PeerGroupActivity activity =
+          peerGroupActivityService.getByComponent(run, nodeId, componentId);
+      return peerGroupCreateService.create(activity, period);
+    }
+    throw new AccessDeniedException("Not permitted");
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
@@ -36,11 +36,15 @@ public class PeerGroupCreateController {
       @PathVariable("periodId") PersistentGroup period, @PathVariable String nodeId,
       @PathVariable String componentId, Authentication auth)
       throws PeerGroupActivityNotFoundException {
-    if (runService.hasWritePermission(auth, run)) {
+    if (canCreatePeerGroup(run, period, auth)) {
       PeerGroupActivity activity =
           peerGroupActivityService.getByComponent(run, nodeId, componentId);
       return peerGroupCreateService.create(activity, period);
     }
     throw new AccessDeniedException("Not permitted");
+  }
+
+  private boolean canCreatePeerGroup(RunImpl run, PersistentGroup period, Authentication auth) {
+    return runService.hasWritePermission(auth, run) && run.getPeriods().contains(period);
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupCreateService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupCreateService.java
@@ -1,0 +1,21 @@
+package org.wise.portal.service.peergroup;
+
+import org.springframework.security.access.annotation.Secured;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+
+/**
+ * @author Hiroki Terashima
+ */
+@Secured("ROLE_TEACHER")
+public interface PeerGroupCreateService {
+
+  /**
+   * Creates a new Peer Group with no members for the given activity and period
+   * @param activity PeerGroupActivity
+   * @param period Group containing students in the PeerGroup
+   * @return newly created Peer Group
+   */
+  PeerGroup create(PeerGroupActivity activity, Group period);
+}

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupCreateServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupCreateServiceImpl.java
@@ -1,0 +1,30 @@
+package org.wise.portal.service.peergroup.impl;
+
+import java.util.HashSet;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.PeerGroupCreateService;
+
+/**
+ * @author Hiroki Terashima
+ */
+@Service
+public class PeerGroupCreateServiceImpl implements PeerGroupCreateService {
+
+  @Autowired
+  private PeerGroupDao<PeerGroup> peerGroupDao;
+
+  @Override
+  public PeerGroup create(PeerGroupActivity activity, Group period) {
+    PeerGroup peerGroup = new PeerGroupImpl(activity, period, new HashSet<Workgroup>());
+    this.peerGroupDao.save(peerGroup);
+    return peerGroup;
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -70,7 +70,7 @@ public abstract class APIControllerTest {
   protected Long projectId3 = 3L;
   protected RunImpl run1, run2, run3;
   protected List<Tag> run1Tags;
-  protected Group run1Period1, run1Period2, run2Period2, run3Period4;
+  protected PersistentGroup run1Period1, run1Period2, run2Period2, run3Period4;
   protected Long run1Period1Id = 1L;
   protected Long run1Period2Id = 2L;
   protected Long run2Period2Id = 3L;
@@ -308,15 +308,15 @@ public abstract class APIControllerTest {
     return project;
   }
 
-  protected Group createPeriod(Long id, String name) {
-    Group period = new PersistentGroup();
+  protected PersistentGroup createPeriod(Long id, String name) {
+    PersistentGroup period = new PersistentGroup();
     period.setId(id);
     period.setName(name);
     return period;
   }
 
-  protected Group createPeriod(Long id, String name, User student) {
-    Group period = createPeriod(id, name);
+  protected PersistentGroup createPeriod(Long id, String name, User student) {
+    PersistentGroup period = createPeriod(id, name);
     period.addMember(student);
     return period;
   }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -169,11 +169,11 @@ public abstract class APIControllerTest {
     HashSet<Group> run1Periods = new HashSet<Group>(Arrays.asList(run1Period1, run1Period2));
     run1 = createRun(runId1, teacher1, new Date(), new Date(), 3, RUN1_RUNCODE, project1,
         run1Periods);
-    run2Period2 = createPeriod(run2Period2Id, "2", student1);
+    run2Period2 = createPeriod(run2Period2Id, "Run2Period2", student1);
     HashSet<Group> run2Periods = new HashSet<Group>(Arrays.asList(run2Period2));
     run2 = createRun(runId2, teacher1, new Date(), new Date(), 3, RUN2_RUNCODE, project2,
         run2Periods);
-    run3Period4 = createPeriod(run3Period4Id, "4", student1);
+    run3Period4 = createPeriod(run3Period4Id, "Run3Period4", student1);
     HashSet<Group> run3Periods = new HashSet<Group>(Arrays.asList(run3Period4));
     run3 = createRun(runId3, teacher2, new Date(), new Date(), 3, RUN3_RUNCODE, project3,
         run3Periods);

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateControllerTest.java
@@ -35,6 +35,18 @@ public class PeerGroupCreateControllerTest extends AbstractPeerGroupAPIControlle
   }
 
   @Test
+  public void create_PeriodNotInRun_ThrowException() throws Exception {
+    expectUserHasRunWritePermission(true);
+    replayAll();
+    try {
+      controller.create(run1, run2Period2, run1Node1Id, run1Component1Id, teacherAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
   public void create_PeerGroupActivityNotFound_ThrowException() throws Exception {
     expectUserHasRunWritePermission(true);
     expectPeerGroupActivityNotFound();

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateControllerTest.java
@@ -1,0 +1,80 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.service.peergroup.PeerGroupCreateService;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
+
+@RunWith(EasyMockRunner.class)
+public class PeerGroupCreateControllerTest extends AbstractPeerGroupAPIControllerTest {
+
+  @TestSubject
+  private PeerGroupCreateController controller = new PeerGroupCreateController();
+
+  @Mock
+  private PeerGroupCreateService peerGroupCreateService;
+
+  @Test
+  public void create_UserHasNoWritePermission_ThrowAccessDenied() throws Exception {
+    expectUserHasRunWritePermission(false);
+    replayAll();
+    try {
+      controller.create(run1, run1Period1, run1Node1Id, run1Component1Id, teacherAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void create_PeerGroupActivityNotFound_ThrowException() throws Exception {
+    expectUserHasRunWritePermission(true);
+    expectPeerGroupActivityNotFound();
+    replayAll();
+    try {
+      controller.create(run1, run1Period1, run1Node1Id, run1Component1Id, teacherAuth);
+      fail("Expected PeerGroupActivityNotFoundException, but was not thrown");
+    } catch (PeerGroupActivityNotFoundException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void create_PeerGroupActivityFound_CreateGroup() throws Exception {
+    expectUserHasRunWritePermission(true);
+    expectPeerGroupActivityFound();
+    expectCreatePeerGroup();
+    replayAll();
+    assertNotNull(controller.create(run1, run1Period1, run1Node1Id, run1Component1Id, teacherAuth));
+    verifyAll();
+  }
+
+  private void expectUserHasRunWritePermission(boolean hasPermission) {
+    expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(hasPermission);
+  }
+
+  private void expectCreatePeerGroup() {
+    expect(peerGroupCreateService.create(peerGroupActivity, run1Period1)).andReturn(
+        new PeerGroupImpl());
+  }
+
+  @Override
+  public void replayAll() {
+    super.replayAll();
+    replay(peerGroupCreateService);
+  }
+
+  @Override
+  public void verifyAll() {
+    super.verifyAll();
+    verify(peerGroupCreateService);
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupCreateServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupCreateServiceImplTest.java
@@ -1,0 +1,48 @@
+package org.wise.portal.service.peergroup.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.junit.Assert.*;
+import static org.easymock.EasyMock.*;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.service.WISEServiceTest;
+
+/**
+ * @author Hiroki Terashima
+ */
+@RunWith(EasyMockRunner.class)
+public class PeerGroupCreateServiceImplTest extends WISEServiceTest {
+
+  @TestSubject
+  private PeerGroupCreateServiceImpl service = new PeerGroupCreateServiceImpl();
+
+  @Mock
+  private PeerGroupDao<PeerGroup> peerGroupDao;
+
+  PeerGroupServiceTestHelper testHelper;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    testHelper = new PeerGroupServiceTestHelper(run1, run1Component2);
+  }
+
+  @Test
+  public void create_ReturnPeerGroupWithNoMembers() {
+    peerGroupDao.save(isA(PeerGroupImpl.class));
+    expectLastCall();
+    replay(peerGroupDao);
+    PeerGroup peerGroup = service.create(testHelper.activity, run1Period1);
+    assertEquals(0, peerGroup.getMembers().size());
+    verify(peerGroupDao);
+  }
+}


### PR DESCRIPTION
## Changes
- Add a new endpoint for teachers to create new PeerGroup at ```/api/peer-group/create/{runId}/{periodId}/{nodeId}/{componentId}```

## Test
- The endpoint should throw PeerGroupActivityNotFoundException if the given params do not point to an existing PeerGroupActivity
- The endpoint should throw AccessDeniedException if user does not have write permission on the run
- Otherwise, it should create a new PeerGroup for the specified PeerGroupActivity and Period and return it in the response

Closes #72 