### PR TITLE
feat(Peer Group): Add ability to get manually assigned peer group

### DIFF
--- a/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
@@ -40,6 +40,8 @@ public interface PeerGroupActivity {
 
   String getLogicComponentId() throws JSONException;
 
+  String getLogicName() throws JSONException;
+
   String getLogicNodeId() throws JSONException;
 
   int getLogicThresholdCount();

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
@@ -53,8 +53,7 @@ import lombok.Setter;
  */
 @Entity
 @Table(name = "peer_group_activities", indexes = {
-  @Index(columnList = "runId", name = "peer_group_activities_run_id_index")
-})
+    @Index(columnList = "runId", name = "peer_group_activities_run_id_index") })
 @Getter
 @Setter
 public class PeerGroupActivityImpl implements PeerGroupActivity {
@@ -63,8 +62,8 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id = null;
 
-  @ManyToOne(targetEntity = RunImpl.class, cascade = { CascadeType.PERSIST },
-      fetch = FetchType.LAZY)
+  @ManyToOne(targetEntity = RunImpl.class, cascade = {
+      CascadeType.PERSIST }, fetch = FetchType.LAZY)
   @JoinColumn(name = "runId", nullable = false)
   @JsonIgnore
   private Run run;
@@ -111,5 +110,10 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
 
   private JSONObject getFirstLogicJSON() throws JSONException {
     return new JSONArray(this.logic).getJSONObject(0);
+  }
+
+  public String getLogicName() throws JSONException {
+    JSONObject logic = getFirstLogicJSON();
+    return logic.getString("name");
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -23,6 +23,7 @@
  */
 package org.wise.portal.presentation.web.controllers.peergroup;
 
+import org.json.JSONException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
@@ -69,7 +70,7 @@ public class PeerGroupAPIController {
   @GetMapping("/{runId}/{workgroupId}/{nodeId}/{componentId}")
   PeerGroup getPeerGroup(@PathVariable Long runId, @PathVariable Long workgroupId,
       @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
-      throws ObjectNotFoundException, PeerGroupActivityNotFoundException,
+      throws JSONException, ObjectNotFoundException, PeerGroupActivityNotFoundException,
       PeerGroupCreationException, PeerGroupActivityThresholdNotSatisfiedException {
     Run run = runService.retrieveById(runId);
     Workgroup workgroup = workgroupService.retrieveById(workgroupId);
@@ -82,7 +83,7 @@ public class PeerGroupAPIController {
   }
 
   private PeerGroup getPeerGroup(Run run, String nodeId, String componentId, Workgroup workgroup)
-      throws PeerGroupActivityNotFoundException, PeerGroupCreationException,
+      throws JSONException, PeerGroupActivityNotFoundException, PeerGroupCreationException,
       PeerGroupActivityThresholdNotSatisfiedException {
     PeerGroupActivity activity = peerGroupActivityService.getByComponent(run, nodeId, componentId);
     return peerGroupService.getPeerGroup(workgroup, activity);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIController.java
@@ -2,6 +2,7 @@ package org.wise.portal.presentation.web.controllers.peergroup;
 
 import java.util.List;
 
+import org.json.JSONException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
@@ -66,7 +67,7 @@ public class PeerGroupWorkAPIController {
   @GetMapping("/{runId}/{workgroupId}/{nodeId}/{componentId}/student-work")
   List<StudentWork> getPeerGroupWork(@PathVariable Long runId, @PathVariable Long workgroupId,
       @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
-      throws ObjectNotFoundException, PeerGroupActivityNotFoundException,
+      throws JSONException, ObjectNotFoundException, PeerGroupActivityNotFoundException,
       PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException {
     Run run = runService.retrieveById(runId);
     User user = userService.retrieveUserByUsername(auth.getName());

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
@@ -25,6 +25,7 @@ package org.wise.portal.service.peergroup;
 
 import java.util.List;
 
+import org.json.JSONException;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
@@ -56,8 +57,8 @@ public interface PeerGroupService {
    * @throws PeerGroupCreationException the PeerGroup cannot be created for other reasons
    * like an error occurred while grouping members
    */
-  PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
-      throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException;
+  PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity) throws JSONException,
+      PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException;
 
   /**
    * Gets all the PeerGroups for the specified PeerGroupActivity
@@ -75,5 +76,6 @@ public interface PeerGroupService {
 
   public List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId);
 
-  public List<StudentWork> getLatestStudentWork(PeerGroup peerGroup, String nodeId, String componentId);
+  public List<StudentWork> getLatestStudentWork(PeerGroup peerGroup, String nodeId,
+      String componentId);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -73,9 +73,14 @@ public class PeerGroupServiceImpl implements PeerGroupService {
 
   @Override
   public PeerGroup getPeerGroup(Workgroup workgroup, PeerGroupActivity activity)
-      throws PeerGroupActivityThresholdNotSatisfiedException, PeerGroupCreationException {
+      throws JSONException, PeerGroupActivityThresholdNotSatisfiedException,
+      PeerGroupCreationException {
     PeerGroup peerGroup = peerGroupDao.getByWorkgroupAndActivity(workgroup, activity);
-    return peerGroup != null ? peerGroup : this.createPeerGroup(workgroup, activity);
+    if (activity.getLogicName().equals("manual")) {
+      return peerGroup;
+    } else {
+      return peerGroup != null ? peerGroup : this.createPeerGroup(workgroup, activity);
+    }
   }
 
   private PeerGroup createPeerGroup(Workgroup workgroup, PeerGroupActivity activity)

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -179,7 +179,7 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
 
   @Test
   public void getPeerGroup_ManualLogicPeerGroupNotExist_ReturnNull() throws Exception {
-    expectPeerGroupFromDB(null, run1Workgroup1, manualActivity);
+    expectPeerGroupFromDB(null, manualActivity);
     replayAll();
     assertNull(service.getPeerGroup(run1Workgroup1, manualActivity));
     verifyAll();
@@ -189,10 +189,9 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
   public void getPeerGroup_ManualLogicPeerGroupExists_ReturnPeerGroup() throws Exception {
     PeerGroup peerGroup = new PeerGroupImpl(manualActivity, run1Period1,
         new HashSet<Workgroup>(Arrays.asList(run1Workgroup1, run1Workgroup2)));
-    expectPeerGroupFromDB(peerGroup, run1Workgroup1, manualActivity);
+    expectPeerGroupFromDB(peerGroup, manualActivity);
     replayAll();
-    PeerGroup actualPeerGroup = service.getPeerGroup(run1Workgroup1, manualActivity);
-    assertEquals(peerGroup, actualPeerGroup);
+    assertEquals(peerGroup, service.getPeerGroup(run1Workgroup1, manualActivity));
     verifyAll();
   }
 
@@ -288,12 +287,11 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
   }
 
   private void expectPeerGroupFromDB(PeerGroup peerGroup) {
-    expect(peerGroupDao.getByWorkgroupAndActivity(run1Workgroup1, activity)).andReturn(peerGroup);
+    expectPeerGroupFromDB(peerGroup, activity);
   }
 
-  private void expectPeerGroupFromDB(PeerGroup peerGroup, Workgroup workgroup,
-      PeerGroupActivity activity) {
-    expect(peerGroupDao.getByWorkgroupAndActivity(workgroup, activity)).andReturn(peerGroup);
+  private void expectPeerGroupFromDB(PeerGroup peerGroup, PeerGroupActivity activity) {
+    expect(peerGroupDao.getByWorkgroupAndActivity(run1Workgroup1, activity)).andReturn(peerGroup);
   }
 
   private void expectWorkForComponentByWorkgroup(List<StudentWork> expectedWork)

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 import static org.easymock.EasyMock.*;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -80,7 +81,7 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
   @Mock
   private StudentWorkDao<StudentWork> studentWorkDao;
 
-  PeerGroupActivity activity;
+  PeerGroupActivity activity, manualActivity;
 
   PeerGroup peerGroup;
 
@@ -91,6 +92,7 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
     super.setUp();
     PeerGroupServiceTestHelper testHelper = new PeerGroupServiceTestHelper(run1, run1Component2);
     activity = testHelper.activity;
+    manualActivity = testHelper.manualActivity;
     peerGroup = testHelper.peerGroup1;
     peerGroups = testHelper.peerGroups;
   }
@@ -172,6 +174,25 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
     expectLastCall();
     replayAll();
     assertEquals(2, service.getPeerGroup(run1Workgroup1, activity).getMembers().size());
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_ManualLogicPeerGroupNotExist_ReturnNull() throws Exception {
+    expectPeerGroupFromDB(null, run1Workgroup1, manualActivity);
+    replayAll();
+    assertNull(service.getPeerGroup(run1Workgroup1, manualActivity));
+    verifyAll();
+  }
+
+  @Test
+  public void getPeerGroup_ManualLogicPeerGroupExists_ReturnPeerGroup() throws Exception {
+    PeerGroup peerGroup = new PeerGroupImpl(manualActivity, run1Period1,
+        new HashSet<Workgroup>(Arrays.asList(run1Workgroup1, run1Workgroup2)));
+    expectPeerGroupFromDB(peerGroup, run1Workgroup1, manualActivity);
+    replayAll();
+    PeerGroup actualPeerGroup = service.getPeerGroup(run1Workgroup1, manualActivity);
+    assertEquals(peerGroup, actualPeerGroup);
     verifyAll();
   }
 
@@ -268,6 +289,11 @@ public class PeerGroupServiceImplTest extends WISEServiceTest {
 
   private void expectPeerGroupFromDB(PeerGroup peerGroup) {
     expect(peerGroupDao.getByWorkgroupAndActivity(run1Workgroup1, activity)).andReturn(peerGroup);
+  }
+
+  private void expectPeerGroupFromDB(PeerGroup peerGroup, Workgroup workgroup,
+      PeerGroupActivity activity) {
+    expect(peerGroupDao.getByWorkgroupAndActivity(workgroup, activity)).andReturn(peerGroup);
   }
 
   private void expectWorkForComponentByWorkgroup(List<StudentWork> expectedWork)

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
@@ -24,10 +24,11 @@
 package org.wise.portal.service.peergroup.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.wise.portal.dao.Component;
 import org.wise.portal.domain.peergroup.PeerGroup;
@@ -44,23 +45,7 @@ import org.wise.portal.service.WISEServiceTest;
  */
 public class PeerGroupServiceTestHelper extends WISEServiceTest {
 
-  String logic = "[{\"name\": \"maximizeDifferentIdeas\"," +
-      "\"nodeId\": \"" + run1Node1Id + "\", \"componentId\": \"" + run1Component1Id + "\"}]";
-
-  int logicThresholdCount = 3;
-
-  int logicThresholdPercent = 50;
-
-  int maxMembershipCount = 2;
-
-  String peerGroupActivityComponentString =
-      "{\"id\":\"" + run1Component2Id + "\"," +
-      "\"logic\":" + logic + "," +
-      "\"logicThresholdCount\":" + logicThresholdCount + "," +
-      "\"logicThresholdPercent\":" + logicThresholdPercent + "," +
-      "\"maxMembershipCount\":" + maxMembershipCount + "}";
-
-  PeerGroupActivity activity;
+  PeerGroupActivity activity, manualActivity;
 
   PeerGroup peerGroup1, peerGroup2, peerGroup3;
 
@@ -68,13 +53,56 @@ public class PeerGroupServiceTestHelper extends WISEServiceTest {
 
   public PeerGroupServiceTestHelper(Run run, Component component) throws Exception {
     super.setUp();
-    activity = new PeerGroupActivityImpl(run, component.nodeId,
-        new ProjectComponent(new JSONObject(peerGroupActivityComponentString)));
-    Set<Workgroup> members = new HashSet<Workgroup>();
-    members.add(run1Workgroup1);
-    members.add(run1Workgroup2);
-    peerGroup1 = new PeerGroupImpl(activity, run1Period1, members);
+    activity = createPeerGroupActivity(run, component, run1Component2Id, "maximizeDifferentIdeas",
+        run1Node1Id, run1Component1Id, 3, 50, 2);
+    peerGroup1 = new PeerGroupImpl(activity, run1Period1,
+        new HashSet<Workgroup>(Arrays.asList(run1Workgroup1, run1Workgroup2)));
     peerGroups.add(peerGroup1);
     peerGroup2 = new PeerGroupImpl(activity, run1Period1, new HashSet<Workgroup>());
+    manualActivity = createPeerGroupActivity(run, component, run1Component2Id, "manual",
+        run1Node1Id, run1Component1Id, 2, 50, 2);
+  }
+
+  public PeerGroupActivity createPeerGroupActivity(Run run, Component component, String componentId,
+      String logicName, String logicNodeId, String logicComponentId, Integer logicThresholdCount,
+      Integer logicThresholdPercent, Integer maxMembershipCount) throws JSONException {
+    String peerGroupActivityComponentString = createPeerGroupActivityComponentString(componentId,
+        logicName, logicNodeId, logicComponentId, logicThresholdCount, logicThresholdPercent,
+        maxMembershipCount);
+    return new PeerGroupActivityImpl(run, component.nodeId,
+        new ProjectComponent(new JSONObject(peerGroupActivityComponentString)));
+  }
+
+  public String createPeerGroupActivityComponentString(String componentId, String logicName,
+      String logicNodeId, String logicComponentId, Integer logicThresholdCount,
+      Integer logicThresholdPercent, Integer maxMembershipCount) {
+    String logic = createLogicString(logicName, logicNodeId, logicComponentId);
+    return createPeerGroupActivityComponentString(componentId, logic, logicThresholdCount,
+        logicThresholdPercent, maxMembershipCount);
+  }
+
+  public String createPeerGroupActivityComponentString(String componentId, String logic,
+      Integer logicThresholdCount, Integer logicThresholdPercent, Integer maxMembershipCount) {
+    return new StringBuilder()
+        .append("{")
+        .append("  \"id\": \"" + componentId + "\",")
+        .append("  \"logic\": " + logic + ",")
+        .append("  \"logicThresholdCount\": \"" + logicThresholdCount + "\",")
+        .append("  \"logicThresholdPercent\": \"" + logicThresholdPercent + "\",")
+        .append("  \"maxMembershipCount\": \"" + maxMembershipCount + "\"")
+        .append("}")
+        .toString();
+  }
+
+  public String createLogicString(String name, String nodeId, String componentId) {
+    return new StringBuilder()
+        .append("[")
+        .append("  {")
+        .append("    \"name\": \"" + name + "\",")
+        .append("    \"nodeId\": \"" + nodeId + "\",")
+        .append("    \"componentId\": \"" + componentId + "\"")
+        .append("  }")
+        .append("]")
+        .toString();
   }
 }

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTestHelper.java
@@ -42,6 +42,7 @@ import org.wise.portal.service.WISEServiceTest;
 
 /**
  * @author Hiroki Terashima
+ * @author Geoffrey Kwan
  */
 public class PeerGroupServiceTestHelper extends WISEServiceTest {
 
@@ -63,7 +64,7 @@ public class PeerGroupServiceTestHelper extends WISEServiceTest {
         run1Node1Id, run1Component1Id, 2, 50, 2);
   }
 
-  public PeerGroupActivity createPeerGroupActivity(Run run, Component component, String componentId,
+  private PeerGroupActivity createPeerGroupActivity(Run run, Component component, String componentId,
       String logicName, String logicNodeId, String logicComponentId, Integer logicThresholdCount,
       Integer logicThresholdPercent, Integer maxMembershipCount) throws JSONException {
     String peerGroupActivityComponentString = createPeerGroupActivityComponentString(componentId,
@@ -73,7 +74,7 @@ public class PeerGroupServiceTestHelper extends WISEServiceTest {
         new ProjectComponent(new JSONObject(peerGroupActivityComponentString)));
   }
 
-  public String createPeerGroupActivityComponentString(String componentId, String logicName,
+  private String createPeerGroupActivityComponentString(String componentId, String logicName,
       String logicNodeId, String logicComponentId, Integer logicThresholdCount,
       Integer logicThresholdPercent, Integer maxMembershipCount) {
     String logic = createLogicString(logicName, logicNodeId, logicComponentId);
@@ -81,7 +82,7 @@ public class PeerGroupServiceTestHelper extends WISEServiceTest {
         logicThresholdPercent, maxMembershipCount);
   }
 
-  public String createPeerGroupActivityComponentString(String componentId, String logic,
+  private String createPeerGroupActivityComponentString(String componentId, String logic,
       Integer logicThresholdCount, Integer logicThresholdPercent, Integer maxMembershipCount) {
     return new StringBuilder()
         .append("{")
@@ -94,7 +95,7 @@ public class PeerGroupServiceTestHelper extends WISEServiceTest {
         .toString();
   }
 
-  public String createLogicString(String name, String nodeId, String componentId) {
+  private String createLogicString(String name, String nodeId, String componentId) {
     return new StringBuilder()
         .append("[")
         .append("  {")


### PR DESCRIPTION
As a student, make a request to get your Peer Group for a Peer Activity that uses manual assignment.

If the Peer Group exists, make sure the it is retrieved.
If the Peer Group does not exist, make sure it does not automatically create the Peer Group.

Closes #74