### PR TITLE
feat(PeerGroup): Add teacher endpoint to remove member from PeerGroup

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupMembershipController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupMembershipController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,13 +30,22 @@ public class PeerGroupMembershipController {
   @PostMapping("/add/{peerGroupId}/{workgroupId}")
   PeerGroup addMember(@PathVariable("peerGroupId") PeerGroupImpl peerGroup,
       @PathVariable("workgroupId") WorkgroupImpl workgroup, Authentication auth) {
-    if (canAddMember(peerGroup, workgroup, auth)) {
+    if (canChangeMembership(peerGroup, workgroup, auth)) {
       return peerGroupMembershipService.addMember(peerGroup, workgroup);
     }
     throw new AccessDeniedException("Not permitted");
   }
 
-  private boolean canAddMember(PeerGroupImpl peerGroup, WorkgroupImpl workgroup,
+  @DeleteMapping("/{peerGroupId}/{workgroupId}")
+  PeerGroup removeMember(@PathVariable("peerGroupId") PeerGroupImpl peerGroup,
+      @PathVariable("workgroupId") WorkgroupImpl workgroup, Authentication auth) {
+    if (canChangeMembership(peerGroup, workgroup, auth)) {
+      return peerGroupMembershipService.removeMember(peerGroup, workgroup);
+    }
+    throw new AccessDeniedException("Not permitted");
+  }
+
+  private boolean canChangeMembership(PeerGroupImpl peerGroup, WorkgroupImpl workgroup,
       Authentication auth) {
     Run peerGroupActivityRun = peerGroup.getPeerGroupActivity().getRun();
     return runService.hasWritePermission(auth, peerGroupActivityRun) &&

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupMembershipService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupMembershipService.java
@@ -16,4 +16,13 @@ public interface PeerGroupMembershipService {
    * @return PeerGroup updated PeerGroup
    */
   PeerGroup addMember(PeerGroup peerGroup, Workgroup workgroup);
+
+  /**
+   * Remove a workgroup from the PeerGroup. If the workgroup is not a member of the PeerGroup,
+   * do nothing.
+   * @param peerGroup PeerGroup to remove workgroup from membership
+   * @param workgroup Workgroup to remove from PeerGroup
+   * @return PeerGroup updated PeerGroup
+   */
+  PeerGroup removeMember(PeerGroup peerGroup, Workgroup workgroup);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImpl.java
@@ -27,8 +27,9 @@ public class PeerGroupMembershipServiceImpl implements PeerGroupMembershipServic
     return peerGroup;
   }
 
-  private void removeMember(PeerGroup peerGroup, Workgroup workgroup) {
+  public PeerGroup removeMember(PeerGroup peerGroup, Workgroup workgroup) {
     peerGroup.removeMember(workgroup);
     peerGroupDao.save(peerGroup);
+    return peerGroup;
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupMembershipControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupMembershipControllerTest.java
@@ -53,9 +53,45 @@ public class PeerGroupMembershipControllerTest extends AbstractPeerGroupAPIContr
     verifyAll();
   }
 
+  @Test
+  public void removeMember_UserHasNoWritePermission_ThrowAccessDenied() {
+    expectUserHasRunWritePermission(false);
+    replayAll();
+    try {
+      controller.removeMember(peerGroup1, workgroup1, teacherAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void removeMember_WorkgroupNotInRun_ThrowAccessDenied() {
+    expectUserHasRunWritePermission(true);
+    replayAll();
+    try {
+      controller.removeMember(peerGroup1, workgroup3, teacherAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void removeMember_ReturnModifiedGroup() {
+    expectUserHasRunWritePermission(true);
+    expectRemoveMember();
+    replayAll();
+    controller.removeMember(peerGroup1, workgroup1, teacherAuth);
+    verifyAll();
+  }
 
   private void expectAddMember() {
     expect(peerGroupMembershipService.addMember(peerGroup1, workgroup1)).andReturn(peerGroup1);
+  }
+
+  private void expectRemoveMember() {
+    expect(peerGroupMembershipService.removeMember(peerGroup1, workgroup1)).andReturn(peerGroup1);
   }
 
   @Override

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImplTest.java
@@ -56,6 +56,15 @@ public class PeerGroupMembershipServiceImplTest extends WISEServiceTest {
     verify(peerGroupDao);
   }
 
+  @Test
+  public void removeMember_ReturnUpdatedGroup() {
+    expectSavePeerGroup(1);
+    replay(peerGroupDao);
+    PeerGroup peerGroup = service.removeMember(testHelper.peerGroup1, run1Workgroup1);
+    assertEquals(2, peerGroup.getMembers().size());
+    verify(peerGroupDao);
+  }
+
   private void expectSavePeerGroup(int times) {
     peerGroupDao.save(isA(PeerGroupImpl.class));
     expectLastCall().times(times);

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImplTest.java
@@ -53,8 +53,10 @@ public class PeerGroupMembershipServiceImplTest extends PeerGroupServiceTest {
   public void removeMember_ReturnUpdatedGroup() {
     expectSavePeerGroup(1);
     replay(peerGroupDao);
-    PeerGroup peerGroup = service.removeMember(testHelper.peerGroup1, run1Workgroup1);
-    assertEquals(2, peerGroup.getMembers().size());
+    assertEquals(2, peerGroup1.getMembers().size());
+    PeerGroup peerGroup = service.removeMember(peerGroup1, run1Workgroup1);
+    assertEquals(1, peerGroup.getMembers().size());
+    assertEquals(1, peerGroup1.getMembers().size());
     verify(peerGroupDao);
   }
 


### PR DESCRIPTION
## Changes
- Added a new DELETE endpoint for teachers to remove a member from a PeerGroup at 
```/api/peer-group/membership/{peerGroupId}/{workgroupId}```

## Test
- Make a DELETE request to ```/api/peer-group/membership/{peerGroupId}/{workgroupId}```
   - The endpoint should throw AccessDeniedException if 
      - user does not have write permission on the run
      - workgroup was not in the run that is associated with the Peer Group 
   - If the workgroup is not a member of the PeerGroup, do nothing and return the PeerGroup
   - Otherwise, remove the workgroup from the PeerGroup and return the modified PeerGroup
