### PR TITLE
feat(Get Classmate Work): Create endpoint for classmate Graph work

### DIFF
--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
@@ -23,6 +23,7 @@
  */
 package org.wise.portal.domain.project.impl;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -52,5 +53,9 @@ public class ProjectComponent {
 
   public int getInt(String key) throws JSONException {
     return this.componentJSON.getInt(key);
+  }
+
+  public JSONArray getJSONArray(String key) throws JSONException {
+    return this.componentJSON.getJSONArray(key);
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
@@ -44,7 +44,6 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
       @PathVariable String componentId) throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
-
       return getAnnotations(run, period, nodeId, componentId);
     } else {
       throw new AccessDeniedException(NOT_PERMITTED);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.vle.domain.annotation.wise5.Annotation;
 import org.wise.vle.domain.work.StudentWork;
 
@@ -25,10 +26,10 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
   String DISCUSSION_TYPE = "Discussion";
 
   @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}")
-  public List<StudentWork> getClassmateDiscussionWork(Authentication auth, @PathVariable Long runId,
-      @PathVariable Long periodId, @PathVariable String nodeId, @PathVariable String componentId)
+  public List<StudentWork> getClassmateDiscussionWork(Authentication auth,
+      @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
+      @PathVariable String componentId)
       throws IOException, JSONException, ObjectNotFoundException {
-    Run run = runService.retrieveById(runId);
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
       return getStudentWork(run, period, nodeId, componentId);
@@ -39,11 +40,11 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
 
   @GetMapping("/annotations/{runId}/{periodId}/{nodeId}/{componentId}")
   public List<Annotation> getClassmateDiscussionAnnotations(Authentication auth,
-      @PathVariable Long runId, @PathVariable Long periodId, @PathVariable String nodeId,
+      @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
       @PathVariable String componentId) throws IOException, JSONException, ObjectNotFoundException {
-    Run run = runService.retrieveById(runId);
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
+
       return getAnnotations(run, period, nodeId, componentId);
     } else {
       throw new AccessDeniedException(NOT_PERMITTED);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataController.java
@@ -1,0 +1,91 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
+import org.wise.vle.domain.work.StudentWork;
+
+@RestController
+@Secured("ROLE_STUDENT")
+@RequestMapping("/api/classmate/graph")
+public class ClassmateGraphDataController extends ClassmateDataController {
+
+  final String CLASS_SOURCE = "class";
+  final String GRAPH_TYPE = "Graph";
+  final String PERIOD_SOURCE = "period";
+  final String SHOW_CLASSMATE_WORK_TYPE = "showClassmateWork";
+
+  @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{showWorkNodeId}/{showWorkComponentId}/{showClassmateWorkSource}")
+  public List<StudentWork> getClassmateGraphWork(Authentication auth,
+      @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
+      @PathVariable String componentId, @PathVariable String showWorkNodeId,
+      @PathVariable String showWorkComponentId, @PathVariable String showClassmateWorkSource)
+      throws IOException, JSONException, ObjectNotFoundException {
+    Group period = groupService.retrieveById(periodId);
+    if (isAllowedToGetData(auth, run, period, nodeId, componentId, showWorkNodeId,
+        showWorkComponentId, showClassmateWorkSource)) {
+      if (showClassmateWorkSource.equals(PERIOD_SOURCE)) {
+        return getStudentWork(run, period, showWorkNodeId, showWorkComponentId);
+      } else if (showClassmateWorkSource.equals(CLASS_SOURCE)) {
+        return getStudentWork(run, showWorkNodeId, showWorkComponentId);
+      }
+    }
+    throw new AccessDeniedException(NOT_PERMITTED);
+  }
+
+  private boolean isAllowedToGetData(Authentication auth, Run run, Group period, String nodeId,
+      String componentId, String showWorkNodeId, String showWorkComponentId,
+      String showClassmateWorkSource) throws IOException, JSONException, ObjectNotFoundException {
+    return isUserInRunAndPeriod(auth, run, period) && isValidGraphComponent(run, nodeId,
+        componentId, showWorkNodeId, showWorkComponentId, showClassmateWorkSource);
+  }
+
+  private boolean isValidGraphComponent(Run run, String nodeId, String componentId,
+      String showWorkNodeId, String showWorkComponentId, String showClassmateWorkSource)
+      throws IOException, JSONException, ObjectNotFoundException {
+    ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
+    return isGraphComponent(projectComponent) && hasMatchingConnectedComponent(projectComponent,
+        showWorkNodeId, showWorkComponentId, showClassmateWorkSource);
+  }
+
+  private boolean isGraphComponent(ProjectComponent projectComponent) throws JSONException {
+    return GRAPH_TYPE.equals(projectComponent.getString("type"));
+  }
+
+  private boolean hasMatchingConnectedComponent(ProjectComponent projectComponent,
+      String showWorkNodeId, String showWorkComponentId, String showClassmateWorkSource)
+      throws JSONException {
+    JSONArray connectedComponents = projectComponent.getJSONArray("connectedComponents");
+    for (int c = 0; c < connectedComponents.length(); c++) {
+      JSONObject connectedComponent = connectedComponents.getJSONObject(c);
+      if (isMatchingConnectedComponent(connectedComponent, showWorkNodeId, showWorkComponentId,
+          showClassmateWorkSource)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isMatchingConnectedComponent(JSONObject connectedComponent, String showWorkNodeId,
+      String showWorkComponentId, String showClassmateWorkSource) throws JSONException {
+    return connectedComponent.getString("nodeId").equals(showWorkNodeId)
+        && connectedComponent.getString("componentId").equals(showWorkComponentId)
+        && connectedComponent.getString("type").equals(SHOW_CLASSMATE_WORK_TYPE)
+        && connectedComponent.getString("showClassmateWorkSource").equals(showClassmateWorkSource);
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
@@ -15,6 +15,7 @@ import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.vle.domain.annotation.wise5.Annotation;
 import org.wise.vle.domain.work.StudentWork;
 
@@ -28,11 +29,11 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
   final String SUMMARY_TYPE = "Summary";
 
   @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}/{source}")
-  public List<StudentWork> getClassmateSummaryWork(Authentication auth, @PathVariable Long runId,
-      @PathVariable Long periodId, @PathVariable String nodeId, @PathVariable String componentId,
-      @PathVariable String otherNodeId, @PathVariable String otherComponentId,
-      @PathVariable String source) throws IOException, JSONException, ObjectNotFoundException {
-    Run run = runService.retrieveById(runId);
+  public List<StudentWork> getClassmateSummaryWork(Authentication auth,
+      @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
+      @PathVariable String componentId, @PathVariable String otherNodeId,
+      @PathVariable String otherComponentId, @PathVariable String source)
+      throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
       if (PERIOD_SOURCE.equals(source)) {
@@ -46,11 +47,10 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
 
   @GetMapping("/annotations/{runId}/{periodId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}/{source}")
   public List<Annotation> getClassmateSummaryAnnotations(Authentication auth,
-      @PathVariable Long runId, @PathVariable Long periodId, @PathVariable String nodeId,
+      @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
       @PathVariable String componentId, @PathVariable String otherNodeId,
       @PathVariable String otherComponentId, @PathVariable String source)
       throws IOException, JSONException, ObjectNotFoundException {
-    Run run = runService.retrieveById(runId);
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
       if (PERIOD_SOURCE.equals(source)) {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
@@ -49,7 +49,6 @@ public abstract class AbstractClassmateDataControllerTest extends APIControllerT
 
   protected void expectIsUserInRun(boolean isInRun)
       throws NoSuchMethodException, ObjectNotFoundException {
-    expect(runService.retrieveById(runId1)).andReturn(run1);
     expect(groupService.retrieveById(run1Period1Id)).andReturn(run1Period1);
     expect(userService.retrieveUser(student1UserDetails)).andReturn(student1);
     expect(runService.isUserInRunAndPeriod(student1, run1, run1Period1)).andReturn(isInRun);

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataControllerTest.java
@@ -29,7 +29,7 @@ public class ClassmateDiscussionDataControllerTest extends AbstractClassmateData
     expectIsUserInRun(false);
     replayAll();
     assertThrows(AccessDeniedException.class, () -> controller
-        .getClassmateDiscussionWork(studentAuth, runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1));
+        .getClassmateDiscussionWork(studentAuth, run1, run1Period1Id, NODE_ID1, COMPONENT_ID1));
     verifyAll();
   }
 
@@ -40,7 +40,7 @@ public class ClassmateDiscussionDataControllerTest extends AbstractClassmateData
     expectComponentType(OPEN_RESPONSE_TYPE);
     replayAll();
     assertThrows(AccessDeniedException.class, () -> controller
-        .getClassmateDiscussionWork(studentAuth, runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1));
+        .getClassmateDiscussionWork(studentAuth, run1, run1Period1Id, NODE_ID1, COMPONENT_ID1));
     verifyAll();
   }
 
@@ -54,7 +54,7 @@ public class ClassmateDiscussionDataControllerTest extends AbstractClassmateData
     replayAll();
     try {
       List<StudentWork> classmateDiscussionWork = controller.getClassmateDiscussionWork(studentAuth,
-          runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1);
+          run1, run1Period1Id, NODE_ID1, COMPONENT_ID1);
       assertEquals(classmateDiscussionWork, studentWork);
     } catch (Exception e) {
       fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
@@ -72,7 +72,7 @@ public class ClassmateDiscussionDataControllerTest extends AbstractClassmateData
     replayAll();
     try {
       List<Annotation> classmateDiscussionAnnotations = controller
-          .getClassmateDiscussionAnnotations(studentAuth, runId1, run1Period1Id, NODE_ID1,
+          .getClassmateDiscussionAnnotations(studentAuth, run1, run1Period1Id, NODE_ID1,
               COMPONENT_ID1);
       assertEquals(classmateDiscussionAnnotations, annotations);
     } catch (Exception e) {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataControllerTest.java
@@ -1,0 +1,141 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.vle.domain.work.StudentWork;
+
+@RunWith(EasyMockRunner.class)
+public class ClassmateGraphDataControllerTest extends AbstractClassmateDataControllerTest {
+
+  String SHOW_WORK_COMPONENT_ID = "component2";
+  String SHOW_WORK_COMPONENT_ID_NOT_ALLOWED = "component3";
+  String SHOW_WORK_NODE_ID = "node2";
+  String SHOW_WORK_NODE_ID_NOT_ALLOWED = "node3";
+
+  @TestSubject
+  private ClassmateGraphDataController controller = new ClassmateGraphDataController();
+
+  @Test
+  public void getClassmateGraphWork_NotInRun_ThrowException()
+      throws NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(false);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateGraphWork(studentAuth, run1, run1Period1Id, NODE_ID1,
+            COMPONENT_ID1, SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID, controller.PERIOD_SOURCE));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateGraphWork_NotGraphComponent_ThrowException()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(OPEN_RESPONSE_TYPE);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateGraphWork(studentAuth, run1, run1Period1Id, NODE_ID1,
+            COMPONENT_ID1, SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID, controller.PERIOD_SOURCE));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateGraphWork_InvalidNodeId_ThrowException()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateGraphWork_InvalidField_ThrowException(SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID,
+        controller.PERIOD_SOURCE, SHOW_WORK_NODE_ID_NOT_ALLOWED, SHOW_WORK_COMPONENT_ID,
+        controller.PERIOD_SOURCE);
+  }
+
+  @Test
+  public void getClassmateGraphWork_InvalidComponentId_ThrowException()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateGraphWork_InvalidField_ThrowException(SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID,
+        controller.PERIOD_SOURCE, SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID_NOT_ALLOWED,
+        controller.PERIOD_SOURCE);
+  }
+
+  @Test
+  public void getClassmateGraphWork_InvalidSource_ThrowException()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    getClassmateGraphWork_InvalidField_ThrowException(SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID,
+        controller.PERIOD_SOURCE, SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID,
+        controller.CLASS_SOURCE);
+  }
+
+  private void getClassmateGraphWork_InvalidField_ThrowException(String actualNodeId,
+      String actualComponentId, String actualSource, String requestedNodeId,
+      String requestedComponentId, String requestedSource)
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.GRAPH_TYPE, actualNodeId,
+        actualComponentId, controller.SHOW_CLASSMATE_WORK_TYPE, actualSource);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateGraphWork(studentAuth, run1, run1Period1Id, NODE_ID1,
+            COMPONENT_ID1, requestedNodeId, requestedComponentId, requestedSource));
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateGraphWork_ValidParams_ReturnWork()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    expectIsUserInRun(true);
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.GRAPH_TYPE, SHOW_WORK_NODE_ID,
+        SHOW_WORK_COMPONENT_ID, controller.SHOW_CLASSMATE_WORK_TYPE, controller.PERIOD_SOURCE);
+    List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
+    expectStudentWork(run1, run1Period1, SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID, studentWork);
+    replayAll();
+    try {
+      List<StudentWork> classmateGraphWork = controller.getClassmateGraphWork(studentAuth, run1,
+          run1Period1Id, NODE_ID1, COMPONENT_ID1, SHOW_WORK_NODE_ID, SHOW_WORK_COMPONENT_ID,
+          controller.PERIOD_SOURCE);
+      assertEquals(classmateGraphWork, studentWork);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  protected void expectComponentType(String nodeId, String componentId, String componentType,
+      String connectedComponentNodeId, String connectedComponentComponentId,
+      String connectedComponentType, String showClassmateWorkSource)
+      throws IOException, ObjectNotFoundException {
+    String projectJSONString = new StringBuilder()
+        .append("{")
+        .append("  \"nodes\": [")
+        .append("    {")
+        .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"components\": [")
+        .append("        {")
+        .append("          \"id\": \"" + componentId + "\",")
+        .append("          \"type\": \"" + componentType + "\",")
+        .append("          \"connectedComponents\": [")
+        .append("            {")
+        .append("              \"nodeId\": \"" + connectedComponentNodeId + "\",")
+        .append("              \"componentId\": \"" + connectedComponentComponentId + "\",")
+        .append("              \"type\": \"" + connectedComponentType + "\",")
+        .append("              \"showClassmateWorkSource\": \"" + showClassmateWorkSource + "\"")
+        .append("            }")
+        .append("          ]")
+        .append("        }")
+        .append("      ]")
+        .append("    }")
+        .append("  ]")
+        .append("}")
+        .toString();
+    expect(projectService.getProjectContent(project1)).andReturn(projectJSONString);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
@@ -35,7 +35,7 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
     expectIsUserInRun(false);
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth, runId1, run1Period1Id, NODE_ID1,
+        () -> controller.getClassmateSummaryWork(studentAuth, run1, run1Period1Id, NODE_ID1,
             COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
     verifyAll();
   }
@@ -47,7 +47,7 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
     expectComponentType(OPEN_RESPONSE_TYPE);
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth, runId1, run1Period1Id, NODE_ID1,
+        () -> controller.getClassmateSummaryWork(studentAuth, run1, run1Period1Id, NODE_ID1,
             COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
     verifyAll();
   }
@@ -60,7 +60,7 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
         OTHER_COMPONENT_ID, controller.PERIOD_SOURCE);
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth, runId1, run1Period1Id, NODE_ID1,
+        () -> controller.getClassmateSummaryWork(studentAuth, run1, run1Period1Id, NODE_ID1,
             COMPONENT_ID1, OTHER_NODE_ID_NOT_ALLOWED, OTHER_COMPONENT_ID_NOT_ALLOWED,
             controller.PERIOD_SOURCE));
     verifyAll();
@@ -92,7 +92,7 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
     replayAll();
     try {
       List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWork(studentAuth,
-          runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID,
+          run1, run1Period1Id, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID, OTHER_COMPONENT_ID,
           source);
       assertEquals(classmateSummaryWork, studentWork);
     } catch (Exception e) {
@@ -129,7 +129,7 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
     replayAll();
     try {
       List<Annotation> classmateSummaryAnnotations = controller.getClassmateSummaryAnnotations(
-          studentAuth, runId1, run1Period1Id, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID,
+          studentAuth, run1, run1Period1Id, NODE_ID1, COMPONENT_ID1, OTHER_NODE_ID,
           OTHER_COMPONENT_ID, source);
       assertEquals(classmateSummaryAnnotations, annotations);
     } catch (Exception e) {


### PR DESCRIPTION
Review https://github.com/WISE-Community/WISE-Client/pull/438 before reviewing this PR to make it easier to test this PR.

Author a project/run to have
- Graph component 1
- Graph component 2 that shows period classmate work from Graph component 1
- Graph component 3 that shows class classmate work from Graph component 1

1. Log in as a student
2. In a different tab, go to the Graph student work endpoint (shown below) using the id values from your Graph components
3. Make sure the endpoint returns all the Graph work for that period
4. Modify the endpoint to get the Classmate Graph work from the whole class (shown below, just change the last parameter from period to class)
5. Make sure the endpoint returns all the Graph work for the class (all periods)
6. Modify the endpoint to point to a component that is not a Graph 
7. Make sure the endpoint returns Access Denied

Classmate Graph work in period endpoint
```
http://localhost:81/api/classmate/graph/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{showWorkNodeId}/{showWorkComponentId}/period
```

Classmate Graph work in class endpoint
```
http://localhost:81/api/classmate/graph/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{showWorkNodeId}/{showWorkComponentId}/class
```

Closes #89