### PR TITLE
feat(PeerGroup): Create PeerGroupActivity from tag in project

### DIFF
--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectContent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectContent.java
@@ -23,6 +23,9 @@
  */
 package org.wise.portal.domain.project.impl;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -53,5 +56,32 @@ public class ProjectContent {
   public ProjectComponent getComponent(String nodeId, String componentId) throws JSONException {
     ProjectNode node = getNode(nodeId);
     return node != null ? node.getComponent(componentId) : null;
+  }
+
+  public Set<String> getPeerGroupActivityTags() throws JSONException {
+    Set<String> tags = new HashSet<String>();
+    JSONArray components = getComponents();
+    for (int j = 0; j < components.length(); j++) {
+      JSONObject component = components.getJSONObject(j);
+      if (component.has("peerGroupActivityTag")) {
+        tags.add(component.getString("peerGroupActivityTag"));
+      }
+    }
+    return tags;
+  }
+
+  private JSONArray getComponents() throws JSONException {
+    JSONArray components = new JSONArray();
+    JSONArray nodes = this.projectJSON.getJSONArray("nodes");
+    for (int i = 0; i < nodes.length(); i++) {
+      JSONObject node = nodes.getJSONObject(i);
+      if (node.has("components")) {
+        JSONArray nodeComponents = node.getJSONArray("components");
+        for (int j = 0; j < nodeComponents.length(); j++) {
+          components.put(nodeComponents.get(j));
+        }
+      }
+    }
+    return components;
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -80,6 +80,7 @@ import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.presentation.web.response.ErrorResponse;
 import org.wise.portal.presentation.web.response.SimpleResponse;
 import org.wise.portal.presentation.web.response.SuccessResponse;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.portal.PortalService;
 import org.wise.portal.service.project.ProjectService;
 import org.wise.portal.service.run.RunService;
@@ -104,6 +105,9 @@ public class AuthorAPIController {
 
   @Autowired
   protected UserService userService;
+
+  @Autowired
+  protected PeerGroupActivityService peerGroupActivityService;
 
   @Autowired
   protected ProjectService projectService;
@@ -251,12 +255,21 @@ public class AuthorAPIController {
         projectService.saveProjectContentToDisk(projectJSONString, project);
         projectService.updateMetadataAndLicenseIfNecessary(project, projectJSONString);
         projectService.saveProjectToDatabase(project, user, projectJSONString);
+        scanForPeerGroupActivities(project);
         return new SuccessResponse("projectSaved");
       } catch (Exception e) {
         return new ErrorResponse("errorSavingProject");
       }
     } else {
       return new ErrorResponse("notAllowedToEditThisProject");
+    }
+  }
+
+  private void scanForPeerGroupActivities(ProjectImpl project) {
+    List<Run> projectRuns = runService.getProjectRuns(project.getId());
+    if (projectRuns.size() > 0) {
+      Run projectRun = projectRuns.get(0);
+      peerGroupActivityService.getByRun(projectRun);
     }
   }
 

--- a/src/main/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityService.java
+++ b/src/main/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityService.java
@@ -23,6 +23,8 @@
  */
 package org.wise.portal.service.peergroupactivity;
 
+import java.util.Set;
+
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.run.Run;
 
@@ -53,4 +55,11 @@ public interface PeerGroupActivityService {
    * @return PeerGroupActivity
    */
   PeerGroupActivity getByTag(Run run, String tag);
+
+  /**
+   * Retrieves PeerGroupActivity for the specified run. Scans run's project content for
+   * ProjectActivityTags and looks up the database for the PeerGroupActivity for that tag.
+   * If none is found, creates a new PeerGroupActivity for the tag.
+   */
+  Set<PeerGroupActivity> getByRun(Run run);
 }

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -66,6 +66,7 @@ import org.wise.portal.presentation.web.exception.TeacherAlreadySharedWithRunExc
 import org.wise.portal.presentation.web.response.SharedOwner;
 import org.wise.portal.service.acl.AclService;
 import org.wise.portal.service.authentication.UserDetailsService;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.portal.PortalService;
 import org.wise.portal.service.project.ProjectService;
 import org.wise.portal.service.run.DuplicateRunCodeException;
@@ -118,6 +119,9 @@ public class RunServiceImpl implements RunService {
 
   @Autowired
   private ProjectService projectService;
+
+  @Autowired
+  private PeerGroupActivityService peerGroupActivityService;
 
   @Transactional(readOnly = true)
   public List<Run> getRunList() {
@@ -241,6 +245,7 @@ public class RunServiceImpl implements RunService {
         maxStudentsPerTeam, startDate, endDate, isLockedAfterEndDate, locale);
     Run run = createRun(runParameters);
     createTeacherWorkgroup(run, user);
+    peerGroupActivityService.getByRun(run);
     return run;
   }
 

--- a/src/test/java/org/wise/portal/domain/project/ProjectContentTest.java
+++ b/src/test/java/org/wise/portal/domain/project/ProjectContentTest.java
@@ -1,0 +1,60 @@
+package org.wise.portal.domain.project;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.easymock.EasyMockRunner;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.domain.project.impl.ProjectContent;
+
+@RunWith(EasyMockRunner.class)
+public class ProjectContentTest {
+
+  ProjectContent content;
+
+  final String PROJECT_1 = "{\"nodes\":[" +
+      "{\"id\":\"node1\"," +
+          "\"components\":[" +
+              "{\"id\":\"c1\"}," +
+              "{\"id\":\"c2\", \"peerGroupActivityTag\":\"tag1\"}]}]}";
+
+  @Before
+  public void setup() throws JSONException {
+    content = new ProjectContent(new JSONObject(PROJECT_1));
+  }
+
+  @Test
+  public void getNode_NodeDoesNotExist_ReturnNull() throws JSONException {
+    assertNull(content.getNode("node_id_not_exists"));
+  }
+
+  @Test
+  public void getNode_NodeExists_ReturnNode() throws JSONException {
+    assertNotNull(content.getNode("node1"));
+  }
+
+  @Test
+  public void getComponent_ComponentDoesNotExist_ReturnNull() throws JSONException {
+    assertNull(content.getComponent("node1", "component_id_not_exists"));
+  }
+
+  @Test
+  public void getComponent_ComponentExists_ReturnComponent() throws JSONException {
+    assertNotNull(content.getComponent("node1", "c1"));
+  }
+
+  @Test
+  public void getPeerGroupActivityTags_ReturnTags() throws JSONException {
+    Set<String> tags = content.getPeerGroupActivityTags();
+    assertEquals(1, tags.size());
+    assertTrue(tags.contains("tag1"));
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIControllerTest.java
@@ -25,12 +25,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpSession;
+import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.portal.impl.PortalImpl;
 import org.wise.portal.domain.project.Project;
 import org.wise.portal.domain.project.impl.ProjectImpl;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.presentation.web.controllers.APIControllerTest;
 import org.wise.portal.presentation.web.response.SimpleResponse;
+import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.session.SessionService;
 import org.wise.portal.spring.data.redis.MessagePublisher;
 
@@ -42,6 +44,9 @@ public class AuthorAPIControllerTest extends APIControllerTest {
 
   @Mock
   private SessionService sessionService;
+
+  @Mock
+  private PeerGroupActivityService peerGroupActivityService;
 
   @Mock
   private MessagePublisher redisPublisher;
@@ -233,9 +238,8 @@ public class AuthorAPIControllerTest extends APIControllerTest {
   }
 
   @Test
-  public void saveProject_NoErrors_shouldReturnProjectSaved() throws Exception {
+  public void saveProject_NoAssociatedRun_shouldReturnProjectSaved() throws Exception {
     expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
-    replay(userService);
     project1.setMetadata("{\"title\":\"Old Title\"}");
     expect(projectService.canAuthorProject(project1, teacher1)).andReturn(true);
     projectService.evictProjectContentCache(projectId1);
@@ -247,13 +251,41 @@ public class AuthorAPIControllerTest extends APIControllerTest {
     expectLastCall();
     projectService.saveProjectToDatabase(project1, teacher1, projectJSONString);
     expectLastCall();
-    replay(projectService);
+    expect(runService.getProjectRuns(projectId1)).andReturn(new ArrayList<Run>());
+    replay(userService, projectService, runService);
     SimpleResponse response = authorAPIController.saveProject(teacherAuth, project1,
         projectJSONString);
     assertEquals("success", response.getStatus());
     assertEquals("projectSaved", response.getMessageCode());
-    verify(userService, projectService);
+    verify(userService, projectService, runService);
   }
+
+  @Test
+  public void saveProject_ProjectHasAssociatedRun_shouldScanForPeerGroupActivitiesAndReturnProjectSaved() throws Exception {
+    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
+    project1.setMetadata("{\"title\":\"Old Title\"}");
+    expect(projectService.canAuthorProject(project1, teacher1)).andReturn(true);
+    projectService.evictProjectContentCache(projectId1);
+    expectLastCall();
+    String projectJSONString = "{\"metadata\":{\"title\":\"New Title\"}}";
+    projectService.saveProjectContentToDisk(projectJSONString, project1);
+    expectLastCall();
+    projectService.updateMetadataAndLicenseIfNecessary(anyObject(), anyObject());
+    expectLastCall();
+    projectService.saveProjectToDatabase(project1, teacher1, projectJSONString);
+    expectLastCall();
+    List<Run> runsAssociatedWithProject = new ArrayList<Run>();
+    runsAssociatedWithProject.add(run1);
+    expect(runService.getProjectRuns(projectId1)).andReturn(runsAssociatedWithProject);
+    expect(peerGroupActivityService.getByRun(run1)).andReturn(new HashSet<PeerGroupActivity>());
+    replay(userService, projectService, runService, peerGroupActivityService);
+    SimpleResponse response = authorAPIController.saveProject(teacherAuth, project1,
+        projectJSONString);
+    assertEquals("success", response.getStatus());
+    assertEquals("projectSaved", response.getMessageCode());
+    verify(userService, projectService, runService, peerGroupActivityService);
+  }
+
 
   @Test
   public void getAssetFileNames_withDuplicateReferences_shouldReturnUniqueFileNames()

--- a/src/test/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroupactivity/PeerGroupActivityServiceImplTest.java
@@ -84,12 +84,19 @@ public class PeerGroupActivityServiceImplTest {
 
   private int maxMembershipCount = 2;
 
+  String tagInDB = "existingPeerGroupActivityTag";
+
+  String tagNotInDB = "newPeerGroupActivityTag";
+
+  PeerGroupActivity peerGroupActivity = new PeerGroupActivityImpl();
+
   private String projectJSONString = "{\"nodes\":[{\"id\":\"" + nodeId + "\"," +
       "\"components\":[" +
       "{\"id\":\"" + componentIdWithPGActivity + "\",\"logic\":\"" + logic + "\"," +
       "\"logicThresholdCount\":\"" + logicThresholdCount + "\"," +
       "\"logicThresholdPercent\":\"" + logicThresholdPercent + "\"," +
-      "\"maxMembershipCount\":\"" + maxMembershipCount + "\"" +
+      "\"maxMembershipCount\":\"" + maxMembershipCount + "\"," +
+      "\"peerGroupActivityTag\":\"" + tagInDB + "\"" +
       "}, {\"id\":\"" + componentIdWithoutPGActivity + "\"}]}]}";
 
   @Before
@@ -148,7 +155,6 @@ public class PeerGroupActivityServiceImplTest {
 
   @Test
   public void getByTag_notInDB_SaveAndReturnNewPeerGroupActivity() {
-    String tagNotInDB = "newPeerGroupActivityTag";
     expect(peerGroupActivityDao.getByTag(run, tagNotInDB)).andReturn(null);
     peerGroupActivityDao.save(isA(PeerGroupActivity.class));
     expectLastCall();
@@ -160,11 +166,19 @@ public class PeerGroupActivityServiceImplTest {
 
   @Test
   public void getByTag_foundInDB_ReturnPeerGroupActivity() {
-    String tagInDB = "existingPeerGroupActivityTag";
-    PeerGroupActivity peerGroupActivity = new PeerGroupActivityImpl();
     expect(peerGroupActivityDao.getByTag(run, tagInDB)).andReturn(peerGroupActivity);
     replayAll();
     assertEquals(peerGroupActivity, service.getByTag(run, tagInDB));
+    verifyAll();
+  }
+
+  @Test
+  public void getByRun_ReturnPeerGroupActivitiesInRunProject() throws IOException {
+    expect(appProperties.getProperty("curriculum_base_dir")).andReturn("/var/curriculum");
+    expect(FileUtils.readFileToString(isA(File.class))).andReturn(projectJSONString);
+    expect(peerGroupActivityDao.getByTag(run, tagInDB)).andReturn(peerGroupActivity);
+    replayAll();
+    assertEquals(1, service.getByRun(run).size());
     verifyAll();
   }
 }


### PR DESCRIPTION
## Changes
When a peerGroupActivityTag is added in the project in the authoring tool or if a new run is created from the project that contains the tag, PeerGroupActivities are created for each tag.

## Test
- In the AT, add peerGroupActivityTag to a component for a Run project. It should create the tag (if not exists) in the db
- In the AT, add peerGroupActivityTag to a component for a regular project. It should still work as before
- Create a run using a Project that has peerGroupActivityTag's. It should create tags in the db for the new run
- Create a run using a Project that doesn't have peerGroupActivityTag's. It should create the new run

