### PR TITLE
refactor(PeerGroup): Use PeerGroupActivityTag to get PeerGroup

### DIFF
--- a/src/main/java/org/wise/portal/dao/peergroup/PeerGroupDao.java
+++ b/src/main/java/org/wise/portal/dao/peergroup/PeerGroupDao.java
@@ -28,7 +28,6 @@ import org.wise.portal.dao.SimpleDao;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
-import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 
 /**
@@ -39,10 +38,6 @@ public interface PeerGroupDao<T extends PeerGroup> extends SimpleDao<T> {
   PeerGroup getByWorkgroupAndActivity(Workgroup workgroup, PeerGroupActivity activity);
 
   List<PeerGroup> getListByActivity(PeerGroupActivity activity);
-
-  List<PeerGroup> getListByRun(Run run);
-
-  List<PeerGroup> getListByComponent(Run run, String nodeId, String componentId);
 
   List<PeerGroup> getListByWorkgroup(Workgroup workgroup);
 

--- a/src/main/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDao.java
+++ b/src/main/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDao.java
@@ -87,29 +87,17 @@ public class HibernatePeerGroupDao extends AbstractHibernateDao<PeerGroup>
 
   @Override
   public List<PeerGroup> getListByActivity(PeerGroupActivity activity) {
-    return getListByComponent(activity.getRun(), activity.getNodeId(), activity.getComponentId());
+    return getListByTag(activity.getRun(), activity.getTag());
   }
 
-  @Override
-  public List<PeerGroup> getListByRun(Run run) {
-    return getListByComponent(run, null, null);
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public List<PeerGroup> getListByComponent(Run run, String nodeId, String componentId) {
+  private List<PeerGroup> getListByTag(Run run, String tag) {
     CriteriaBuilder cb = getCriteriaBuilder();
     CriteriaQuery<PeerGroupImpl> cq = cb.createQuery(PeerGroupImpl.class);
     Root<PeerGroupImpl> peerGroupImplRoot = cq.from(PeerGroupImpl.class);
     Root<PeerGroupActivityImpl> peerGroupActivityImplRoot = cq.from(PeerGroupActivityImpl.class);
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.equal(peerGroupActivityImplRoot.get("run"), run.getId()));
-    if (nodeId != null) {
-      predicates.add(cb.equal(peerGroupActivityImplRoot.get("nodeId"), nodeId));
-    }
-    if (componentId != null) {
-      predicates.add(cb.equal(peerGroupActivityImplRoot.get("componentId"), componentId));
-    }
+    predicates.add(cb.equal(peerGroupActivityImplRoot.get("tag"), tag));
     predicates.add(cb.equal(peerGroupImplRoot.get("peerGroupActivity"),
         peerGroupActivityImplRoot.get("id")));
     cq.select(peerGroupImplRoot).where(predicates.toArray(new Predicate[predicates.size()]));

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
@@ -31,14 +31,12 @@ public class PeerGroupCreateController {
   @Autowired
   private RunService runService;
 
-  @PostMapping("/{runId}/{periodId}/{nodeId}/{componentId}")
+  @PostMapping("/{runId}/{periodId}/{peerGroupActivityTag}")
   PeerGroup create(@PathVariable("runId") RunImpl run,
-      @PathVariable("periodId") PersistentGroup period, @PathVariable String nodeId,
-      @PathVariable String componentId, Authentication auth)
-      throws PeerGroupActivityNotFoundException {
+      @PathVariable("periodId") PersistentGroup period, @PathVariable String peerGroupActivityTag,
+      Authentication auth) throws PeerGroupActivityNotFoundException {
     if (canCreatePeerGroup(run, period, auth)) {
-      PeerGroupActivity activity =
-          peerGroupActivityService.getByComponent(run, nodeId, componentId);
+      PeerGroupActivity activity = peerGroupActivityService.getByTag(run, peerGroupActivityTag);
       return peerGroupCreateService.create(activity, period);
     }
     throw new AccessDeniedException("Not permitted");

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateController.java
@@ -13,7 +13,6 @@ import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroupactivity.PeerGroupActivity;
 import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.service.peergroup.PeerGroupCreateService;
-import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.run.RunService;
 
@@ -34,7 +33,7 @@ public class PeerGroupCreateController {
   @PostMapping("/{runId}/{periodId}/{peerGroupActivityTag}")
   PeerGroup create(@PathVariable("runId") RunImpl run,
       @PathVariable("periodId") PersistentGroup period, @PathVariable String peerGroupActivityTag,
-      Authentication auth) throws PeerGroupActivityNotFoundException {
+      Authentication auth) {
     if (canCreatePeerGroup(run, period, auth)) {
       PeerGroupActivity activity = peerGroupActivityService.getByTag(run, peerGroupActivityTag);
       return peerGroupCreateService.create(activity, period);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/TeacherPeerGroupInfoAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/TeacherPeerGroupInfoAPIController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.dao.ObjectNotFoundException;
-import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.service.peergroup.PeerGroupInfoService;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
@@ -34,14 +34,13 @@ public class TeacherPeerGroupInfoAPIController {
   @Autowired
   private RunService runService;
 
-  @GetMapping("/{runId}/{nodeId}/{componentId}")
-  public Map<String, Object> getPeerGroupsInfo(@PathVariable Long runId,
-      @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
+  @GetMapping("/{runId}/{peerGroupActivityTag}")
+  public Map<String, Object> getPeerGroupsInfo(@PathVariable("runId") RunImpl run,
+      @PathVariable String peerGroupActivityTag, Authentication auth)
       throws ObjectNotFoundException, PeerGroupActivityNotFoundException {
-    Run run = runService.retrieveById(runId);
     if (runService.hasReadPermission(auth, run)) {
-      return peerGroupInfoService.getPeerGroupInfo(peerGroupActivityService.getByComponent(run,
-          nodeId, componentId));
+      return peerGroupInfoService.getPeerGroupInfo(peerGroupActivityService.getByTag(run,
+          peerGroupActivityTag));
     } else {
       throw new AccessDeniedException("Not permitted");
     }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/TeacherPeerGroupInfoAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/TeacherPeerGroupInfoAPIController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.service.peergroup.PeerGroupInfoService;
-import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.run.RunService;
 
@@ -37,7 +36,7 @@ public class TeacherPeerGroupInfoAPIController {
   @GetMapping("/{runId}/{peerGroupActivityTag}")
   public Map<String, Object> getPeerGroupsInfo(@PathVariable("runId") RunImpl run,
       @PathVariable String peerGroupActivityTag, Authentication auth)
-      throws ObjectNotFoundException, PeerGroupActivityNotFoundException {
+      throws ObjectNotFoundException {
     if (runService.hasReadPermission(auth, run)) {
       return peerGroupInfoService.getPeerGroupInfo(peerGroupActivityService.getByTag(run,
           peerGroupActivityTag));

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
@@ -105,8 +105,7 @@ public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService 
 
   private int getNumWorkgroupsInPeerGroup(PeerGroupActivity activity, Group period) {
     int numWorkgroupsInPeerGroup = 0;
-    List<PeerGroup> peerGroups = peerGroupDao.getListByComponent(activity.getRun(),
-        activity.getNodeId(), activity.getComponentId());
+    List<PeerGroup> peerGroups = peerGroupDao.getListByActivity(activity);
     for (PeerGroup peerGroup : peerGroups) {
       for (Workgroup workgroup : peerGroup.getMembers()) {
         if (workgroup.getPeriod().equals(period)) {

--- a/src/main/resources/wise_db_init.sql
+++ b/src/main/resources/wise_db_init.sql
@@ -218,6 +218,7 @@ create table peer_group_activities (
     maxMembershipCount integer,
     nodeId varchar(30),
     componentId varchar(30),
+    tag varchar(30),
     OPTLOCK integer,
     index peer_group_activities_run_id_index (runId),
     constraint peerGroupActivitiesRunIdFK foreign key (runId) references runs (id),

--- a/src/test/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDaoTest.java
@@ -60,11 +60,15 @@ public class HibernatePeerGroupDaoTest extends WISEHibernateTest {
 
   PeerGroupActivity activity1, activity2;
 
+  String peerGroupActivity1Tag = "peerGroupActivity1";
+
+  String peerGroupActivity2Tag = "peerGroupActivity2";
+
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    activity1 = createPeerGroupActivity(component1);
-    activity2 = createPeerGroupActivity(component2);
+    activity1 = createPeerGroupActivity(component1, peerGroupActivity1Tag);
+    activity2 = createPeerGroupActivity(component2, peerGroupActivity2Tag);
     createPeerGroup(activity1, workgroup1);
     createPeerGroup(activity2, workgroup1, workgroup2);
   }
@@ -76,8 +80,9 @@ public class HibernatePeerGroupDaoTest extends WISEHibernateTest {
     peerGroupDao.save(peerGroup);
   }
 
-  private PeerGroupActivityImpl createPeerGroupActivity(Component component) {
+  private PeerGroupActivityImpl createPeerGroupActivity(Component component, String tag) {
     PeerGroupActivityImpl peerGroupActivity = new PeerGroupActivityImpl();
+    peerGroupActivity.setTag(tag);
     peerGroupActivity.setRun(component.run);
     peerGroupActivity.setNodeId(component.nodeId);
     peerGroupActivity.setComponentId(component.componentId);
@@ -100,22 +105,6 @@ public class HibernatePeerGroupDaoTest extends WISEHibernateTest {
   public void getListByActivity_ReturnListByActivity() {
     assertEquals(1, peerGroupDao.getListByActivity(activity1).size());
     assertEquals(1, peerGroupDao.getListByActivity(activity2).size());
-  }
-
-  @Test
-  public void getListByRun_ReturnListByRun() {
-    assertEquals(2, peerGroupDao.getListByRun(run1).size());
-    assertEquals(0, peerGroupDao.getListByRun(run2).size());
-  }
-
-  @Test
-  public void getListByComponent_ReturnListByComponent() {
-    assertEquals(1, peerGroupDao.getListByComponent(component1.run, component1.nodeId,
-        component1.componentId).size());
-    assertEquals(1, peerGroupDao.getListByComponent(component2.run, component2.nodeId,
-        component2.componentId).size());
-    assertEquals(0, peerGroupDao.getListByComponent(componentNotExists.run,
-        componentNotExists.nodeId, componentNotExists.componentId).size());
   }
 
   @Test

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupAPIControllerTest.java
@@ -38,6 +38,8 @@ public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTe
 
   protected Long peerGroup2Id = 2L;
 
+  protected String peerGroupActivity1Tag = "peerGroupActivity1";
+
   protected List<PeerGroup> peerGroups = new ArrayList<PeerGroup>();
 
   protected List<Workgroup> workgroupsNotInPeerGroups = new ArrayList<Workgroup>();
@@ -47,6 +49,7 @@ public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTe
     super.setUp();
     peerGroupActivity = new PeerGroupActivityImpl();
     peerGroupActivity.setRun(run1);
+    peerGroupActivity.setTag(peerGroupActivity1Tag);
     peerGroup1 = new PeerGroupImpl();
     peerGroup1.setPeerGroupActivity(peerGroupActivity);
     peerGroup1.addMember(workgroup1);
@@ -64,6 +67,11 @@ public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTe
   protected void expectPeerGroupActivityNotFound() throws PeerGroupActivityNotFoundException {
     expect(peerGroupActivityService.getByComponent(run1, run1Node1Id, run1Component1Id))
         .andThrow(new PeerGroupActivityNotFoundException());
+  }
+
+  protected void expectPeerGroupActivityByTagFound() {
+    expect(peerGroupActivityService.getByTag(run1, peerGroupActivity1Tag))
+        .andReturn(peerGroupActivity);
   }
 
   protected void expectPeerGroupCreationException() throws Exception {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupCreateControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.springframework.security.access.AccessDeniedException;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.service.peergroup.PeerGroupCreateService;
-import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 
 @RunWith(EasyMockRunner.class)
 public class PeerGroupCreateControllerTest extends AbstractPeerGroupAPIControllerTest {
@@ -27,7 +26,7 @@ public class PeerGroupCreateControllerTest extends AbstractPeerGroupAPIControlle
     expectUserHasRunWritePermission(false);
     replayAll();
     try {
-      controller.create(run1, run1Period1, run1Node1Id, run1Component1Id, teacherAuth);
+      controller.create(run1, run1Period1, peerGroupActivity1Tag, teacherAuth);
       fail("Expected AccessDeniedException, but was not thrown");
     } catch (AccessDeniedException e) {
     }
@@ -39,7 +38,7 @@ public class PeerGroupCreateControllerTest extends AbstractPeerGroupAPIControlle
     expectUserHasRunWritePermission(true);
     replayAll();
     try {
-      controller.create(run1, run2Period2, run1Node1Id, run1Component1Id, teacherAuth);
+      controller.create(run1, run2Period2, peerGroupActivity1Tag, teacherAuth);
       fail("Expected AccessDeniedException, but was not thrown");
     } catch (AccessDeniedException e) {
     }
@@ -47,25 +46,12 @@ public class PeerGroupCreateControllerTest extends AbstractPeerGroupAPIControlle
   }
 
   @Test
-  public void create_PeerGroupActivityNotFound_ThrowException() throws Exception {
-    expectUserHasRunWritePermission(true);
-    expectPeerGroupActivityNotFound();
-    replayAll();
-    try {
-      controller.create(run1, run1Period1, run1Node1Id, run1Component1Id, teacherAuth);
-      fail("Expected PeerGroupActivityNotFoundException, but was not thrown");
-    } catch (PeerGroupActivityNotFoundException e) {
-    }
-    verifyAll();
-  }
-
-  @Test
   public void create_PeerGroupActivityFound_CreateGroup() throws Exception {
     expectUserHasRunWritePermission(true);
-    expectPeerGroupActivityFound();
+    expectPeerGroupActivityByTagFound();
     expectCreatePeerGroup();
     replayAll();
-    assertNotNull(controller.create(run1, run1Period1, run1Node1Id, run1Component1Id, teacherAuth));
+    assertNotNull(controller.create(run1, run1Period1, peerGroupActivity1Tag, teacherAuth));
     verifyAll();
   }
 

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/TeacherPeerGroupInfoAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/TeacherPeerGroupInfoAPIControllerTest.java
@@ -13,9 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.security.access.AccessDeniedException;
-import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.peergroup.PeerGroup;
-import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 
 /**
  * @author Hiroki Terashima
@@ -29,7 +27,6 @@ public class TeacherPeerGroupInfoAPIControllerTest extends AbstractPeerGroupAPIC
   @Before
   public void setUp() {
     super.setUp();
-    expectRunExists();
   }
 
   @Test
@@ -37,22 +34,9 @@ public class TeacherPeerGroupInfoAPIControllerTest extends AbstractPeerGroupAPIC
     expectTeacherHasAccessToRun(false);
     replayAll();
     try {
-      controller.getPeerGroupsInfo(runId1, run1Node1Id, run1Component1Id, teacherAuth);
+      controller.getPeerGroupsInfo(run1, peerGroupActivity1Tag, teacherAuth);
       fail("Expected AccessDeniedException, but was not thrown");
     } catch (AccessDeniedException e) {
-    }
-    verifyAll();
-  }
-
-  @Test
-  public void getPeerGroupsInfo_PeerGroupActivityNotFound_ThrowException() throws Exception {
-    expectTeacherHasAccessToRun(true);
-    expectPeerGroupActivityNotFound();
-    replayAll();
-    try {
-      controller.getPeerGroupsInfo(runId1, run1Node1Id, run1Component1Id, teacherAuth);
-      fail("Expected PeerGroupActivityNotFoundException, but was not thrown");
-    } catch (PeerGroupActivityNotFoundException e) {
     }
     verifyAll();
   }
@@ -61,11 +45,11 @@ public class TeacherPeerGroupInfoAPIControllerTest extends AbstractPeerGroupAPIC
   @Test
   public void getPeerGroupsInfo_ActivityFound_ReturnInfo() throws Exception {
     expectTeacherHasAccessToRun(true);
-    expectPeerGroupActivityFound();
+    expectPeerGroupActivityByTagFound();
     expectPeerGroupInfo();
     replayAll();
-    Map<String, Object> peerGroupsInfo = controller.getPeerGroupsInfo(runId1, run1Node1Id,
-        run1Component1Id, teacherAuth);
+    Map<String, Object> peerGroupsInfo = controller.getPeerGroupsInfo(run1, peerGroupActivity1Tag,
+        teacherAuth);
     assertEquals(2, peerGroupsInfo.size());
     assertEquals(2, ((List<PeerGroup>) peerGroupsInfo.get("peerGroups")).size());
     assertEquals(0, ((List<PeerGroup>) peerGroupsInfo.get("workgroupsNotInPeerGroups")).size());
@@ -77,13 +61,6 @@ public class TeacherPeerGroupInfoAPIControllerTest extends AbstractPeerGroupAPIC
     peerGroupInfo.put("peerGroups", peerGroups);
     peerGroupInfo.put("workgroupsNotInPeerGroups", workgroupsNotInPeerGroups);
     expect(peerGroupInfoService.getPeerGroupInfo(peerGroupActivity)).andReturn(peerGroupInfo);
-  }
-
-  private void expectRunExists() {
-    try {
-      expect(runService.retrieveById(runId1)).andReturn(run1);
-    } catch (ObjectNotFoundException e) {
-    }
   }
 
   private void expectTeacherHasAccessToRun(boolean hasAccess) {

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
@@ -119,13 +119,11 @@ public class PeerGroupThresholdServiceTest extends PeerGroupServiceTest {
   }
 
   private void expectNoWorkgroupsInPeerGroup() {
-    expect(peerGroupDao.getListByComponent(run1, activity.getNodeId(), activity.getComponentId()))
-        .andReturn(Arrays.asList());
+    expect(peerGroupDao.getListByActivity(activity)).andReturn(Arrays.asList());
   }
 
   private void expectTwoWorkgroupsInPeerGroup() {
-    expect(peerGroupDao.getListByComponent(run1, activity.getNodeId(), activity.getComponentId()))
-        .andReturn(Arrays.asList(peerGroup1));
+    expect(peerGroupDao.getListByActivity(activity)).andReturn(Arrays.asList(peerGroup1));
   }
 
   private void expectOneWorkgroupsCompletedLogicComponent() {


### PR DESCRIPTION
## Changes
- Switch to using the new PeerGroupActivityTag to lookup the PeerGroupActivity instead of nodeId/componentId.
- Add tag column to db init sql
- Clean up code

## Test
- The endpoint ```/api/peer-group/create/{runId}/{periodId}/{peerGroupActivityTag}``` should create a new PeerGroup for the specified PeerGroupActivity and Period and return it in the response
- The endpoint ```/api/teacher/peer-group-info/{runId}/{peerGroupActivityTag}```  should return a map containing two objects:
   - "peerGroups": list of PeerGroups for the activity in the run
   - "workgroupsNotInPeerGroup": list of Workgroups that are not in a PeerGroup for the activity


closes #95