### PR TITLE
feat(Student Status): Add endpoint for students to get student status

### DIFF
--- a/src/main/java/org/wise/vle/web/StudentStatusController.java
+++ b/src/main/java/org/wise/vle/web/StudentStatusController.java
@@ -33,20 +33,28 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.service.run.RunService;
+import org.wise.portal.service.user.UserService;
 import org.wise.portal.service.vle.wise5.VLEService;
+import org.wise.portal.service.workgroup.WorkgroupService;
 import org.wise.portal.spring.data.redis.MessagePublisher;
 import org.wise.vle.domain.status.StudentStatus;
 
-@Controller
+@RestController
+@Secured("ROLE_USER")
 @RequestMapping("/api/studentStatus")
 public class StudentStatusController {
 
@@ -58,6 +66,12 @@ public class StudentStatusController {
 
   @Autowired
   private MessagePublisher redisPublisher;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  protected WorkgroupService workgroupService;
 
   /**
    * Handles POST requests from students when they send their status to the server so we can keep
@@ -143,4 +157,14 @@ public class StudentStatusController {
     redisPublisher.publish(message.toString());
   }
 
+  @GetMapping("/{workgroupId}")
+  StudentStatus getStudentStatus(Authentication auth,
+      @PathVariable("workgroupId") WorkgroupImpl workgroup) {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    if (workgroupService.isUserInWorkgroupForRun(user, workgroup.getRun(), workgroup)) {
+      return vleService.getStudentStatusByWorkgroupId(workgroup.getId());
+    } else {
+      return null;
+    }
+  }
 }

--- a/src/main/java/org/wise/vle/web/StudentStatusController.java
+++ b/src/main/java/org/wise/vle/web/StudentStatusController.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -159,12 +160,12 @@ public class StudentStatusController {
 
   @GetMapping("/{workgroupId}")
   StudentStatus getStudentStatus(Authentication auth,
-      @PathVariable("workgroupId") WorkgroupImpl workgroup) {
+      @PathVariable("workgroupId") WorkgroupImpl workgroup) throws AccessDeniedException {
     User user = userService.retrieveUserByUsername(auth.getName());
     if (workgroupService.isUserInWorkgroupForRun(user, workgroup.getRun(), workgroup)) {
       return vleService.getStudentStatusByWorkgroupId(workgroup.getId());
     } else {
-      return null;
+      throw new AccessDeniedException("User does not have permission to view this Student Status");
     }
   }
 }

--- a/src/test/java/org/wise/vle/web/StudentStatusControllerTest.java
+++ b/src/test/java/org/wise/vle/web/StudentStatusControllerTest.java
@@ -1,0 +1,66 @@
+package org.wise.vle.web;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.vle.domain.status.StudentStatus;
+
+@RunWith(EasyMockRunner.class)
+public class StudentStatusControllerTest extends APIControllerTest {
+  
+  @TestSubject
+  private StudentStatusController controller = new StudentStatusController();
+
+  @Test
+  public void getStudentStatus_NotInWorkgroup_ThrowException() {
+    expectRetrieveUserByUsername(STUDENT_USERNAME, student1);
+    expectIsUserInWorkgroupForRun(student1, run1, workgroup2, false);
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getStudentStatus(studentAuth, workgroup2));
+    verifyAll();
+  }
+
+  @Test
+  public void getStudentStatus_InWorkgroup_ReturnStudentStatus() {
+    expectRetrieveUserByUsername(STUDENT_USERNAME, student1);
+    expectIsUserInWorkgroupForRun(student1, run1, workgroup1, true);
+    StudentStatus studentStatus = new StudentStatus();
+    expectGetStudentStatusByWorkgroupId(workgroup1, studentStatus);
+    replayAll();
+    assertEquals(studentStatus, controller.getStudentStatus(studentAuth, workgroup1));
+    verifyAll();
+  }
+
+  private void expectRetrieveUserByUsername(String username, User user) {
+    expect(userService.retrieveUserByUsername(username)).andReturn(user);
+  }
+
+  private void expectIsUserInWorkgroupForRun(
+      User user, Run run, Workgroup workgroup, boolean isInWorkgroup) {
+    expect(workgroupService.isUserInWorkgroupForRun(user, run, workgroup)).andReturn(isInWorkgroup);
+  }
+
+  private void expectGetStudentStatusByWorkgroupId(
+      Workgroup workgroup, StudentStatus studentStatus) {
+    expect(vleService.getStudentStatusByWorkgroupId(workgroup.getId())).andReturn(studentStatus);
+  }
+
+  protected void replayAll() {
+    replay(userService, vleService, workgroupService);
+  }
+
+  protected void verifyAll() {
+    verify(userService, vleService, workgroupService);
+  }
+}


### PR DESCRIPTION
## Changes

Added endpoint for students to retrieve their Student Status. Previously only teachers could retrieve Student Statuses.

## Test

- Make sure student can retrieve the Student Status for their workgroup
- Make sure student can not retrieve the Student Status for other workgroups

Closes #102