### PR TITLE
refactor(PeerGroupActivity): Remove nodeId and componentId fields

### DIFF
--- a/src/main/java/org/wise/portal/dao/peergroupactivity/PeerGroupActivityDao.java
+++ b/src/main/java/org/wise/portal/dao/peergroupactivity/PeerGroupActivityDao.java
@@ -32,7 +32,5 @@ import org.wise.portal.domain.run.Run;
  */
 public interface PeerGroupActivityDao<T extends PeerGroupActivity> extends SimpleDao<T> {
 
-  PeerGroupActivity getByComponent(Run run, String nodeId, String componentId);
-
   PeerGroupActivity getByTag(Run run, String tag);
 }

--- a/src/main/java/org/wise/portal/dao/peergroupactivity/impl/HibernatePeerGroupActivityDao.java
+++ b/src/main/java/org/wise/portal/dao/peergroupactivity/impl/HibernatePeerGroupActivityDao.java
@@ -63,20 +63,6 @@ public class HibernatePeerGroupActivityDao extends AbstractHibernateDao<PeerGrou
   }
 
   @Override
-  public PeerGroupActivity getByComponent(Run run, String nodeId, String componentId) {
-    CriteriaBuilder cb = getCriteriaBuilder();
-    CriteriaQuery<PeerGroupActivityImpl> cq = cb.createQuery(PeerGroupActivityImpl.class);
-    Root<PeerGroupActivityImpl> peerGroupActivityImplRoot = cq.from(PeerGroupActivityImpl.class);
-    List<Predicate> predicates = new ArrayList<>();
-    predicates.add(cb.equal(peerGroupActivityImplRoot.get("run"), run.getId()));
-    predicates.add(cb.equal(peerGroupActivityImplRoot.get("nodeId"), nodeId));
-    predicates.add(cb.equal(peerGroupActivityImplRoot.get("componentId"), componentId));
-    cq.select(peerGroupActivityImplRoot).where(predicates.toArray(new Predicate[predicates.size()]));
-    TypedQuery<PeerGroupActivityImpl> query = entityManager.createQuery(cq);
-    return (PeerGroupActivityImpl) query.getResultStream().findFirst().orElse(null);
-  }
-
-  @Override
   public PeerGroupActivity getByTag(Run run, String tag) {
     CriteriaBuilder cb = getCriteriaBuilder();
     CriteriaQuery<PeerGroupActivityImpl> cq = cb.createQuery(PeerGroupActivityImpl.class);

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
@@ -32,8 +32,6 @@ import org.wise.portal.domain.run.Run;
  */
 public interface PeerGroupActivity {
 
-  String getComponentId();
-
   Long getId();
 
   String getLogic();
@@ -49,8 +47,6 @@ public interface PeerGroupActivity {
   int getLogicThresholdPercent();
 
   int getMaxMembershipCount();
-
-  String getNodeId();
 
   Run getRun();
 

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
@@ -68,14 +68,8 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
   @JsonIgnore
   private Run run;
 
-  @Column(length = 30)
-  private String nodeId;
-
-  @Column(length = 30)
-  private String componentId;
-
   @Column(length = 32768, columnDefinition = "text")
-  private String logic;
+  private String logic = "[{\"name\":\"manual\"}]";
 
   @Column(length = 30)
   private String tag;
@@ -97,11 +91,8 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
     this.tag = tag;
   }
 
-  public PeerGroupActivityImpl(Run run, String nodeId, ProjectComponent component)
-      throws JSONException {
+  public PeerGroupActivityImpl(Run run, ProjectComponent component) throws JSONException {
     this.run = run;
-    this.nodeId = nodeId;
-    this.componentId = component.getId();
     this.logic = component.getString("logic");
     this.logicThresholdCount = component.getInt("logicThresholdCount");
     this.logicThresholdPercent = component.getInt("logicThresholdPercent");

--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
@@ -62,6 +62,10 @@ public class ProjectComponent {
     return this.componentJSON.getInt(key);
   }
 
+  public String getPeerGroupActivityTag() throws JSONException {
+    return this.componentJSON.getString("peerGroupActivityTag");
+  }
+
   public JSONArray getJSONArray(String key) throws JSONException {
     return this.componentJSON.getJSONArray(key);
   }

--- a/src/main/resources/wise_db_init.sql
+++ b/src/main/resources/wise_db_init.sql
@@ -216,8 +216,6 @@ create table peer_group_activities (
     logicThresholdCount integer,
     logicThresholdPercent integer,
     maxMembershipCount integer,
-    nodeId varchar(30),
-    componentId varchar(30),
     tag varchar(30),
     OPTLOCK integer,
     index peer_group_activities_run_id_index (runId),

--- a/src/test/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/peergroup/impl/HibernatePeerGroupDaoTest.java
@@ -84,8 +84,6 @@ public class HibernatePeerGroupDaoTest extends WISEHibernateTest {
     PeerGroupActivityImpl peerGroupActivity = new PeerGroupActivityImpl();
     peerGroupActivity.setTag(tag);
     peerGroupActivity.setRun(component.run);
-    peerGroupActivity.setNodeId(component.nodeId);
-    peerGroupActivity.setComponentId(component.componentId);
     peerGroupActivityDao.save(peerGroupActivity);
     return peerGroupActivity;
   }

--- a/src/test/java/org/wise/portal/dao/peergroupactivity/impl/HibernatePeerGroupActivityDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/peergroupactivity/impl/HibernatePeerGroupActivityDaoTest.java
@@ -52,14 +52,6 @@ public class HibernatePeerGroupActivityDaoTest extends WISEHibernateTest {
   }
 
   @Test
-  public void getByComponent() {
-    assertNotNull(peerGroupActivityDao.getByComponent(component1.run, component1.nodeId,
-        component1.componentId));
-    assertNull(peerGroupActivityDao.getByComponent(componentNotExists.run,
-        componentNotExists.nodeId, componentNotExists.componentId));
-  }
-
-  @Test
   public void getByTag() {
     assertNotNull(peerGroupActivityDao.getByTag(run1, peerGroupActivityTag1));
     assertNull(peerGroupActivityDao.getByTag(run1, "tagNotInDB"));

--- a/src/test/java/org/wise/portal/dao/peergroupactivity/impl/HibernatePeerGroupActivityDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/peergroupactivity/impl/HibernatePeerGroupActivityDaoTest.java
@@ -60,8 +60,6 @@ public class HibernatePeerGroupActivityDaoTest extends WISEHibernateTest {
   private void createPeerGroupActivityWithComponent(Component component) {
     PeerGroupActivityImpl peerGroupActivity = new PeerGroupActivityImpl();
     peerGroupActivity.setRun(component.run);
-    peerGroupActivity.setNodeId(component.nodeId);
-    peerGroupActivity.setComponentId(component.componentId);
     peerGroupActivityDao.save(peerGroupActivity);
   }
 

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTest.java
@@ -74,7 +74,7 @@ public class PeerGroupServiceTest extends WISEServiceTest {
     String peerGroupActivityComponentString = createPeerGroupActivityComponentString(componentId,
         logicName, logicNodeId, logicComponentId, logicThresholdCount, logicThresholdPercent,
         maxMembershipCount, peerGroupActivityTag);
-    return new PeerGroupActivityImpl(run, component.nodeId,
+    return new PeerGroupActivityImpl(run,
         new ProjectComponent(new ProjectNode(new JSONObject("{\"id\":\"node1\"}")),
         new JSONObject(peerGroupActivityComponentString)));
   }


### PR DESCRIPTION
## Changes
- Remove nodeId, componentId fields from PeerGroupActivity
- Set PeerGroupActivity.logic field's default value to [{"name":"manual"}]
- Remove PeerGroupActivityDao.getByComponent()

## Test
- run command to remove columns from PeerGroupActivity table:
```
alter table peer_group_activities drop column nodeId, drop column componentId;
```
- Test that you can use the same PeerGroupActivityTag across multiple PeerChat activities
   - As teacher, edit existing run
      - Create a new PeerChat ("PeerChat1") component and give it a tag (e.g. "apple") 
      - Create a second PeerChat ("PeerChat2") component and give it the same tag
      - Verify that in the DB, peer_group_activities now has one new row with logic  [{"name":"manual"}] and tag "apple"
   - As teacher, put students in pairs for the the "apple" PeerGroupActivity
   - As students, go to PeerChat1 and PeerChat2, and make sure that you are in the same pair for both
- Test that ShowGroupWork works as before

Closes #104 