### PR TITLE
refactor(PeerGroupActivity): Change logic field from json to string

### DIFF
--- a/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/PeerGroupActivity.java
@@ -38,8 +38,6 @@ public interface PeerGroupActivity {
 
   String getLogicComponentId() throws JSONException;
 
-  String getLogicName() throws JSONException;
-
   String getLogicNodeId() throws JSONException;
 
   int getLogicThresholdCount();

--- a/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergroupactivity/impl/PeerGroupActivityImpl.java
@@ -68,8 +68,8 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
   @JsonIgnore
   private Run run;
 
-  @Column(length = 32768, columnDefinition = "text")
-  private String logic = "[{\"name\":\"manual\"}]";
+  @Column(length = 30)
+  private String logic = "manual";
 
   @Column(length = 30)
   private String tag;
@@ -110,10 +110,5 @@ public class PeerGroupActivityImpl implements PeerGroupActivity {
 
   private JSONObject getFirstLogicJSON() throws JSONException {
     return new JSONArray(this.logic).getJSONObject(0);
-  }
-
-  public String getLogicName() throws JSONException {
-    JSONObject logic = getFirstLogicJSON();
-    return logic.getString("name");
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -76,7 +76,9 @@ public class PeerGroupServiceImpl implements PeerGroupService {
       throws JSONException, PeerGroupActivityThresholdNotSatisfiedException,
       PeerGroupCreationException {
     PeerGroup peerGroup = peerGroupDao.getByWorkgroupAndActivity(workgroup, activity);
-    if (activity.getLogicName().equals("manual")) {
+    if (activity.getLogic().contains("manual")) {
+      // use contains check instead of equals until custom logic is implemented for
+      // backwards-compatibility
       return peerGroup;
     } else {
       return peerGroup != null ? peerGroup : this.createPeerGroup(workgroup, activity);
@@ -148,7 +150,9 @@ public class PeerGroupServiceImpl implements PeerGroupService {
     Set<Workgroup> members = new HashSet<Workgroup>();
     members.add(workgroup);
     possibleMembers.remove(workgroup);
-    if (activity.getLogicName().equals("random")) {
+    if (activity.getLogic().contains("random")) {
+      // use contains check instead of equals until custom logic is implemented for
+      // backwards-compatibility
       addMembersRandomly(activity, possibleMembers, members);
     } else {
       addMembersInOrder(activity, possibleMembers, members);


### PR DESCRIPTION
## Changes
Instead of expressing the logic entirely in the logic field, use the logic field to only store a string from the following: "manual", "random", "custom".

## Test
- Run query to re-set PGA.logic values from JSON array [{"name":"manual"}] to string "manual"
``` update peer_group_activities set logic="manual" where logic="[{\"name\":\"manual\"}]"; ```
- Test that existing PeerGroupActivities with manual grouping works as before
- Create a new PeerGroupActivity with manual grouping and make sure that it works

## Note
- Random pairing and component completion requirements before pairing will not work in this intermediary PR. We will fix it in a future PR, before it gets merged into issue-370.