### PR TITLE
chore(Peer Group API): Remove getPeerGroup() by component

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -42,7 +42,6 @@ import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.service.peergroup.PeerGroupActivityThresholdNotSatisfiedException;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
 import org.wise.portal.service.peergroup.PeerGroupService;
-import org.wise.portal.service.peergroupactivity.PeerGroupActivityNotFoundException;
 import org.wise.portal.service.peergroupactivity.PeerGroupActivityService;
 import org.wise.portal.service.user.UserService;
 import org.wise.portal.service.workgroup.WorkgroupService;
@@ -68,8 +67,8 @@ public class PeerGroupAPIController {
   PeerGroup getPeerGroup(@PathVariable("runId") RunImpl run,
       @PathVariable("workgroupId") WorkgroupImpl workgroup,
       @PathVariable String peerGroupActivityTag, Authentication auth)
-      throws JSONException, PeerGroupActivityNotFoundException,
-      PeerGroupCreationException, PeerGroupActivityThresholdNotSatisfiedException {
+      throws JSONException, PeerGroupCreationException,
+      PeerGroupActivityThresholdNotSatisfiedException  {
     User user = userService.retrieveUserByUsername(auth.getName());
     if (workgroupService.isUserInWorkgroupForRun(user, run, workgroup) ||
         run.isTeacherAssociatedToThisRun(user)) {
@@ -79,31 +78,10 @@ public class PeerGroupAPIController {
     }
   }
 
-  @GetMapping("/{runId}/{workgroupId}/{nodeId}/{componentId}")
-  PeerGroup getPeerGroup(@PathVariable("runId") RunImpl run,
-      @PathVariable ("workgroupId") WorkgroupImpl workgroup,
-      @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
-      throws JSONException, PeerGroupActivityNotFoundException,
-      PeerGroupCreationException, PeerGroupActivityThresholdNotSatisfiedException {
-    User user = userService.retrieveUserByUsername(auth.getName());
-    if (workgroupService.isUserInWorkgroupForRun(user, run, workgroup)) {
-      return getPeerGroup(run, nodeId, componentId, workgroup);
-    } else {
-      throw new AccessDeniedException("Not permitted");
-    }
-  }
-
   private PeerGroup getPeerGroup(Run run, String peerGroupActivityTag, Workgroup workgroup)
-      throws JSONException, PeerGroupActivityNotFoundException, PeerGroupCreationException,
+      throws JSONException, PeerGroupCreationException,
       PeerGroupActivityThresholdNotSatisfiedException {
     PeerGroupActivity activity = peerGroupActivityService.getByTag(run, peerGroupActivityTag);
-    return peerGroupService.getPeerGroup(workgroup, activity);
-  }
-
-  private PeerGroup getPeerGroup(Run run, String nodeId, String componentId, Workgroup workgroup)
-      throws JSONException, PeerGroupActivityNotFoundException, PeerGroupCreationException,
-      PeerGroupActivityThresholdNotSatisfiedException {
-    PeerGroupActivity activity = peerGroupActivityService.getByComponent(run, nodeId, componentId);
     return peerGroupService.getPeerGroup(workgroup, activity);
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIControllerTest.java
@@ -19,26 +19,13 @@ public class PeerGroupAPIControllerTest extends AbstractPeerGroupAPIControllerTe
   private PeerGroupAPIController controller = new PeerGroupAPIController();
 
   @Test
-  public void getPeerGroupByComponent_WorkgroupNotAssociatedWithRun_AccessDenied() throws Exception {
+  public void getPeerGroup_UserNotAssociatedWithRun_AccessDenied() throws Exception {
     expectWorkgroupAssociatedWithRun(false);
     replayAll();
     try {
-      controller.getPeerGroup(run1, workgroup1, run1Node1Id, run1Component1Id, studentAuth);
+      controller.getPeerGroup(run1, workgroup1, peerGroupActivity1Tag, studentAuth);
       fail("Expected AccessDeniedException, but was not thrown");
     } catch (AccessDeniedException e) {
-    }
-    verifyAll();
-  }
-
-  @Test
-  public void getPeerGroupByComponent_PeerGroupActivityNotFound_ThrowException() throws Exception {
-    expectWorkgroupAssociatedWithRun(true);
-    expectPeerGroupActivityNotFound();
-    replayAll();
-    try {
-      controller.getPeerGroup(run1, workgroup1, run1Node1Id, run1Component1Id, studentAuth);
-      fail("Expected PeerGroupActivityNotFoundException, but was not thrown");
-    } catch (PeerGroupActivityNotFoundException e) {
     }
     verifyAll();
   }
@@ -49,7 +36,7 @@ public class PeerGroupAPIControllerTest extends AbstractPeerGroupAPIControllerTe
     expectPeerGroupThresholdNotSatisifed();
     replayAll();
     try {
-      controller.getPeerGroup(run1, workgroup1, run1Node1Id, run1Component1Id, studentAuth);
+      controller.getPeerGroup(run1, workgroup1, peerGroupActivity1Tag, studentAuth);
       fail("Expected PeerGroupCreationException, but was not thrown");
     } catch (PeerGroupActivityThresholdNotSatisfiedException e) {
     }
@@ -62,7 +49,7 @@ public class PeerGroupAPIControllerTest extends AbstractPeerGroupAPIControllerTe
     expectPeerGroupCreationException();
     replayAll();
     try {
-      controller.getPeerGroup(run1, workgroup1, run1Node1Id, run1Component1Id, studentAuth);
+      controller.getPeerGroup(run1, workgroup1, peerGroupActivity1Tag, studentAuth);
       fail("Expected PeerGroupCreationException, but was not thrown");
     } catch (PeerGroupCreationException e) {
     }
@@ -70,19 +57,18 @@ public class PeerGroupAPIControllerTest extends AbstractPeerGroupAPIControllerTe
   }
 
   @Test
-  public void getPeerGroupByComponent_FoundExistingGroupOrGroupCreated_ReturnGroup() throws Exception {
+  public void getPeerGroup_FoundExistingGroupOrGroupCreated_ReturnGroup() throws Exception {
     expectWorkgroupAssociatedWithRunAndActivityFound();
     expectPeerGroupCreated();
     replayAll();
-    assertNotNull(controller.getPeerGroup(run1, workgroup1, run1Node1Id, run1Component1Id,
-        studentAuth));
+    assertNotNull(controller.getPeerGroup(run1, workgroup1, peerGroupActivity1Tag, studentAuth));
     verifyAll();
   }
 
   private void expectWorkgroupAssociatedWithRunAndActivityFound() throws Exception,
       PeerGroupActivityNotFoundException {
     expectWorkgroupAssociatedWithRun(true);
-    expectPeerGroupActivityFound();
+    expectPeerGroupActivityByTagFound();
   }
 
   private void expectWorkgroupAssociatedWithRun(boolean isAssociated) throws Exception {


### PR DESCRIPTION
## Changes
- Removed endpoint to get Peer Group by nodeId/componentId. We now get PeerGroup by tag instead.
- Updated tests

## Test
- PeerChat and ShowGroupWork activities work as before

Closes #109 