### PR TITLE
fix(Peer Grouping): Create run with Peer Groupings with correct fields

### DIFF
--- a/src/main/java/org/wise/portal/domain/peergrouping/impl/PeerGroupingImpl.java
+++ b/src/main/java/org/wise/portal/domain/peergrouping/impl/PeerGroupingImpl.java
@@ -42,7 +42,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
-import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.run.impl.RunImpl;
 
@@ -90,18 +89,14 @@ public class PeerGroupingImpl implements PeerGrouping {
   public PeerGroupingImpl() {
   }
 
-  public PeerGroupingImpl(Run run, String tag) {
+  public PeerGroupingImpl(Run run, String tag, String logic, Integer logicThresholdCount,
+      Integer logicThresholdPercent, Integer maxMembershipCount) {
     this.run = run;
     this.tag = tag;
-  }
-
-  public PeerGroupingImpl(Run run, ProjectComponent component) throws JSONException {
-    this.run = run;
-    this.logic = component.getString("logic");
-    this.logicThresholdCount = component.getInt("logicThresholdCount");
-    this.logicThresholdPercent = component.getInt("logicThresholdPercent");
-    this.maxMembershipCount = component.getInt("maxMembershipCount");
-    this.tag = component.getString("peerGroupingTag");
+    this.logic = logic;
+    this.logicThresholdCount = logicThresholdCount;
+    this.logicThresholdPercent = logicThresholdPercent;
+    this.maxMembershipCount = maxMembershipCount;
   }
 
   public String getLogicNodeId() throws JSONException {

--- a/src/main/java/org/wise/portal/service/peergrouping/PeerGroupingService.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/PeerGroupingService.java
@@ -23,8 +23,10 @@
  */
 package org.wise.portal.service.peergrouping;
 
+import java.io.IOException;
 import java.util.Set;
 
+import org.json.JSONException;
 import org.springframework.transaction.annotation.Transactional;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.run.Run;
@@ -57,15 +59,11 @@ public interface PeerGroupingService {
    */
   PeerGrouping getByTag(Run run, String tag);
 
-  /**
-   * Retrieves PeerGrouping for the specified run. Scans run's project content for
-   * PeerGroupingTags and looks up the database for the PeerGrouping for that tag.
-   * If none is found, creates a new PeerGrouping for the tag.
-   */
-  Set<PeerGrouping> getByRun(Run run);
-
   @Transactional
   PeerGrouping createPeerGrouping(Run run, PeerGrouping peerGrouping);
+
+  @Transactional
+  Set<PeerGrouping> createPeerGroupings(Run run) throws IOException, JSONException;
 
   @Transactional
   PeerGrouping updatePeerGrouping(Run run, String tag, PeerGrouping peerGrouping);

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -245,7 +245,7 @@ public class RunServiceImpl implements RunService {
         maxStudentsPerTeam, startDate, endDate, isLockedAfterEndDate, locale);
     Run run = createRun(runParameters);
     createTeacherWorkgroup(run, user);
-    peerGroupingService.getByRun(run);
+    peerGroupingService.createPeerGroupings(run);
     return run;
   }
 

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTest.java
@@ -29,15 +29,11 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
-import org.wise.portal.dao.Component;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.peergrouping.impl.PeerGroupingImpl;
-import org.wise.portal.domain.project.impl.ProjectComponent;
-import org.wise.portal.domain.project.impl.ProjectNode;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.WISEServiceTest;
@@ -57,60 +53,18 @@ public class PeerGroupServiceTest extends WISEServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    peerGrouping = createPeerGrouping(run1, run1Component2, run1Component2Id,
-        "maximizeDifferentIdeas", run1Node1Id, run1Component1Id, 3, 50, 2, "tag1");
+    peerGrouping = createPeerGrouping(run1, "tag1", "random", 3, 50, 2);
     peerGroup1 = new PeerGroupImpl(peerGrouping, run1Period1,
         new HashSet<Workgroup>(Arrays.asList(run1Workgroup1, run1Workgroup2)));
     peerGroups.add(peerGroup1);
     peerGroup2 = new PeerGroupImpl(peerGrouping, run1Period1, new HashSet<Workgroup>());
-    manualPeerGrouping = createPeerGrouping(run1, run1Component2, run1Component2Id, "manual",
-        run1Node1Id, run1Component1Id, 2, 50, 2, "tag1");
+    manualPeerGrouping = createPeerGrouping(run1, "tag1", "manual", 2, 50, 2);
   }
 
-  private PeerGrouping createPeerGrouping(Run run, Component component, String componentId,
-      String logicName, String logicNodeId, String logicComponentId, Integer logicThresholdCount,
-      Integer logicThresholdPercent, Integer maxMembershipCount, String peerGroupingTag)
+  private PeerGrouping createPeerGrouping(Run run, String peerGroupingTag, String logicName,
+      Integer logicThresholdCount, Integer logicThresholdPercent, Integer maxMembershipCount)
       throws JSONException {
-    String peerGroupingComponentString = createPeerGroupingComponentString(componentId,
-        logicName, logicNodeId, logicComponentId, logicThresholdCount, logicThresholdPercent,
-        maxMembershipCount, peerGroupingTag);
-    return new PeerGroupingImpl(run,
-        new ProjectComponent(new ProjectNode(new JSONObject("{\"id\":\"node1\"}")),
-        new JSONObject(peerGroupingComponentString)));
-  }
-
-  private String createPeerGroupingComponentString(String componentId, String logicName,
-      String logicNodeId, String logicComponentId, Integer logicThresholdCount,
-      Integer logicThresholdPercent, Integer maxMembershipCount, String peerGroupingTag) {
-    String logic = createLogicString(logicName, logicNodeId, logicComponentId);
-    return createPeerGroupingComponentString(componentId, logic, logicThresholdCount,
-        logicThresholdPercent, maxMembershipCount, peerGroupingTag);
-  }
-
-  private String createPeerGroupingComponentString(String componentId, String logic,
-      Integer logicThresholdCount, Integer logicThresholdPercent, Integer maxMembershipCount,
-      String peerGroupingTag) {
-    return new StringBuilder()
-        .append("{")
-        .append("  \"id\": \"" + componentId + "\",")
-        .append("  \"logic\": " + logic + ",")
-        .append("  \"logicThresholdCount\": \"" + logicThresholdCount + "\",")
-        .append("  \"logicThresholdPercent\": \"" + logicThresholdPercent + "\",")
-        .append("  \"maxMembershipCount\": \"" + maxMembershipCount + "\",")
-        .append("  \"peerGroupingTag\": \"" + peerGroupingTag + "\"")
-        .append("}")
-        .toString();
-  }
-
-  private String createLogicString(String name, String nodeId, String componentId) {
-    return new StringBuilder()
-        .append("[")
-        .append("  {")
-        .append("    \"name\": \"" + name + "\",")
-        .append("    \"nodeId\": \"" + nodeId + "\",")
-        .append("    \"componentId\": \"" + componentId + "\"")
-        .append("  }")
-        .append("]")
-        .toString();
+    return new PeerGroupingImpl(run, peerGroupingTag, logicName, logicThresholdCount,
+        logicThresholdPercent, maxMembershipCount);
   }
 }

--- a/src/test/java/org/wise/portal/service/peergrouping/PeerGroupingServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/PeerGroupingServiceImplTest.java
@@ -76,14 +76,6 @@ public class PeerGroupingServiceImplTest {
 
   private String componentIdWithoutPeerGrouping = "component2";
 
-  private String logic = "[{“name”: “maximizeSimilarIdeas”, “nodeId”: “node1”, “componentId”: “xyz”}]";
-
-  private int logicThresholdCount = 10;
-
-  private int logicThresholdPercent = 50;
-
-  private int maxMembershipCount = 2;
-
   String tagInDB = "existingPeerGroupingTag";
 
   String tagNotInDB = "newPeerGroupingTag";
@@ -94,10 +86,7 @@ public class PeerGroupingServiceImplTest {
       "\"peerGroupings\":[{\"tag\": \"" + tagInDB + "\"}]," +
       "\"nodes\":[{\"id\":\"" + nodeId + "\"," +
       "\"components\":[" +
-      "{\"id\":\"" + componentIdWithPeerGrouping + "\",\"logic\":\"" + logic + "\"," +
-      "\"logicThresholdCount\":\"" + logicThresholdCount + "\"," +
-      "\"logicThresholdPercent\":\"" + logicThresholdPercent + "\"," +
-      "\"maxMembershipCount\":\"" + maxMembershipCount + "\"," +
+      "{\"id\":\"" + componentIdWithPeerGrouping + "\"," +
       "\"peerGroupingTag\":\"" + tagInDB + "\"" +
       "}, {\"id\":\"" + componentIdWithoutPeerGrouping + "\"}]}]}";
 
@@ -124,20 +113,6 @@ public class PeerGroupingServiceImplTest {
   }
 
   @Test
-  public void getByComponent_TagInContentButNotInDB_CreateNewPeerGrouping()
-      throws IOException, PeerGroupingNotFoundException {
-    expect(peerGroupingDao.getByTag(run, tagInDB)).andReturn(null);
-    expect(appProperties.getProperty("curriculum_base_dir")).andReturn("/var/curriculum");
-    expect(FileUtils.readFileToString(isA(File.class))).andReturn(projectJSONString);
-    peerGroupingDao.save(isA(PeerGrouping.class));
-    expectLastCall();
-    replayAll();
-    PeerGrouping peerGrouping = service.getByComponent(run, nodeId, componentIdWithPeerGrouping);
-    assertEquals(tagInDB, peerGrouping.getTag());
-    verifyAll();
-  }
-
-  @Test
   public void getByComponent_TagInContentAndInDB_ReturnPeerGroupingFromDB()
       throws IOException, PeerGroupingNotFoundException {
     expect(peerGroupingDao.getByTag(run, tagInDB)).andReturn(peerGrouping);
@@ -150,31 +125,10 @@ public class PeerGroupingServiceImplTest {
   }
 
   @Test
-  public void getByTag_notInDB_SaveAndReturnNewPeerGrouping() {
-    expect(peerGroupingDao.getByTag(run, tagNotInDB)).andReturn(null);
-    peerGroupingDao.save(isA(PeerGrouping.class));
-    expectLastCall();
-    replayAll();
-    PeerGrouping peerGrouping = service.getByTag(run, tagNotInDB);
-    assertEquals(tagNotInDB, peerGrouping.getTag());
-    verifyAll();
-  }
-
-  @Test
   public void getByTag_foundInDB_ReturnPeerGrouping() {
     expect(peerGroupingDao.getByTag(run, tagInDB)).andReturn(peerGrouping);
     replayAll();
     assertEquals(peerGrouping, service.getByTag(run, tagInDB));
-    verifyAll();
-  }
-
-  @Test
-  public void getByRun_ReturnPeerGroupingsInRunProject() throws IOException {
-    expect(appProperties.getProperty("curriculum_base_dir")).andReturn("/var/curriculum");
-    expect(FileUtils.readFileToString(isA(File.class))).andReturn(projectJSONString);
-    expect(peerGroupingDao.getByTag(run, tagInDB)).andReturn(peerGrouping);
-    replayAll();
-    assertEquals(1, service.getByRun(run).size());
     verifyAll();
   }
 }


### PR DESCRIPTION
## Changes

- Only create Peer Groupings when run is created or through Authoring Tool (we no longer create Peer Groupings when a request is made for a tag that does not exist in the database)

## Test

- Create a run that contains Peer Groupings that do not contain the default values (defaults values are logic = "manual", maxMembershipCount = 2) and make sure the Peer Groupings in the database contain the correct values

Closes #118