### PR TITLE
fix(Peer Group): Return Peer Group not found response

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupAPIController.java
@@ -41,6 +41,7 @@ import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.service.peergroup.PeerGroupingThresholdNotSatisfiedException;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupNotFoundException;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergrouping.PeerGroupingService;
 import org.wise.portal.service.user.UserService;
@@ -67,7 +68,7 @@ public class PeerGroupAPIController {
   PeerGroup getPeerGroup(@PathVariable("runId") RunImpl run,
       @PathVariable("workgroupId") WorkgroupImpl workgroup,
       @PathVariable String peerGroupingTag, Authentication auth)
-      throws JSONException, PeerGroupCreationException,
+      throws JSONException, PeerGroupCreationException, PeerGroupNotFoundException,
       PeerGroupingThresholdNotSatisfiedException  {
     User user = userService.retrieveUserByUsername(auth.getName());
     if (workgroupService.isUserInWorkgroupForRun(user, run, workgroup) ||
@@ -79,7 +80,7 @@ public class PeerGroupAPIController {
   }
 
   private PeerGroup getPeerGroup(Run run, String peerGroupingTag, Workgroup workgroup)
-      throws JSONException, PeerGroupCreationException,
+      throws JSONException, PeerGroupCreationException, PeerGroupNotFoundException,
       PeerGroupingThresholdNotSatisfiedException {
     PeerGrouping peerGrouping = peerGroupingService.getByTag(run, peerGroupingTag);
     return peerGroupService.getPeerGroup(workgroup, peerGrouping);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIController.java
@@ -19,6 +19,7 @@ import org.wise.portal.domain.user.User;
 import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.service.peergroup.PeerGroupingThresholdNotSatisfiedException;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupNotFoundException;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergrouping.PeerGroupingNotFoundException;
 import org.wise.portal.service.peergrouping.PeerGroupingService;
@@ -64,7 +65,8 @@ public class PeerGroupWorkAPIController {
       @PathVariable("workgroupId") WorkgroupImpl workgroup,
       @PathVariable String nodeId, @PathVariable String componentId, Authentication auth)
       throws JSONException, PeerGroupingNotFoundException,
-      PeerGroupingThresholdNotSatisfiedException, PeerGroupCreationException {
+      PeerGroupingThresholdNotSatisfiedException, PeerGroupNotFoundException,
+      PeerGroupCreationException {
     User user = userService.retrieveUserByUsername(auth.getName());
     if (runService.isAllowedToViewStudentWork(run, user)) {
       PeerGrouping peerGrouping = peerGroupingService.getByComponent(run, nodeId,

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupNotFoundException.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupNotFoundException.java
@@ -1,0 +1,14 @@
+package org.wise.portal.service.peergroup;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class PeerGroupNotFoundException extends Exception {
+  
+  private static final long serialVersionUID = 1L;
+
+  public PeerGroupNotFoundException() {
+    super("PeerGroupNotFound");
+  }
+}

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
@@ -58,7 +58,8 @@ public interface PeerGroupService {
    * like an error occurred while grouping members
    */
   PeerGroup getPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping) throws JSONException,
-      PeerGroupingThresholdNotSatisfiedException, PeerGroupCreationException;
+      PeerGroupingThresholdNotSatisfiedException, PeerGroupNotFoundException,
+      PeerGroupNotFoundException, PeerGroupCreationException;
 
   /**
    * Gets all the PeerGroups for the specified PeerGrouping

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -42,6 +42,7 @@ import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupNotFoundException;
 import org.wise.portal.service.peergroup.PeerGroupingThresholdNotSatisfiedException;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergroup.PeerGroupThresholdService;
@@ -72,12 +73,16 @@ public class PeerGroupServiceImpl implements PeerGroupService {
   @Override
   public PeerGroup getPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
       throws JSONException, PeerGroupingThresholdNotSatisfiedException,
-      PeerGroupCreationException {
+      PeerGroupNotFoundException, PeerGroupCreationException {
     PeerGroup peerGroup = peerGroupDao.getByWorkgroupAndPeerGrouping(workgroup, peerGrouping);
     if (peerGrouping.getLogic().contains("manual")) {
       // use contains check instead of equals until custom logic is implemented for
       // backwards-compatibility
-      return peerGroup;
+      if (peerGroup == null) {
+        throw new PeerGroupNotFoundException();
+      } else {
+        return peerGroup;
+      }
     } else {
       return peerGroup != null ? peerGroup : this.createPeerGroup(workgroup, peerGrouping);
     }

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -53,6 +53,7 @@ import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergroup.PeerGroupNotFoundException;
 import org.wise.portal.service.peergroup.PeerGroupThresholdService;
 import org.wise.portal.service.run.RunService;
 import org.wise.vle.domain.work.StudentWork;
@@ -135,7 +136,11 @@ public class PeerGroupServiceImplTest extends PeerGroupServiceTest {
   public void getPeerGroup_ManualLogicPeerGroupNotExist_ReturnNull() throws Exception {
     expectPeerGroupFromDB(null, manualPeerGrouping);
     replayAll();
-    assertNull(service.getPeerGroup(run1Workgroup1, manualPeerGrouping));
+    try {
+      assertNull(service.getPeerGroup(run1Workgroup1, manualPeerGrouping));
+      fail("PeerGroupNotFoundException expected, but wasn't thrown");
+    } catch(PeerGroupNotFoundException e) {
+    }
     verifyAll();
   }
 
@@ -197,11 +202,6 @@ public class PeerGroupServiceImplTest extends PeerGroupServiceTest {
         .andReturn(isSatisfied);
   }
 
-  private void expectWorkForLogicComponent(List<StudentWork> workForLogicComponent) {
-    expect(studentWorkDao.getWorkForComponentByPeriod(run1, run1Period1, run1Node1Id,
-        run1Component1Id)).andReturn(workForLogicComponent);
-  }
-
   private void expectPeerGroupFromDB(PeerGroup peerGroup) {
     expectPeerGroupFromDB(peerGroup, peerGrouping);
   }
@@ -209,12 +209,6 @@ public class PeerGroupServiceImplTest extends PeerGroupServiceTest {
   private void expectPeerGroupFromDB(PeerGroup peerGroup, PeerGrouping peerGrouping) {
     expect(peerGroupDao.getByWorkgroupAndPeerGrouping(run1Workgroup1, peerGrouping))
       .andReturn(peerGroup);
-  }
-
-  private void expectWorkForComponentByWorkgroup(List<StudentWork> expectedWork)
-      throws JSONException {
-    expect(studentWorkDao.getWorkForComponentByWorkgroup(run1Workgroup1,
-        peerGrouping.getLogicNodeId(), peerGrouping.getLogicComponentId())).andReturn(expectedWork);
   }
 
   private void expectIsLastOnesLeftToPair() {


### PR DESCRIPTION
## Changes

When a manual assigned Peer Group is not found, throw an exception and have it return a not found response.

## Test

On the client
1. Create a Peer Chat that uses manual assignment
2. Log in as a student and go to the Peer Chat (do not have that teacher manually assign them to a group)
3. The console should not throw a null pointer anymore. The Peer Chat component should show the student that the Peer Chat is not available yet.

This is the client console error that used to be thrown
```
core.mjs:6485 ERROR TypeError: Cannot read properties of null (reading 'members')
    at PeerChatStudentComponent.getPeerGroupWorkgroupIds (peer-chat-student.component.ts:117:22)
    at SafeSubscriber.peerGroupService.retrievePeerGroup.pipe.subscribe.isPeerChatWorkgroupsResponseReceived [as _next] (peer-chat-student.component.ts:101:46)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:183:1)
```

Closes #122 