### PR TITLE
fix(PeerGroup): Return null when random pairing cannot be made

### DIFF
--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -86,7 +86,7 @@ public class PeerGroupServiceImpl implements PeerGroupService {
   private PeerGroup createPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
       throws PeerGroupingThresholdNotSatisfiedException, PeerGroupCreationException {
     if (!peerGroupThresholdService.canCreatePeerGroup(peerGrouping, workgroup.getPeriod())) {
-      throw new PeerGroupCreationException();
+      return null;
     } else {
       PeerGroup peerGroup = new PeerGroupImpl(peerGrouping, workgroup.getPeriod(),
           getPeerGroupMembers(workgroup, peerGrouping));

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
@@ -49,7 +49,7 @@ public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService 
 
   public boolean canCreatePeerGroup(PeerGrouping peerGrouping, Group period) {
     int numWorkgroupsNotInPeerGroup = getNumNonEmptyWorkgroupsInPeriod(peerGrouping, period) -
-        getNumWorkgroupsInPeerGroup(peerGrouping, period);
+        getNumNonEmptyWorkgroupsInPeerGroup(peerGrouping, period);
     return numWorkgroupsNotInPeerGroup > 1;
   }
 
@@ -60,12 +60,12 @@ public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService 
     return workgroupsInPeriod.size();
   }
 
-  private int getNumWorkgroupsInPeerGroup(PeerGrouping activity, Group period) {
+  private int getNumNonEmptyWorkgroupsInPeerGroup(PeerGrouping activity, Group period) {
     int numWorkgroupsInPeerGroup = 0;
     List<PeerGroup> peerGroups = peerGroupDao.getListByPeerGrouping(activity);
     for (PeerGroup peerGroup : peerGroups) {
       for (Workgroup workgroup : peerGroup.getMembers()) {
-        if (workgroup.getPeriod().equals(period)) {
+        if (workgroup.getMembers().size() > 0 && workgroup.getPeriod().equals(period)) {
           numWorkgroupsInPeerGroup++;
         }
       }

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImplTest.java
@@ -93,15 +93,11 @@ public class PeerGroupServiceImplTest extends PeerGroupServiceTest {
   }
 
   @Test
-  public void getPeerGroup_WorkgroupCountThresholdNotSatisfied_ThrowException() throws Exception {
+  public void getPeerGroup_WorkgroupCountThresholdNotSatisfied_ReturnNull() throws Exception {
     expectPeerGroupFromDB(null);
     expectWorkgroupCountThresholdSatisfied(false);
     replayAll();
-    try {
-      service.getPeerGroup(run1Workgroup1, peerGrouping);
-      fail("PeerGroupCreationException expected, but wasn't thrown");
-    } catch (PeerGroupCreationException e) {
-    }
+    assertNull(service.getPeerGroup(run1Workgroup1, peerGrouping));
     verifyAll();
   }
 


### PR DESCRIPTION
## Changes
- Return null instead of throwing exception. This is now the expected behavior, similar to the manual pairing behavior.
- Also fixed corner case where empty teams messed up calculating number of pairings that were already made

## Test
- make sure null is returned when pairing logic is random and a pairing can't be made

Closes #124 