### PR TITLE
feat(Security): Return 403 status when access is denied

### DIFF
--- a/src/main/java/org/wise/portal/spring/impl/WebConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebConfig.java
@@ -180,6 +180,7 @@ public class WebConfig implements WebMvcConfigurer {
     mappings.setProperty("org.wise.portal.presentation.web.exception.NotAuthorizedException",
         "errors/accessdenied");
     resolver.setExceptionMappings(mappings);
+    resolver.addStatusCode("errors/accessdenied", 403);
     return resolver;
   }
 

--- a/src/main/java/org/wise/vle/web/wise5/StudentDataController.java
+++ b/src/main/java/org/wise/vle/web/wise5/StudentDataController.java
@@ -36,6 +36,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,6 +61,7 @@ import org.wise.vle.domain.work.StudentWork;
  *
  * @author Hiroki Terashima
  */
+@Secured("ROLE_USER")
 @Controller("wise5StudentDataController")
 @RequestMapping("/api")
 public class StudentDataController {


### PR DESCRIPTION
## Changes
- Return 403 status when access is denied
- Secure StudentDataController methods to ROLE_USER

## Test
1. Log in as student and launch VLE. Open Network tab in dev tools
2. Log into redis-cli and flush all keys 
```
redis> keys *     // should list all sessions
redis> flushall
redis> keys *     // should be empty
```
3. As student, go to the next step. You should see 403 response for request to save student data

Closes #128