### PR TITLE
refactor(Summary): Update classmate summary endpoints

### DIFF
--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectContent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectContent.java
@@ -23,6 +23,9 @@
  */
 package org.wise.portal.domain.project.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -57,5 +60,22 @@ public class ProjectContent {
 
   public JSONArray getPeerGroupings() {
     return this.projectJSON.optJSONArray("peerGroupings");
+  }
+
+  public List<ProjectComponent> getComponents() throws JSONException {
+    List<ProjectComponent> projectComponents = new ArrayList<ProjectComponent>();
+    JSONArray nodes = this.projectJSON.getJSONArray("nodes");
+    for (int n = 0; n < nodes.length(); n++) {
+      JSONObject node = nodes.getJSONObject(n);
+      if (node.getString("type").equals("node")) {
+        ProjectNode projectNode = new ProjectNode(node);
+        JSONArray components = node.getJSONArray("components");
+        for (int c = 0; c < components.length(); c++) {
+          JSONObject component = components.getJSONObject(c);
+          projectComponents.add(new ProjectComponent(projectNode, component));
+        }
+      }
+    }
+    return projectComponents;
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
@@ -61,6 +61,14 @@ public abstract class ClassmateDataController {
     return projectContent.getComponent(nodeId, componentId);
   }
 
+  protected List<ProjectComponent> getProjectComponents(Run run)
+      throws IOException, JSONException, ObjectNotFoundException {
+    String projectString = projectService.getProjectContent(run.getProject());
+    JSONObject projectJSON = new JSONObject(projectString);
+    ProjectContent projectContent = new ProjectContent(projectJSON);
+    return projectContent.getComponents();
+  }
+
   protected List<StudentWork> getStudentWork(Run run, String nodeId, String componentId) {
     return vleService.getStudentWork(run, nodeId, componentId);
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
@@ -62,7 +62,7 @@ public abstract class ClassmateDataController {
   }
 
   protected List<ProjectComponent> getProjectComponents(Run run)
-      throws IOException, JSONException, ObjectNotFoundException {
+      throws IOException, JSONException {
     String projectString = projectService.getProjectContent(run.getProject());
     JSONObject projectJSON = new JSONObject(projectString);
     ProjectContent projectContent = new ProjectContent(projectJSON);

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
@@ -37,9 +37,9 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
       throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
-      if (PERIOD_SOURCE.equals(source)) {
+      if (isPeriodSource(source)) {
         return getLatestStudentWork(run, period, nodeId, componentId);
-      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+      } else if (isAllPeriodsSource(source)) {
         return getLatestStudentWork(run, nodeId, componentId);
       }
     }
@@ -53,9 +53,9 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
       throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
-      if (PERIOD_SOURCE.equals(source)) {
+      if (isPeriodSource(source)) {
         return getLatestScoreAnnotations(getAnnotations(run, period, nodeId, componentId));
-      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+      } else if (isAllPeriodsSource(source)) {
         return getLatestScoreAnnotations(getAnnotations(run, nodeId, componentId));
       }
     }
@@ -82,10 +82,18 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
     return false;
   }
 
+  private boolean isPeriodSource(String source) {
+    return source.equals(PERIOD_SOURCE);
+  }
+
+  private boolean isAllPeriodsSource(String source) {
+    return source.equals(ALL_PERIODS_SOURCE);
+  }
+
   private List<Annotation> getLatestScoreAnnotations(List<Annotation> annotations) {
     HashMap<Long, Annotation> latestScoreAnnotationPerWorkgroup = new HashMap<Long, Annotation>();
     for (Annotation annotation : annotations) {
-      if (isScoreType(annotation)) {
+      if (annotation.isScoreType()) {
         Long key = annotation.getToWorkgroup().getId();
         if (latestScoreAnnotationPerWorkgroup.containsKey(key)) {
           if (isAfter(annotation, latestScoreAnnotationPerWorkgroup.get(key))) {
@@ -97,11 +105,6 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
       }
     }
     return new ArrayList<Annotation>(latestScoreAnnotationPerWorkgroup.values());
-  }
-
-  private boolean isScoreType(Annotation annotation) {
-    String type = annotation.getType();
-    return type.equals("score") || type.equals("autoScore");
   }
 
   private boolean isAfter(Annotation annotation1, Annotation annotation2) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
@@ -1,6 +1,8 @@
 package org.wise.portal.presentation.web.controllers.student;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.json.JSONException;
@@ -28,53 +30,81 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
   final String PERIOD_SOURCE = "period";
   final String SUMMARY_TYPE = "Summary";
 
-  @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}/{source}")
+  @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{source}")
   public List<StudentWork> getClassmateSummaryWork(Authentication auth,
       @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
-      @PathVariable String componentId, @PathVariable String otherNodeId,
-      @PathVariable String otherComponentId, @PathVariable String source)
+      @PathVariable String componentId, @PathVariable String source)
       throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
-    if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
-      if (source.equals(PERIOD_SOURCE)) {
-        return getStudentWork(run, period, otherNodeId, otherComponentId);
-      } else if (source.equals(ALL_PERIODS_SOURCE)) {
-        return getStudentWork(run, otherNodeId, otherComponentId);
+    if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
+      if (PERIOD_SOURCE.equals(source)) {
+        return getLatestStudentWork(run, period, nodeId, componentId);
+      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+        return getLatestStudentWork(run, nodeId, componentId);
       }
     }
     throw new AccessDeniedException(NOT_PERMITTED);
   }
 
-  @GetMapping("/annotations/{runId}/{periodId}/{nodeId}/{componentId}/{otherNodeId}/{otherComponentId}/{source}")
-  public List<Annotation> getClassmateSummaryAnnotations(Authentication auth,
+  @GetMapping("/scores/{runId}/{periodId}/{nodeId}/{componentId}/{source}")
+  public List<Annotation> getClassmateSummaryScores(Authentication auth,
       @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
-      @PathVariable String componentId, @PathVariable String otherNodeId,
-      @PathVariable String otherComponentId, @PathVariable String source)
+      @PathVariable String componentId, @PathVariable String source)
       throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
-    if (isAllowedToGetData(auth, run, period, nodeId, componentId, otherNodeId, otherComponentId)) {
-      if (source.equals(PERIOD_SOURCE)) {
-        return getAnnotations(run, period, otherNodeId, otherComponentId);
-      } else if (source.equals(ALL_PERIODS_SOURCE)) {
-        return getAnnotations(run, otherNodeId, otherComponentId);
+    if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
+      if (PERIOD_SOURCE.equals(source)) {
+        return getLatestScoreAnnotations(getAnnotations(run, period, nodeId, componentId));
+      } else if (ALL_PERIODS_SOURCE.equals(source)) {
+        return getLatestScoreAnnotations(getAnnotations(run, nodeId, componentId));
       }
     }
     throw new AccessDeniedException(NOT_PERMITTED);
   }
 
   private boolean isAllowedToGetData(Authentication auth, Run run, Group period, String nodeId,
-      String componentId, String otherNodeId, String otherComponentId)
+      String componentId)
       throws IOException, JSONException, ObjectNotFoundException {
     return isUserInRunAndPeriod(auth, run, period)
-        && isValidSummaryComponent(run, nodeId, componentId, otherNodeId, otherComponentId);
+        && isValidSummaryComponent(run, nodeId, componentId);
   }
 
-  private boolean isValidSummaryComponent(Run run, String nodeId, String componentId,
-      String otherNodeId, String otherComponentId)
+  private boolean isValidSummaryComponent(Run run, String nodeId, String componentId)
       throws IOException, JSONException, ObjectNotFoundException {
-    ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
-    return projectComponent.getString("type").equals(SUMMARY_TYPE)
-        && projectComponent.getString("summaryNodeId").equals(otherNodeId)
-        && projectComponent.getString("summaryComponentId").equals(otherComponentId);
+    List<ProjectComponent> projectComponents = getProjectComponents(run);
+    for (ProjectComponent projectComponent : projectComponents) {
+      if (projectComponent.getString("type").equals(SUMMARY_TYPE) &&
+          projectComponent.getString("summaryNodeId").equals(nodeId) &&
+          projectComponent.getString("summaryComponentId").equals(componentId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private List<Annotation> getLatestScoreAnnotations(List<Annotation> annotations) {
+    HashMap<Long, Annotation> latestScoreAnnotationPerWorkgroup = new HashMap<Long, Annotation>();
+    for (Annotation annotation : annotations) {
+      if (isScoreType(annotation)) {
+        Long key = annotation.getToWorkgroup().getId();
+        if (latestScoreAnnotationPerWorkgroup.containsKey(key)) {
+          if (isAfter(annotation, latestScoreAnnotationPerWorkgroup.get(key))) {
+            latestScoreAnnotationPerWorkgroup.put(key, annotation);
+          }
+        } else {
+          latestScoreAnnotationPerWorkgroup.put(key, annotation);
+        }
+      }
+    }
+    return new ArrayList<Annotation>(latestScoreAnnotationPerWorkgroup.values());
+  }
+
+  private boolean isScoreType(Annotation annotation) {
+    String type = annotation.getType();
+    return type.equals("score") || type.equals("autoScore");
+  }
+
+  private boolean isAfter(Annotation annotation1, Annotation annotation2) {
+    return annotation1.getServerSaveTime().after(annotation2.getServerSaveTime());
   }
 }

--- a/src/main/java/org/wise/vle/domain/annotation/wise5/Annotation.java
+++ b/src/main/java/org/wise/vle/domain/annotation/wise5/Annotation.java
@@ -148,6 +148,10 @@ public class Annotation extends PersistableDomain {
     }
   }
 
+  public boolean isScoreType() {
+    return this.type.equals("score") || this.type.equals("autoScore");
+  }
+
   public JSONObject toJSON() {
     JSONObject eventJSONObject = new JSONObject();
 

--- a/src/test/java/org/wise/portal/domain/annotation/AnnotationTest.java
+++ b/src/test/java/org/wise/portal/domain/annotation/AnnotationTest.java
@@ -1,5 +1,7 @@
 package org.wise.portal.domain.annotation;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Timestamp;
@@ -89,5 +91,23 @@ public class AnnotationTest {
         + "\"nodeId\":null,\"periodId\":100,\"runId\":1,\"serverSaveTime\":2000000000000,"
         + "\"type\":\"score\"}";
     assertEquals(expectedJson, json);
+  }
+
+  @Test
+  public void isScoreType_scoreType_shouldReturnTrue() {
+    annotation.setType("score");
+    assertTrue(annotation.isScoreType());
+  }
+
+  @Test
+  public void isScoreType_autoScoreType_shouldReturnTrue() {
+    annotation.setType("autoScore");
+    assertTrue(annotation.isScoreType());
+  }
+
+  @Test
+  public void isScoreType_commentType_shouldReturnFalse() {
+    annotation.setType("comment");
+    assertFalse(annotation.isScoreType());
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
@@ -109,6 +109,7 @@ public abstract class AbstractClassmateDataControllerTest extends APIControllerT
         .append("  \"nodes\": [")
         .append("    {")
         .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"type\": \"node\",")
         .append("      \"components\": [")
         .append("        {")
         .append("          \"id\": \"" + componentId + "\",")

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataControllerTest.java
@@ -107,6 +107,7 @@ public class ClassmateDataControllerTest extends AbstractClassmateDataController
         .append("  \"nodes\": [")
         .append("    {")
         .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"type\": \"node\",")
         .append("      \"components\": [")
         .append("        {")
         .append("          \"id\": \"" + componentId + "\",")

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataControllerTest.java
@@ -153,6 +153,7 @@ public class ClassmateGraphDataControllerTest extends AbstractClassmateDataContr
         .append("  \"nodes\": [")
         .append("    {")
         .append("      \"id\": \"" + nodeId + "\",")
+        .append("      \"type\": \"node\",")
         .append("      \"components\": [")
         .append("        {")
         .append("          \"id\": \"" + componentId + "\",")


### PR DESCRIPTION
You should test this with https://github.com/WISE-Community/WISE-Client/pull/603

## Changes

- The endpoints only require one node id and one component id now
- The endpoints also only return the latest for each workgroup

# Test

- Students can only retrieve summary data from a component that is referenced in a summary component
- Requests for data that is not allowed should receive an Access Denied response
- Make sure the student work endpoint only returns the latest student work for each workgroup
- Make sure the scores endpoint only returns the latest score for each workgroup

Closes #130