### PR TITLE
fix(Student Work): Only allow students to get their own work

### DIFF
--- a/src/main/java/org/wise/vle/web/wise5/StudentDataController.java
+++ b/src/main/java/org/wise/vle/web/wise5/StudentDataController.java
@@ -118,7 +118,7 @@ public class StudentDataController {
     JSONObject result = new JSONObject();
     User user = userService.retrieveUser((StudentUserDetails) authentication.getPrincipal());
     Run run = runService.retrieveById(Long.valueOf(runId));
-    if (getStudentWork && isAllowedToGetStudentData(user, run, workgroupId)) {
+    if (getStudentWork && isMemberOfWorkgroupId(user, run, workgroupId)) {
       try {
         result.put("studentWorkList", getStudentWork(id, runId, periodId, workgroupId,
             isAutoSave, isSubmit, nodeId, componentId, componentType, components, onlyGetLatest));
@@ -126,7 +126,7 @@ public class StudentDataController {
         e.printStackTrace();
       }
     }
-    if (getEvents && isAllowedToGetEvents(user, run, workgroupId)) {
+    if (getEvents && isMemberOfWorkgroupId(user, run, workgroupId)) {
       try {
         result.put("events", getEvents(id, runId, periodId, workgroupId, nodeId, componentId,
             componentType, context, category, event, components));
@@ -150,16 +150,6 @@ public class StudentDataController {
     } catch (IOException e) {
       e.printStackTrace();
     }
-  }
-
-  private boolean isAllowedToGetStudentData(User user, Run run, Integer workgroupId)
-      throws ObjectNotFoundException {
-    return isMemberOfWorkgroupId(user, run, workgroupId);
-  }
-
-  private boolean isAllowedToGetEvents(User user, Run run, Integer workgroupId)
-      throws ObjectNotFoundException {
-    return isMemberOfWorkgroupId(user, run, workgroupId);
   }
 
   private boolean isAllowedToGetAnnotations(User user, Run run, Integer fromWorkgroupId,

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -47,6 +47,7 @@ public abstract class APIControllerTest {
   protected final String RUN3_RUNCODE = "giraffe123";
   protected final String RUN1_PERIOD1_NAME = "1";
   protected final String RUN1_PERIOD2_NAME = "2";
+  protected final String SHOULD_NOT_HAVE_THROWN_EXCEPTION = "Should not have thrown an exception";
   protected final String STUDENT_FIRSTNAME = "SpongeBob";
   protected final String STUDENT_LASTNAME = "Squarepants";
   protected final String STUDENT_PASSWORD = "studentPass";

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
@@ -23,7 +23,6 @@ public abstract class AbstractClassmateDataControllerTest extends APIControllerT
   String OTHER_COMPONENT_ID_NOT_ALLOWED = "component3";
   String OTHER_NODE_ID = "node2";
   String OTHER_NODE_ID_NOT_ALLOWED = "node3";
-  String SHOULD_NOT_HAVE_THROWN_EXCEPTION = "Should not have thrown an exception";
 
   protected void expectStudentWork(List<StudentWork> studentWork) {
     expectStudentWork(run1, run1Period1, NODE_ID1, COMPONENT_ID1, studentWork);

--- a/src/test/java/org/wise/vle/web/wise5/StudentDataControllerTest.java
+++ b/src/test/java/org/wise/vle/web/wise5/StudentDataControllerTest.java
@@ -1,0 +1,170 @@
+package org.wise.vle.web.wise5;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.authentication.impl.StudentUserDetails;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.vle.domain.work.StudentWork;
+
+@SpringBootTest
+@RunWith(EasyMockRunner.class)
+public class StudentDataControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private StudentDataController controller = new StudentDataController(); 
+
+  private HttpServletResponse response;
+  private boolean getStudentWork;
+  private boolean getEvents;
+  private boolean getAnnotations;
+  private Integer id;
+  private Integer runId;
+  private Integer periodId;
+  private Integer workgroupId;
+  private Boolean isAutoSave;
+  private Boolean isSubmit;
+  private String nodeId;
+  private String componentId;
+  private String componentType;
+  private String context;
+  private String category;
+  private String event;
+  private Integer fromWorkgroupId;
+  private Integer toWorkgroupId;
+  private Integer studentWorkId;
+  private String localNotebookItemId;
+  private Integer notebookItemId;
+  private String annotationType;
+  private List<JSONObject> components;
+  private Boolean onlyGetLatest;
+
+  @Before
+  public void init() {
+    response = new MockHttpServletResponse();
+    getStudentWork = false;
+    getEvents = false;
+    getAnnotations = false;
+    id = null;
+    runId = null;
+    periodId = null;
+    workgroupId = null;
+    isAutoSave = false;
+    isSubmit = false;
+    nodeId = null;
+    componentId = null;
+    componentType = null;
+    context = null;
+    category = null;
+    event = null;
+    fromWorkgroupId = null;
+    toWorkgroupId = null;
+    studentWorkId = null;
+    localNotebookItemId = null;
+    notebookItemId = null;
+    annotationType = null;
+    components = null;
+    onlyGetLatest = false;
+  }
+
+  @Test
+  public void getWISE5StudentData_NotAllowedToGetData_DoesNotRetrieveStudentWork() {
+    try {
+      getStudentWork = true;
+      runId = Integer.valueOf(runId1.intValue());
+      workgroupId = Integer.valueOf(workgroup2Id.intValue());
+      expectRetrieveUser(student1UserDetails, student1);
+      expectRetrieveRun(runId1, run1);
+      expectRetrieveWorkgroup(workgroup2Id, workgroup2);
+      expectIsUserInWorkgroupForRun(student1, run1, workgroup2, false);
+      replayAll();
+      controller.getWISE5StudentData(response, studentAuth, getStudentWork, getEvents,
+          getAnnotations, id, runId, periodId, workgroupId, isAutoSave, isSubmit, nodeId,
+          componentId, componentType, context, category, event, fromWorkgroupId, toWorkgroupId,
+          studentWorkId, localNotebookItemId, notebookItemId, annotationType, components,
+          onlyGetLatest);
+    } catch(ObjectNotFoundException | IOException | JSONException e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getWISE5StudentData_AllowedToGetData_RetrievesStudentWork() {
+    try {
+      getStudentWork = true;
+      runId = Integer.valueOf(runId1.intValue());
+      workgroupId = Integer.valueOf(workgroup1Id.intValue());
+      List<StudentWork> studentWorkList = Arrays.asList(new StudentWork(), new StudentWork());
+      expectRetrieveUser(student1UserDetails, student1);
+      expectRetrieveRun(runId1, run1);
+      expectRetrieveWorkgroup(workgroup1Id, workgroup1);
+      expectIsUserInWorkgroupForRun(student1, run1, workgroup1, true);
+      expectGetStudentWorkList(id, runId, periodId, workgroupId, isAutoSave, isSubmit, nodeId,
+          componentId, componentType, components, onlyGetLatest, studentWorkList);
+      replayAll();
+      controller.getWISE5StudentData(response, studentAuth, getStudentWork, getEvents,
+          getAnnotations, id, runId, periodId, workgroupId, isAutoSave, isSubmit, nodeId,
+          componentId, componentType, context, category, event, fromWorkgroupId, toWorkgroupId,
+          studentWorkId, localNotebookItemId, notebookItemId, annotationType, components,
+          onlyGetLatest);
+    } catch(ObjectNotFoundException | IOException | JSONException e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  private void expectRetrieveUser(StudentUserDetails studentUserDetails, User user) {
+    expect(userService.retrieveUser(studentUserDetails)).andReturn(user);
+  }
+
+  private void expectRetrieveRun(Long runId, Run run) throws ObjectNotFoundException {
+    expect(runService.retrieveById(runId)).andReturn(run);
+  }
+
+  private void expectRetrieveWorkgroup(Long workgroupId, Workgroup workgroup)
+      throws ObjectNotFoundException{
+    expect(workgroupService.retrieveById(workgroupId)).andReturn(workgroup);
+  }
+
+  private void expectIsUserInWorkgroupForRun(User user, Run run, Workgroup workgroup,
+      boolean result) {
+    expect(workgroupService.isUserInWorkgroupForRun(user, run, workgroup)).andReturn(result);
+  }
+
+  private void expectGetStudentWorkList(Integer id, Integer runId, Integer periodId,
+      Integer workgroupId, Boolean isAutoSave, Boolean isSubmit, String nodeId, String componentId,
+      String componentType, List<JSONObject> components, Boolean onlyGetLatest,
+      List<StudentWork> result) {
+    expect(vleService.getStudentWorkList(id, runId, periodId, workgroupId, isAutoSave, isSubmit,
+        nodeId, componentId, componentType, components, onlyGetLatest)).andReturn(result);
+  }
+
+  private void replayAll() {
+    replay(runService, userService, vleService, workgroupService);
+  }
+
+  private void verifyAll() {
+    verify(runService, userService, vleService, workgroupService);
+  }
+
+}


### PR DESCRIPTION
## Changes

Only allow students to get their own work.

## Test

- Make sure students can still get their own work
- Make sure students can still get classmate work in Discussion and Summary components (because they use a different endpoint)
- Make sure students can't get other workgroup's work, events, and annotations

You can log in as a student and try to retrieve data from other workgroups by changing the workgroupId in the url. Replace {runId} and {workgroupId}.

Url to get student work
```http://localhost:81/api/student/data?runId={runId}&workgroupId={workgroupId}&getStudentWork=true```

Url to get student events
```http://localhost:81/api/student/data?runId={runId}&workgroupId={workgroupId}&getEvents=true```

Url to get student annotations
```http://localhost:81/api/student/data?runId={runId}&getAnnotations=true&toWorkgroupId={workgroupId}```


Closes #46