### PR TITLE
refactor(Summary): Split classmate summary data endpoints

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.authentication.impl.StudentUserDetails;
+import org.wise.portal.domain.authentication.impl.TeacherUserDetails;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.project.impl.ProjectContent;
@@ -37,14 +38,27 @@ public abstract class ClassmateDataController {
   @Autowired
   protected VLEService vleService;
 
-  protected boolean isUserInRun(Authentication auth, Run run) {
-    User user = userService.retrieveUser((StudentUserDetails) auth.getPrincipal());
-    return run.isStudentAssociatedToThisRun(user);
+  protected boolean isStudent(Authentication auth) {
+    return auth.getPrincipal() instanceof StudentUserDetails;
   }
 
-  protected boolean isUserInRunAndPeriod(Authentication auth, Run run, Group period) {
+  protected boolean isTeacher(Authentication auth) {
+    return auth.getPrincipal() instanceof TeacherUserDetails;
+  }
+
+  protected boolean isStudentInRun(Authentication auth, Run run) {
     User user = userService.retrieveUser((StudentUserDetails) auth.getPrincipal());
-    return run.isStudentAssociatedToThisRunAndPeriod(user, period);
+    return user != null && run.isStudentAssociatedToThisRun(user);
+  }
+
+  protected boolean isStudentInRunAndPeriod(Authentication auth, Run run, Group period) {
+    User user = userService.retrieveUser((StudentUserDetails) auth.getPrincipal());
+    return user != null && run.isStudentAssociatedToThisRunAndPeriod(user, period);
+  }
+
+  protected boolean isTeacherOfRun(Authentication auth, Run run) {
+    User user = userService.retrieveUser((TeacherUserDetails) auth.getPrincipal());
+    return user != null && run.isTeacherAssociatedToThisRun(user);
   }
 
   protected boolean isComponentType(Run run, String nodeId, String componentId,

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateDiscussionDataController.java
@@ -52,7 +52,7 @@ public class ClassmateDiscussionDataController extends ClassmateDataController {
 
   private boolean isAllowedToGetData(Authentication auth, Run run, Group period, String nodeId,
       String componentId) throws IOException, JSONException, ObjectNotFoundException {
-    return isUserInRunAndPeriod(auth, run, period)
+    return isStudentInRunAndPeriod(auth, run, period)
         && isDiscussionComponent(run, nodeId, componentId);
   }
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateGraphDataController.java
@@ -60,14 +60,14 @@ public class ClassmateGraphDataController extends ClassmateDataController {
   private boolean isAllowedToGetData(Authentication auth, Run run, Group period, String nodeId,
       String componentId, String showWorkNodeId, String showWorkComponentId,
       String showClassmateWorkSource) throws IOException, JSONException, ObjectNotFoundException {
-    return isUserInRunAndPeriod(auth, run, period) && isValidGraphComponent(run, nodeId,
+    return isStudentInRunAndPeriod(auth, run, period) && isValidGraphComponent(run, nodeId,
         componentId, showWorkNodeId, showWorkComponentId, showClassmateWorkSource);
   }
 
   private boolean isAllowedToGetData(Authentication auth, Run run, String nodeId,
       String componentId, String showWorkNodeId, String showWorkComponentId,
       String showClassmateWorkSource) throws IOException, JSONException, ObjectNotFoundException {
-    return isUserInRun(auth, run) && isValidGraphComponent(run, nodeId, componentId, showWorkNodeId,
+    return isStudentInRun(auth, run) && isValidGraphComponent(run, nodeId, componentId, showWorkNodeId,
         showWorkComponentId, showClassmateWorkSource);
   }
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataController.java
@@ -22,7 +22,7 @@ import org.wise.vle.domain.annotation.wise5.Annotation;
 import org.wise.vle.domain.work.StudentWork;
 
 @RestController
-@Secured("ROLE_STUDENT")
+@Secured("ROLE_USER")
 @RequestMapping("/api/classmate/summary")
 public class ClassmateSummaryDataController extends ClassmateDataController {
 
@@ -30,43 +30,64 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
   final String PERIOD_SOURCE = "period";
   final String SUMMARY_TYPE = "Summary";
 
-  @GetMapping("/student-work/{runId}/{periodId}/{nodeId}/{componentId}/{source}")
-  public List<StudentWork> getClassmateSummaryWork(Authentication auth,
+  @GetMapping("/student-work/{runId}/{nodeId}/{componentId}/period/{periodId}")
+  public List<StudentWork> getClassmateSummaryWorkInPeriod(Authentication auth,
       @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
-      @PathVariable String componentId, @PathVariable String source)
+      @PathVariable String componentId)
       throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
-      if (isPeriodSource(source)) {
-        return getLatestStudentWork(run, period, nodeId, componentId);
-      } else if (isAllPeriodsSource(source)) {
-        return getLatestStudentWork(run, nodeId, componentId);
-      }
+      return getLatestStudentWork(run, period, nodeId, componentId);
     }
     throw new AccessDeniedException(NOT_PERMITTED);
   }
 
-  @GetMapping("/scores/{runId}/{periodId}/{nodeId}/{componentId}/{source}")
-  public List<Annotation> getClassmateSummaryScores(Authentication auth,
+  @GetMapping("/student-work/{runId}/{nodeId}/{componentId}/class")
+  public List<StudentWork> getClassmateSummaryWorkInClass(Authentication auth,
+      @PathVariable("runId") RunImpl run, @PathVariable String nodeId,
+      @PathVariable String componentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    if (isAllowedToGetData(auth, run, nodeId, componentId)) {
+      return getLatestStudentWork(run, nodeId, componentId);
+    }
+    throw new AccessDeniedException(NOT_PERMITTED);
+  }
+
+  @GetMapping("/scores/{runId}/{nodeId}/{componentId}/period/{periodId}")
+  public List<Annotation> getClassmateSummaryScoresInPeriod(Authentication auth,
       @PathVariable("runId") RunImpl run, @PathVariable Long periodId, @PathVariable String nodeId,
-      @PathVariable String componentId, @PathVariable String source)
+      @PathVariable String componentId)
       throws IOException, JSONException, ObjectNotFoundException {
     Group period = groupService.retrieveById(periodId);
     if (isAllowedToGetData(auth, run, period, nodeId, componentId)) {
-      if (isPeriodSource(source)) {
-        return getLatestScoreAnnotations(getAnnotations(run, period, nodeId, componentId));
-      } else if (isAllPeriodsSource(source)) {
-        return getLatestScoreAnnotations(getAnnotations(run, nodeId, componentId));
-      }
+      return getLatestScoreAnnotations(getAnnotations(run, period, nodeId, componentId));
+    }
+    throw new AccessDeniedException(NOT_PERMITTED);
+  }
+
+  @GetMapping("/scores/{runId}/{nodeId}/{componentId}/class")
+  public List<Annotation> getClassmateSummaryScoresInClass(Authentication auth,
+      @PathVariable("runId") RunImpl run, @PathVariable String nodeId,
+      @PathVariable String componentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    if (isAllowedToGetData(auth, run, nodeId, componentId)) {
+      return getLatestScoreAnnotations(getAnnotations(run, nodeId, componentId));
     }
     throw new AccessDeniedException(NOT_PERMITTED);
   }
 
   private boolean isAllowedToGetData(Authentication auth, Run run, Group period, String nodeId,
-      String componentId)
-      throws IOException, JSONException, ObjectNotFoundException {
-    return isUserInRunAndPeriod(auth, run, period)
-        && isValidSummaryComponent(run, nodeId, componentId);
+      String componentId) throws IOException, JSONException, ObjectNotFoundException {
+    return (isStudent(auth) && isStudentInRunAndPeriod(auth, run, period) &&
+        isValidSummaryComponent(run, nodeId, componentId)) ||
+        (isTeacher(auth) && isTeacherOfRun(auth, run));
+  }
+
+  private boolean isAllowedToGetData(Authentication auth, Run run, String nodeId,
+      String componentId) throws IOException, JSONException, ObjectNotFoundException {
+    return (isStudent(auth) && isStudentInRun(auth, run) &&
+        isValidSummaryComponent(run, nodeId, componentId)) ||
+        (isTeacher(auth) && isTeacherOfRun(auth, run));
   }
 
   private boolean isValidSummaryComponent(Run run, String nodeId, String componentId)
@@ -80,14 +101,6 @@ public class ClassmateSummaryDataController extends ClassmateDataController {
       }
     }
     return false;
-  }
-
-  private boolean isPeriodSource(String source) {
-    return source.equals(PERIOD_SOURCE);
-  }
-
-  private boolean isAllPeriodsSource(String source) {
-    return source.equals(ALL_PERIODS_SOURCE);
   }
 
   private List<Annotation> getLatestScoreAnnotations(List<Annotation> annotations) {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -63,7 +63,7 @@ public abstract class APIControllerTest {
   protected final String TEACHER2_USERNAME = "SandyCheeks";
   protected final String USERNAME_NOT_IN_DB = "usernameNotInDB";
 
-  protected Authentication adminAuth, studentAuth, studentAuth2, teacherAuth;
+  protected Authentication adminAuth, studentAuth, studentAuth2, teacherAuth, teacherAuth2;
   protected ProjectImpl project1, project2, project3;
   protected Long projectId1 = 1L;
   protected Long projectId2 = 2L;
@@ -151,6 +151,7 @@ public abstract class APIControllerTest {
     teacher2UserDetails = createTeacherUserDetails(TEACHER2_FIRSTNAME, TEACHER2_LASTNAME,
         TEACHER2_USERNAME, Schoollevel.COLLEGE, 5);
     teacher2 = createTeacher(teacher2Id, teacher2UserDetails);
+    teacherAuth2 = createAuthentication(teacher2UserDetails);
   }
 
   private void createAdmin() {

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/AbstractClassmateDataControllerTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.authentication.impl.StudentUserDetails;
+import org.wise.portal.domain.authentication.impl.TeacherUserDetails;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.user.User;
@@ -71,6 +72,10 @@ public abstract class AbstractClassmateDataControllerTest extends APIControllerT
     expect(userService.retrieveUser(studentUserDetails)).andReturn(student);
   }
 
+  protected void expectUser(TeacherUserDetails teacherUserDetails, User teacher) {
+    expect(userService.retrieveUser(teacherUserDetails)).andReturn(teacher);
+  }
+
   protected void expectPeriodAndUser(User student, StudentUserDetails studentUserDetails,
       Long periodId, Group period) throws ObjectNotFoundException {
     expectPeriod(periodId, period);
@@ -100,6 +105,14 @@ public abstract class AbstractClassmateDataControllerTest extends APIControllerT
   protected void expectComponentType(String componentType)
       throws IOException, ObjectNotFoundException {
     expectComponentType(NODE_ID1, COMPONENT_ID1, componentType);
+  }
+
+  protected void setupTeacher1() throws ObjectNotFoundException {
+    expectUser(teacher1UserDetails, teacher1);
+  }
+
+  protected void setupTeacher2() throws ObjectNotFoundException {
+    expectUser(teacher2UserDetails, teacher2);
   }
 
   protected void expectComponentType(String nodeId, String componentId, String componentType)

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateDataControllerTest.java
@@ -33,7 +33,7 @@ public class ClassmateDataControllerTest extends AbstractClassmateDataController
       throws NoSuchMethodException, ObjectNotFoundException {
     setupStudent2NotInRun();
     replayAll();
-    assertFalse(controller.isUserInRun(studentAuth2, run3));
+    assertFalse(controller.isStudentInRun(studentAuth2, run3));
     verifyAll();
   }
 
@@ -42,7 +42,7 @@ public class ClassmateDataControllerTest extends AbstractClassmateDataController
       throws NoSuchMethodException, ObjectNotFoundException {
     setupStudent1InRun();
     replayAll();
-    assertTrue(controller.isUserInRun(studentAuth, run1));
+    assertTrue(controller.isStudentInRun(studentAuth, run1));
     verifyAll();
   }
 
@@ -51,7 +51,7 @@ public class ClassmateDataControllerTest extends AbstractClassmateDataController
       throws NoSuchMethodException, ObjectNotFoundException {
     setupStudent2NotInRun();
     replayAll();
-    assertFalse(controller.isUserInRunAndPeriod(studentAuth2, run3, run3Period4));
+    assertFalse(controller.isStudentInRunAndPeriod(studentAuth2, run3, run3Period4));
     verifyAll();
   }
 
@@ -60,7 +60,7 @@ public class ClassmateDataControllerTest extends AbstractClassmateDataController
       throws NoSuchMethodException, ObjectNotFoundException {
     setupStudent1InRun();
     replayAll();
-    assertTrue(controller.isUserInRunAndPeriod(studentAuth, run1, run1Period1));
+    assertTrue(controller.isStudentInRunAndPeriod(studentAuth, run1, run1Period1));
     verifyAll();
   }
 

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/ClassmateSummaryDataControllerTest.java
@@ -27,79 +27,64 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
   private ClassmateSummaryDataController controller = new ClassmateSummaryDataController();
 
   @Test
-  public void getClassmateSummaryWork_NotInRun_ThrowException()
+  public void getClassmateSummaryWorkInPeriod_NotInRun_ShouldThrowException()
       throws NoSuchMethodException, ObjectNotFoundException {
     setupStudent2NotInRunAndNotInPeriod();
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth2, run3, run3Period4Id, OTHER_NODE_ID,
-        OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
+        () -> controller.getClassmateSummaryWorkInPeriod(studentAuth2, run3, run3Period4Id,
+        OTHER_NODE_ID, OTHER_COMPONENT_ID));
     verifyAll();
   }
 
   @Test
-  public void getClassmateSummaryWork_NotInPeriod_ThrowException()
+  public void getClassmateSummaryWorkInPeriod_NotInPeriod_ShouldThrowException()
       throws NoSuchMethodException, ObjectNotFoundException {
     setupStudent2InRunButNotInPeriod();
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth2, run1, run1Period2Id, OTHER_NODE_ID,
-        OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
+        () -> controller.getClassmateSummaryWorkInPeriod(studentAuth2, run1, run1Period2Id,
+        OTHER_NODE_ID, OTHER_COMPONENT_ID));
     verifyAll();
   }
 
   @Test
-  public void getClassmateSummaryWork_NotSummaryComponent_ThrowException()
+  public void getClassmateSummaryWorkInPeriod_NotSummaryComponent_ShouldThrowException()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     setupStudent1InRunAndInPeriod();
     expectComponentType(OPEN_RESPONSE_TYPE);
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth, run1, run1Period1Id, OTHER_NODE_ID,
-        OTHER_COMPONENT_ID, controller.PERIOD_SOURCE));
+        () -> controller.getClassmateSummaryWorkInPeriod(studentAuth, run1, run1Period1Id,
+        OTHER_NODE_ID, OTHER_COMPONENT_ID));
     verifyAll();
   }
 
   @Test
-  public void getClassmateSummaryWork_InvalidOtherComponent_ThrowException()
+  public void getClassmateSummaryWorkInPeriod_InvalidOtherComponent_ShouldThrowException()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     setupStudent1InRunAndInPeriod();
     expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
         OTHER_COMPONENT_ID, controller.PERIOD_SOURCE);
     replayAll();
     assertThrows(AccessDeniedException.class,
-        () -> controller.getClassmateSummaryWork(studentAuth, run1, run1Period1Id,
-            OTHER_NODE_ID_NOT_ALLOWED, OTHER_COMPONENT_ID_NOT_ALLOWED, controller.PERIOD_SOURCE));
+        () -> controller.getClassmateSummaryWorkInPeriod(studentAuth, run1, run1Period1Id,
+            OTHER_NODE_ID_NOT_ALLOWED, OTHER_COMPONENT_ID_NOT_ALLOWED));
     verifyAll();
   }
 
   @Test
-  public void getClassmateSummaryWork_InRunSummaryComponentPeriod_ReturnWork()
-      throws IOException, NoSuchMethodException, ObjectNotFoundException {
-    getClassmateSummaryWork_InRunSummaryComponent_ReturnWork(controller.PERIOD_SOURCE);
-  }
-
-  @Test
-  public void getClassmateSummaryWork_InRunSummaryComponentAllPeriods_ReturnWork()
-      throws IOException, NoSuchMethodException, ObjectNotFoundException {
-    getClassmateSummaryWork_InRunSummaryComponent_ReturnWork(controller.ALL_PERIODS_SOURCE);
-  }
-
-  private void getClassmateSummaryWork_InRunSummaryComponent_ReturnWork(String source)
+  public void getClassmateSummaryWorkInPeriod_InPeriodSummaryComponent_ShouldReturnWork()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     setupStudent1InRunAndInPeriod();
     expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
-        OTHER_COMPONENT_ID, source);
+        OTHER_COMPONENT_ID, controller.PERIOD_SOURCE);
     List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
-    if (controller.PERIOD_SOURCE.equals(source)) {
-      expectLatestStudentWork(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
-    } else if (controller.ALL_PERIODS_SOURCE.equals(source)) {
-      expectLatestStudentWork(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
-    }
+    expectLatestStudentWork(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
     replayAll();
     try {
-      List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWork(studentAuth,
-          run1, run1Period1Id, OTHER_NODE_ID, OTHER_COMPONENT_ID, source);
+      List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWorkInPeriod(
+          studentAuth, run1, run1Period1Id, OTHER_NODE_ID, OTHER_COMPONENT_ID);
       assertEquals(classmateSummaryWork, studentWork);
     } catch (Exception e) {
       fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
@@ -108,42 +93,114 @@ public class ClassmateSummaryDataControllerTest extends AbstractClassmateDataCon
   }
 
   @Test
-  public void getClassmateSummaryAnnotations_InRunSummaryComponentPeriod_ReturnAnnotations()
+  public void getClassmateSummaryWorkInClass_InRunSummaryComponent_ShouldReturnWork()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
-    getClassmateSummaryAnnotations_InRunSummaryComponent_ReturnAnnotations(
-        controller.PERIOD_SOURCE);
+    setupStudent1InRun();
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID, controller.ALL_PERIODS_SOURCE);
+    List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
+    expectLatestStudentWork(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
+    replayAll();
+    try {
+      List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWorkInClass(
+          studentAuth, run1, OTHER_NODE_ID, OTHER_COMPONENT_ID);
+      assertEquals(classmateSummaryWork, studentWork);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
   }
 
   @Test
-  public void getClassmateSummaryAnnotations_InRunSummaryComponentAllPeriods_ReturnAnnotations()
-      throws IOException, NoSuchMethodException, ObjectNotFoundException {
-    getClassmateSummaryAnnotations_InRunSummaryComponent_ReturnAnnotations(
-        controller.ALL_PERIODS_SOURCE);
-  }
-
-  private void getClassmateSummaryAnnotations_InRunSummaryComponent_ReturnAnnotations(String source)
+  public void getClassmateSummaryScoresInPeriod_InPeriodSummaryComponent_ShouldReturnAnnotations()
       throws IOException, NoSuchMethodException, ObjectNotFoundException {
     setupStudent1InRunAndInPeriod();
     expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
-        OTHER_COMPONENT_ID, source);
+        OTHER_COMPONENT_ID, controller.PERIOD_SOURCE);
     Annotation annotation1 = createAnnotation(workgroup1, "score", new Timestamp(1000));
     Annotation annotation2 = createAnnotation(workgroup2, "autoScore", new Timestamp(2000));
     Annotation annotation3 = createAnnotation(workgroup2, "autoScore", new Timestamp(3000));
     List<Annotation> allAnnotations = Arrays.asList(annotation1, annotation2, annotation3);
-    if (controller.PERIOD_SOURCE.equals(source)) {
-      expectAnnotations(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, allAnnotations);
-    } else if (controller.ALL_PERIODS_SOURCE.equals(source)) {
-      expectAnnotations(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, allAnnotations);
-    }
+    expectAnnotations(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, allAnnotations);
     replayAll();
     try {
-      List<Annotation> classmateSummaryAnnotations = controller.getClassmateSummaryScores(
-          studentAuth, run1, run1Period1Id, OTHER_NODE_ID, OTHER_COMPONENT_ID, source);
+      List<Annotation> classmateSummaryAnnotations = controller.getClassmateSummaryScoresInPeriod(
+          studentAuth, run1, run1Period1Id, OTHER_NODE_ID, OTHER_COMPONENT_ID);
       List<Annotation> latestAnnotations = Arrays.asList(annotation1, annotation3);
       assertEquals(classmateSummaryAnnotations, latestAnnotations);
     } catch (Exception e) {
       fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
     }
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryScoresInClass_InRunSummaryComponent_ShouldReturnAnnotations()
+      throws IOException, NoSuchMethodException, ObjectNotFoundException {
+    setupStudent1InRun();
+    expectComponentType(NODE_ID1, COMPONENT_ID1, controller.SUMMARY_TYPE, OTHER_NODE_ID,
+        OTHER_COMPONENT_ID, controller.ALL_PERIODS_SOURCE);
+    Annotation annotation1 = createAnnotation(workgroup1, "score", new Timestamp(1000));
+    Annotation annotation2 = createAnnotation(workgroup2, "autoScore", new Timestamp(2000));
+    Annotation annotation3 = createAnnotation(workgroup2, "autoScore", new Timestamp(3000));
+    List<Annotation> allAnnotations = Arrays.asList(annotation1, annotation2, annotation3);
+    expectAnnotations(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, allAnnotations);
+    replayAll();
+    try {
+      List<Annotation> classmateSummaryAnnotations = controller.getClassmateSummaryScoresInClass(
+          studentAuth, run1, OTHER_NODE_ID, OTHER_COMPONENT_ID);
+      List<Annotation> latestAnnotations = Arrays.asList(annotation1, annotation3);
+      assertEquals(classmateSummaryAnnotations, latestAnnotations);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryWorkInPeriod_TeacherOfRun_ShouldReturnWork()
+      throws ObjectNotFoundException {
+    expectPeriod(run1Period1Id, run1Period1);
+    setupTeacher1();
+    List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
+    expectLatestStudentWork(run1, run1Period1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
+    replayAll();
+    try {
+      List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWorkInPeriod(
+          teacherAuth, run1, run1Period1Id, OTHER_NODE_ID, OTHER_COMPONENT_ID);
+      assertEquals(classmateSummaryWork, studentWork);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryWorkInClass_TeacherOfRun_ShouldReturnWork()
+      throws ObjectNotFoundException {
+    setupTeacher1();
+    List<StudentWork> studentWork = Arrays.asList(new StudentWork(), new StudentWork());
+    expectLatestStudentWork(run1, OTHER_NODE_ID, OTHER_COMPONENT_ID, studentWork);
+    replayAll();
+    try {
+      List<StudentWork> classmateSummaryWork = controller.getClassmateSummaryWorkInClass(
+          teacherAuth, run1, OTHER_NODE_ID, OTHER_COMPONENT_ID);
+      assertEquals(classmateSummaryWork, studentWork);
+    } catch (Exception e) {
+      fail(SHOULD_NOT_HAVE_THROWN_EXCEPTION);
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getClassmateSummaryWorkInPeriod_NotTeacherOfRun_ShouldThrowException()
+      throws ObjectNotFoundException {
+    expectPeriod(run1Period1Id, run1Period1);
+    setupTeacher2();
+    replayAll();
+    assertThrows(AccessDeniedException.class,
+        () -> controller.getClassmateSummaryWorkInPeriod(
+        teacherAuth2, run1, run1Period1Id, OTHER_NODE_ID, OTHER_COMPONENT_ID));
     verifyAll();
   }
 


### PR DESCRIPTION
- Test with https://github.com/WISE-Community/WISE-Client/pull/641

## Changes

- Split the 2 endpoints into 4 endpoints. Here are the new endpoints.
  - Student work in period
  - Student work in all periods
  - Student scores in period
  - Student scores in all periods
- Allow teachers to access these endpoints.

## Test

- Make sure students can retrieve classmate work and scores for period and all periods
- Make sure teacher can retrieve student work and scores for period and all periods

Closes #141