### PR TITLE
fix(Session): Remove stale sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.4.13</version>
+    <version>2.5.10</version>
     <relativePath/>
   </parent>
   <dependencies>

--- a/src/main/java/org/wise/portal/presentation/web/controllers/admin/ShowOnlineUsersController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/admin/ShowOnlineUsersController.java
@@ -1,0 +1,23 @@
+package org.wise.portal.presentation.web.controllers.admin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.wise.portal.service.session.SessionService;
+
+@Controller
+@RequestMapping("/admin/account/show-online-users")
+public class ShowOnlineUsersController {
+
+  @Autowired
+  private SessionService sessionService;
+
+  @GetMapping
+  protected String show(ModelMap modelMap) {
+    modelMap.put("loggedInStudentUsernames", sessionService.getLoggedInStudents());
+    modelMap.put("loggedInTeacherUsernames", sessionService.getLoggedInTeachers());
+    return "admin/account/manageusers";
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/admin/ViewAllUsersController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/admin/ViewAllUsersController.java
@@ -31,13 +31,10 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.wise.portal.domain.authentication.impl.StudentUserDetails;
-import org.wise.portal.domain.authentication.impl.TeacherUserDetails;
 import org.wise.portal.domain.user.User;
 import org.wise.portal.service.authentication.UserDetailsService;
-import org.wise.portal.service.session.SessionService;
 import org.wise.portal.service.user.UserService;
 
 /**
@@ -53,9 +50,6 @@ public class ViewAllUsersController{
   @Autowired
   private UserDetailsService userDetailsService;
 
-  @Autowired
-  private SessionService sessionService;
-
   protected static final String TEACHERS = "teachers";
 
   protected static final String STUDENTS = "students";
@@ -70,44 +64,36 @@ public class ViewAllUsersController{
 
   private static final String USERNAMES = "usernames";
 
-  private static final String LOGGED_IN_STUDENT_USERNAMES = "loggedInStudentUsernames";
-
-  private static final String LOGGED_IN_TEACHER_USERNAMES = "loggedInTeacherUsernames";
-
-  @RequestMapping(method = RequestMethod.GET)
+  @GetMapping
   protected String showUsers(HttpServletRequest request, ModelMap modelMap) throws Exception {
-    String onlyShowLoggedInUser = request.getParameter("onlyShowLoggedInUser");
     String onlyShowUsersWhoLoggedIn = request.getParameter("onlyShowUsersWhoLoggedIn");
-    if (onlyShowLoggedInUser != null && onlyShowLoggedInUser.equals("true")) {
-      modelMap.put(LOGGED_IN_STUDENT_USERNAMES, sessionService.getLoggedInStudents());
-      modelMap.put(LOGGED_IN_TEACHER_USERNAMES, sessionService.getLoggedInTeachers());
-    } else if (onlyShowUsersWhoLoggedIn != null) {
+    if (onlyShowUsersWhoLoggedIn != null) {
       List<User> studentsWhoLoggedInSince = new ArrayList<User>();
       List<User> teachersWhoLoggedInSince = new ArrayList<User>();
       if ("today".equals(onlyShowUsersWhoLoggedIn)) {
         studentsWhoLoggedInSince =
             userService.retrieveStudentUsersWhoLoggedInToday();
-        teachersWhoLoggedInSince = 
+        teachersWhoLoggedInSince =
             userService.retrieveTeacherUsersWhoLoggedInToday();
       } else if ("thisWeek".equals(onlyShowUsersWhoLoggedIn)) {
         studentsWhoLoggedInSince =
             userService.retrieveStudentUsersWhoLoggedInThisWeek();
-        teachersWhoLoggedInSince = 
+        teachersWhoLoggedInSince =
             userService.retrieveTeacherUsersWhoLoggedInThisWeek();
       } else if ("thisMonth".equals(onlyShowUsersWhoLoggedIn)) {
         studentsWhoLoggedInSince =
             userService.retrieveStudentUsersWhoLoggedInThisMonth();
-        teachersWhoLoggedInSince = 
+        teachersWhoLoggedInSince =
             userService.retrieveTeacherUsersWhoLoggedInThisMonth();
       } else if ("thisYear".equals(onlyShowUsersWhoLoggedIn)) {
         studentsWhoLoggedInSince =
             userService.retrieveStudentUsersWhoLoggedInThisYear();
-        teachersWhoLoggedInSince = 
+        teachersWhoLoggedInSince =
             userService.retrieveTeacherUsersWhoLoggedInThisYear();
       } else {
         studentsWhoLoggedInSince =
             userService.retrieveStudentUsersWhoLoggedInSinceYesterday();
-        teachersWhoLoggedInSince = 
+        teachersWhoLoggedInSince =
             userService.retrieveTeacherUsersWhoLoggedInSinceYesterday();
       }
       modelMap.put("studentsWhoLoggedInSince", studentsWhoLoggedInSince);

--- a/src/main/webapp/portal/admin/index.jsp
+++ b/src/main/webapp/portal/admin/index.jsp
@@ -105,7 +105,7 @@
                             <sec:authorize access="hasRole('ROLE_ADMINISTRATOR')">
                                 <spring:message code='admin.index.list' />
                                 <spring:message code='admin.index.allUsersWhoLoggedIn' />
-                                <a href="${contextPath}/admin/account/manageusers?onlyShowLoggedInUser=true">
+                                <a href="${contextPath}/admin/account/show-online-users">
                                     <spring:message code='now' /> (${numCurrentlyLoggedInUsers})</a> |
                                 <a href="${contextPath}/admin/account/manageusers?onlyShowUsersWhoLoggedIn=today">
                                     <spring:message code='today' /> (${numUsersWhoLoggedInToday})</a> |


### PR DESCRIPTION
## Changes
- Upgrade to SpringBoot 2.5.10 to get fix https://github.com/spring-projects/spring-session/issues/1791
- Go through current users and remove any stale sessions when admin accesses the admin home page
- Refactor page to show current users to new ShowOnlineUsersController

## Test Prep
- Flush session in Redis to avoid version conflict via ```flushall```
- Set ```server.servlet.session.timeout=1m``` in application-dockerdev.properties. This will logout the session after 1 minute of inactivity.
- Run ```mvn clean compile``` to get new Maven dependencies, then restart the API server. This will start WISE-API using SpringBoot 2.5.10

## Test
- Log in as admin user in one browser and log in and out as a teacher or student in others.
- In the admin view, verify that the "List All Users Who Logged In Now (X)" has the right number as other users log in and out.
- Clicking on the "Now" link should take you to /admin/account/show-online-users which is now backed by the new ShowOnlineUsersController, and show the users who are currently logged in.

Closes #3