### PR TITLE
feat(TeacherRuns): Combine personal and shared run endpoints

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -64,7 +64,7 @@ public class TeacherAPIController extends UserAPIController {
     User user = userService.retrieveUserByUsername(auth.getName());
     List<Run> runs = runService.getRunListByOwner(user);
     runs.addAll(runService.getRunListBySharedOwner(user));
-    runs.sort((a,b) -> a.getStarttime().compareTo(b.getStarttime()));
+    runs.sort((a,b) -> b.getStarttime().compareTo(a.getStarttime()));
     return getRunsList(user, runs);
   }
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIController.java
@@ -63,13 +63,8 @@ public class TeacherAPIController extends UserAPIController {
   List<HashMap<String, Object>> getRuns(Authentication auth) {
     User user = userService.retrieveUserByUsername(auth.getName());
     List<Run> runs = runService.getRunListByOwner(user);
-    return getRunsList(user, runs);
-  }
-
-  @GetMapping("/sharedruns")
-  List<HashMap<String, Object>> getSharedRuns(Authentication auth) {
-    User user = userService.retrieveUserByUsername(auth.getName());
-    List<Run> runs = runService.getRunListBySharedOwner(user);
+    runs.addAll(runService.getRunListBySharedOwner(user));
+    runs.sort((a,b) -> a.getStarttime().compareTo(b.getStarttime()));
     return getRunsList(user, runs);
   }
 

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -234,7 +233,7 @@ public class UserAPIController {
     }
   }
 
-  protected HashMap<String, Object> getProjectMap(Project project) {
+  private HashMap<String, Object> getProjectMap(Project project) {
     HashMap<String, Object> map = new HashMap<String, Object>();
     map.put("id", project.getId());
     map.put("name", project.getName());
@@ -253,29 +252,14 @@ public class UserAPIController {
 
   protected HashMap<String, Object> getRunMap(User user, Run run) {
     HashMap<String, Object> map = new HashMap<String, Object>();
-    Project project = run.getProject();
-    String curriculumBaseWWW = appProperties.getProperty("curriculum_base_www");
-    String projectThumb = "";
-    String modulePath = project.getModulePath();
-    int lastIndexOfSlash = modulePath.lastIndexOf("/");
-    if (lastIndexOfSlash != -1) {
-      /*
-       * The project thumb url by default is the same (/assets/project_thumb.png) for all projects,
-       * but this could be overwritten in the future e.g. /253/assets/projectThumb.png
-       */
-      projectThumb = curriculumBaseWWW + modulePath.substring(0, lastIndexOfSlash)
-          + PROJECT_THUMB_PATH;
-    }
-
     map.put("id", run.getId());
     map.put("name", run.getName());
     map.put("maxStudentsPerTeam", run.getMaxWorkgroupSize());
-    map.put("projectThumb", projectThumb);
     map.put("runCode", run.getRuncode());
     map.put("startTime", run.getStartTimeMilliseconds());
     map.put("endTime", run.getEndTimeMilliseconds());
     map.put("isLockedAfterEndDate", run.isLockedAfterEndDate());
-    map.put("project", getProjectMap(project));
+    map.put("project", getProjectMap(run.getProject()));
     map.put("owner", convertUserToMap(run.getOwner()));
     map.put("numStudents", run.getNumStudents());
     map.put("wiseVersion", run.getProject().getWiseVersion());

--- a/src/main/java/org/wise/portal/service/project/ProjectService.java
+++ b/src/main/java/org/wise/portal/service/project/ProjectService.java
@@ -58,6 +58,8 @@ import java.util.Set;
  */
 public interface ProjectService {
 
+  void init();
+
   /**
    * Get a <code>List</code> of <code>Project</code> that the specified user owns.
    *

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/StudentAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/StudentAPIControllerTest.java
@@ -17,7 +17,6 @@ import org.easymock.Mock;
 import org.easymock.TestSubject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.core.env.Environment;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.PeriodNotFoundException;
 import org.wise.portal.domain.RunHasEndedException;
@@ -47,9 +46,6 @@ public class StudentAPIControllerTest extends APIControllerTest {
 
   @Mock
   private StudentAttendanceService studentAttendanceService;
-
-  @Mock(fieldName = "appProperties")
-  private Environment appProperties;
 
   @Mock(fieldName = "i18nProperties")
   private Properties i18nProperties;
@@ -198,16 +194,12 @@ public class StudentAPIControllerTest extends APIControllerTest {
     expect(workgroupService.getWorkgroupListByRunAndUser(isA(Run.class), isA(User.class)))
         .andReturn(workgroups).times(3);
     replay(workgroupService);
-    expect(appProperties.getProperty("curriculum_base_www"))
-        .andReturn("http://localhost:8080/curriculum").times(3);
-    replay(appProperties);
     List<HashMap<String, Object>> runs = studentAPIController.getRuns(studentAuth);
     assertEquals(3, runs.size());
     verify(userService);
     verify(runService);
     verify(projectService);
     verify(workgroupService);
-    verify(appProperties);
   }
 
   @Test

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/TeacherAPIControllerTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,6 +42,27 @@ public class TeacherAPIControllerTest extends APIControllerTest {
 
   @Mock
   private UserDetailsService userDetailsService;
+
+  @Test
+  public void getRuns_ReturnPersonalAndSharedRunsSortedByStartTimeDesc() {
+    expect(userService.retrieveUserByUsername(teacherAuth.getName())).andReturn(teacher1);
+    List<Run> personalRuns = new ArrayList<Run>(Arrays.asList(run1, run3));
+    expect(runService.getRunListByOwner(teacher1)).andReturn(personalRuns);
+    List<Run> sharedRuns = new ArrayList<Run>(Arrays.asList(run2));
+    expect(runService.getRunListBySharedOwner(teacher1)).andReturn(sharedRuns);
+    expect(projectService.getProjectPath(isA(Project.class))).andReturn("");
+    expect(projectService.getProjectSharedOwnersList(isA(Project.class)))
+       .andReturn(Arrays.asList());
+    expect(projectService.getProjectURI(isA(Project.class))).andReturn("").times(3);
+    expect(projectService.getLicensePath(isA(Project.class))).andReturn("").times(3);
+    expect(projectService.getProjectPath(isA(Project.class))).andReturn("").times(2);
+    expect(projectService.getProjectSharedOwnersList(isA(Project.class)))
+       .andReturn(Arrays.asList()).times(2);
+    replay(projectService, runService, userService);
+    List<HashMap<String, Object>> allRuns = teacherAPIController.getRuns(teacherAuth);
+    assertEquals(3, allRuns.size());
+    verify(projectService, runService, userService);
+  }
 
   @Test
   public void getAllTeacherUsernames_OneTeachersInDB_ReturnOneUsername() {


### PR DESCRIPTION
## Changes
- Both personal and shared runs are now handled by ```/api/teacher/runs```. Before (personal: ```/api/teacher/runs```, shared: ```/api/teacher/sharedruns```)
- Remove ```run.projectThumb```. Consumers should use ```run.project.projectThumb``` instead. This also reduces computation.
- Other minor optimizations (like storing values from calls to appProperties.get(*)) and code cleanup
- Add unit test to getRuns()

## Test
- Log in as teacher and make sure that calls to ```/api/teacher/runs``` returns both personal and shared runs, sorted by run.startTime in descending order

Closes #153 