### PR TITLE
chore(MySQL/J): Upgrade to 8.0.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.48</version>
+      <version>8.0.30</version>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>

--- a/src/main/java/org/wise/portal/domain/admin/DailyAdminJob.java
+++ b/src/main/java/org/wise/portal/domain/admin/DailyAdminJob.java
@@ -224,7 +224,7 @@ public class DailyAdminJob {
       String username = appProperties.getProperty("spring.datasource.username");
       String password = appProperties.getProperty("spring.datasource.password");
       String url = appProperties.getProperty("spring.datasource.url");
-      Class.forName("com.mysql.jdbc.Driver").newInstance();
+      Class.forName("com.mysql.cj.jdbc.Driver").newInstance();
       Connection conn = DriverManager.getConnection(url, username, password);
       Statement statement = conn.createStatement();
       JSONObject vleStatistics = new JSONObject();

--- a/src/main/java/org/wise/portal/spring/impl/ACLContext.java
+++ b/src/main/java/org/wise/portal/spring/impl/ACLContext.java
@@ -98,7 +98,7 @@ public class ACLContext {
     JdbcMutableAclService aclService = new JdbcMutableAclService(dataSource, lookupStrategy(), aclCache());
     if (appProperties.containsProperty("spring.datasource.driver-class-name")) {
       String driverClass = (String) appProperties.getProperty("spring.datasource.driver-class-name");
-      if ("com.mysql.jdbc.Driver".equals(driverClass)) {
+      if ("com.mysql.cj.jdbc.Driver".equals(driverClass)) {
         aclService.setClassIdentityQuery("SELECT @@IDENTITY");
         aclService.setSidIdentityQuery("SELECT @@IDENTITY");
       }

--- a/src/main/java/org/wise/portal/spring/impl/WISEJdbcMutableAclService.java
+++ b/src/main/java/org/wise/portal/spring/impl/WISEJdbcMutableAclService.java
@@ -42,7 +42,7 @@ public class WISEJdbcMutableAclService extends JdbcMutableAclService {
     super(dataSource, lookupStrategy, aclCache);
     if (appProperties.containsKey("spring.datasource.driver-class-name")) {
       String driverClass = (String) appProperties.get("spring.datasource.driver-class-name");
-      if ("com.mysql.jdbc.Driver".equals(driverClass)) {
+      if ("com.mysql.cj.jdbc.Driver".equals(driverClass)) {
         setClassIdentityQuery("SELECT @@IDENTITY");
         setSidIdentityQuery("SELECT @@IDENTITY");
       }

--- a/src/main/resources/application-dockerdev-sample.properties
+++ b/src/main/resources/application-dockerdev-sample.properties
@@ -72,8 +72,8 @@ cRater_password=
 # The default settings below is for mysql running on port 3306.
 # with username "wiseuser", password "wisepass" and schema name "wise_database"
 
-spring.datasource.url=jdbc:mysql://wise-mysql:3306/wise_database?autoReconnect=true&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false&driver=com.mysql.jdbc.Driver
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://wise-mysql:3306/wise_database?autoReconnect=true&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=wiseuser
 spring.datasource.password=wisepass
 

--- a/src/main/resources/application_sample.properties
+++ b/src/main/resources/application_sample.properties
@@ -71,8 +71,8 @@ cRater_password=
 # The default settings below is for mysql running on port 3306.
 # with username "wiseuser", password "wisepass" and schema name "wise_database"
 
-spring.datasource.url=jdbc:mysql://localhost:3306/wise_database?autoReconnect=true&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false&driver=com.mysql.jdbc.Driver
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/wise_database?autoReconnect=true&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=wiseuser
 spring.datasource.password=wisepass
 


### PR DESCRIPTION
## Changes
- Upgrade MySQL/J connector from 5.1.48 (July 2019) to 8.0.30 (July 2022). This fixes 3 known vulnerabilities (CVE-2022-21363, CVE-2019-2692, CVE-2018-3258)
- Remove unused jdbcUrl parameter

## Test Prep
- In application-dockerdev.properties
   - remove ```&driver=com.mysql.jdbc.Driver``` param from ```spring.datasource.url``` property, if it's specified
   - change ```spring.datasource.driver-class-name=com.mysql.jdbc.Driver``` to ```spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver```
- Run ```mvn clean compile``` to download updated maven dependency 
- Restart WISE-API container

## Test
- Saving and loading data (account, runs, work, events) work as before

Closes #163 