### PR TITLE
feat(Password): Increase password validation requirements

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIController.java
@@ -1,12 +1,14 @@
 package org.wise.portal.presentation.web.controllers.student;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,11 +18,16 @@ import org.wise.portal.domain.authentication.MutableUserDetails;
 import org.wise.portal.domain.authentication.impl.StudentUserDetails;
 import org.wise.portal.domain.user.User;
 import org.wise.portal.presentation.web.controllers.ControllerUtil;
+import org.wise.portal.presentation.web.response.ResponseEntityGenerator;
+import org.wise.portal.service.password.PasswordService;
 import org.wise.portal.service.user.UserService;
 
 @RestController
 @RequestMapping(value = "/api/student/forgot", produces = "application/json;charset=UTF-8")
 public class StudentForgotAccountAPIController {
+
+  @Autowired
+  private PasswordService passwordService;
 
   @Autowired
   private UserService userService;
@@ -30,17 +37,16 @@ public class StudentForgotAccountAPIController {
 
   @GetMapping("/username/search")
   protected String getStudentUsernames(@RequestParam("firstName") String firstName,
-        @RequestParam("lastName") String lastName,
-        @RequestParam("birthMonth") Integer birthMonth,
-        @RequestParam("birthDay") Integer birthDay) {
-    List<User> accountsThatMatch = 
-        userService.retrieveStudentsByNameAndBirthday(firstName, lastName, birthMonth, birthDay);
+      @RequestParam("lastName") String lastName, @RequestParam("birthMonth") Integer birthMonth,
+      @RequestParam("birthDay") Integer birthDay) {
+    List<User> accountsThatMatch = userService.retrieveStudentsByNameAndBirthday(firstName,
+        lastName, birthMonth, birthDay);
     return getUsernamesJSON(accountsThatMatch).toString();
   }
 
   private JSONArray getUsernamesJSON(List<User> users) {
     JSONArray usernamesJSON = new JSONArray();
-    for (User user: users) {
+    for (User user : users) {
       MutableUserDetails userDetails = user.getUserDetails();
       usernamesJSON.put(userDetails.getUsername());
     }
@@ -48,7 +54,7 @@ public class StudentForgotAccountAPIController {
   }
 
   @GetMapping("/password/security-question")
-  protected String getSecurityQuestion(@RequestParam("username") String username) 
+  protected String getSecurityQuestion(@RequestParam("username") String username)
       throws JSONException {
     User user = userService.retrieveUserByUsername(username);
     JSONObject response;
@@ -66,9 +72,9 @@ public class StudentForgotAccountAPIController {
 
   @PostMapping("/password/security-question")
   protected String checkSecurityAnswer(@RequestParam("username") String username,
-        @RequestParam("answer") String answer) throws JSONException {
+      @RequestParam("answer") String answer) throws JSONException {
     User user = userService.retrieveUserByUsername(username);
-    JSONObject response; 
+    JSONObject response;
     if (user != null) {
       if (isAnswerCorrect(user, answer)) {
         response = ControllerUtil.createSuccessResponse("correctAnswer");
@@ -82,31 +88,29 @@ public class StudentForgotAccountAPIController {
   }
 
   @PostMapping("/password/change")
-  protected String checkSecurityAnswer(@RequestParam("username") String username,
-        @RequestParam("answer") String answer,
-        @RequestParam("password") String password,
-        @RequestParam("confirmPassword") String confirmPassword) throws JSONException {
+  protected ResponseEntity<Map<String, Object>> changePassword(
+      @RequestParam("username") String username, @RequestParam("answer") String answer,
+      @RequestParam("password") String password,
+      @RequestParam("confirmPassword") String confirmPassword) throws JSONException {
     User user = userService.retrieveUserByUsername(username);
-    JSONObject response;
-    if (user != null) {
+    if (user == null) {
+      return ResponseEntityGenerator.createError("invalidUsername");
+    } else {
       if (isAnswerCorrect(user, answer)) {
-        if (isPasswordBlank(password, confirmPassword)) {
-          response = ControllerUtil.createErrorResponse("passwordIsBlank");
+        if (!passwordService.isValidLength(password)) {
+          return ResponseEntityGenerator.createError("invalidPasswordLength");
+        } else if (!passwordService.isValidPattern(password)) {
+          return ResponseEntityGenerator.createError("invalidPasswordPattern");
         } else if (!isPasswordsMatch(password, confirmPassword)) {
-          response = ControllerUtil.createErrorResponse("passwordsDoNotMatch");
-        } else if (isPasswordsMatch(password, confirmPassword)) {
-          userService.updateUserPassword(user, password);
-          response = ControllerUtil.createSuccessResponse("passwordChanged");
+          return ResponseEntityGenerator.createError("passwordsDoNotMatch");
         } else {
-          response = ControllerUtil.createErrorResponse("invalidPassword");
+          userService.updateUserPassword(user, password);
+          return ResponseEntityGenerator.createSuccess("passwordChanged");
         }
       } else {
-        response = ControllerUtil.createErrorResponse("incorrectAnswer");
+        return ResponseEntityGenerator.createError("incorrectAnswer");
       }
-    } else {
-      response = ControllerUtil.createErrorResponse("invalidUsername");
     }
-    return response.toString();
   }
 
   private String getAccountQuestionKey(User user) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/ChangeStudentPasswordController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/ChangeStudentPasswordController.java
@@ -1,6 +1,9 @@
 package org.wise.portal.presentation.web.controllers.teacher.management;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.Authentication;
@@ -11,7 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.user.User;
-import org.wise.portal.presentation.web.exception.InvalidPasswordException;
+import org.wise.portal.presentation.web.exception.IncorrectPasswordException;
+import org.wise.portal.presentation.web.response.ResponseEntityGenerator;
+import org.wise.portal.service.password.PasswordService;
 import org.wise.portal.service.run.RunService;
 import org.wise.portal.service.user.UserService;
 
@@ -20,33 +25,43 @@ import org.wise.portal.service.user.UserService;
 public class ChangeStudentPasswordController {
 
   @Autowired
+  private PasswordService passwordService;
+
+  @Autowired
   private RunService runService;
 
   @Autowired
   private UserService userService;
 
   @PostMapping("/api/teacher/run/{runId}/student/{studentId}/change-password")
-  void changeStudentPassword(Authentication auth, @PathVariable Long runId,
-      @PathVariable Long studentId, @RequestParam String teacherPassword,
+  ResponseEntity<Map<String, Object>> changeStudentPassword(Authentication auth,
+      @PathVariable Long runId, @PathVariable Long studentId, @RequestParam String teacherPassword,
       @RequestParam String newStudentPassword)
-      throws ObjectNotFoundException, InvalidPasswordException {
+      throws ObjectNotFoundException, IncorrectPasswordException {
     Run run = runService.retrieveById(runId);
     if (runService.hasWritePermission(auth, run)) {
-        User teacherUser = userService.retrieveUserByUsername(auth.getName());
-        boolean isTeacherGoogleUser = teacherUser.getUserDetails().isGoogleUser();
-        if (isTeacherPasswordValid(isTeacherGoogleUser, teacherUser, teacherPassword)) {
-          User studentUser = userService.retrieveById(studentId);
-          userService.updateUserPassword(studentUser, newStudentPassword);
-        } else {
-          throw new InvalidPasswordException();
+      User teacherUser = userService.retrieveUserByUsername(auth.getName());
+      boolean isTeacherGoogleUser = teacherUser.getUserDetails().isGoogleUser();
+      if (isTeacherPasswordCorrect(isTeacherGoogleUser, teacherUser, teacherPassword)) {
+        if (!passwordService.isValidLength(newStudentPassword)) {
+          return ResponseEntityGenerator.createError("invalidPasswordLength");
+        } else if (!passwordService.isValidPattern(newStudentPassword)) {
+          return ResponseEntityGenerator.createError("invalidPasswordPattern");
         }
+        User studentUser = userService.retrieveById(studentId);
+        userService.updateUserPassword(studentUser, newStudentPassword);
+        return ResponseEntityGenerator.createSuccess("passwordUpdated");
+      } else {
+        return ResponseEntityGenerator.createError("incorrectPassword");
+      }
     } else {
       throw new AccessDeniedException(
           "User does not have permission to change this student's password");
     }
   }
 
-  private boolean isTeacherPasswordValid(boolean isGoogleUser, User teacherUser, String password) {
+  private boolean isTeacherPasswordCorrect(boolean isGoogleUser, User teacherUser,
+      String password) {
     return isGoogleUser || userService.isPasswordCorrect(teacherUser, password);
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/response/ResponseEntityGenerator.java
+++ b/src/main/java/org/wise/portal/presentation/web/response/ResponseEntityGenerator.java
@@ -1,0 +1,25 @@
+package org.wise.portal.presentation.web.response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityGenerator {
+  public static ResponseEntity<Map<String, Object>> createSuccess(String messageCode) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("messageCode", messageCode);
+    return new ResponseEntity<>(body, HttpStatus.OK);
+  }
+
+  public static ResponseEntity<Map<String, Object>> createSuccess(Map<String, Object> map) {
+    return new ResponseEntity<>(map, HttpStatus.OK);
+  }
+
+  public static ResponseEntity<Map<String, Object>> createError(String messageCode) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("messageCode", messageCode);
+    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/org/wise/portal/service/password/PasswordService.java
+++ b/src/main/java/org/wise/portal/service/password/PasswordService.java
@@ -1,0 +1,7 @@
+package org.wise.portal.service.password;
+
+public interface PasswordService {
+  public boolean isValidLength(String password);
+
+  public boolean isValidPattern(String password);
+}

--- a/src/main/java/org/wise/portal/service/password/impl/PasswordServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/password/impl/PasswordServiceImpl.java
@@ -1,0 +1,20 @@
+package org.wise.portal.service.password.impl;
+
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+import org.wise.portal.service.password.PasswordService;
+
+@Service
+public class PasswordServiceImpl implements PasswordService {
+  private Integer minLength = 8;
+  private String pattern = "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]+$";
+
+  public boolean isValidLength(String password) {
+    return password.length() >= minLength;
+  }
+
+  public boolean isValidPattern(String password) {
+    return Pattern.matches(pattern, password);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -53,9 +53,11 @@ public abstract class APIControllerTest {
   protected final String STUDENT_PASSWORD = "studentPass";
   protected final String STUDENT_USERNAME = "SpongeBobS0101";
   protected final String STUDENT1_GOOGLE_ID = "google-user-12345";
+  protected final String STUDENT1_ACCOUNT_ANSWER = "Pineapple";
   protected final String STUDENT2_FIRSTNAME = "Patrick";
   protected final String STUDENT2_LASTNAME = "Starr";
   protected final String STUDENT2_USERNAME = "PatrickS0101";
+  protected final String STUDENT2_ACCOUNT_ANSWER = "Rock";
   protected final String TEACHER_FIRSTNAME = "Squidward";
   protected final String TEACHER_LASTNAME = "Tentacles";
   protected final String TEACHER_USERNAME = "SquidwardTentacles";
@@ -135,11 +137,11 @@ public abstract class APIControllerTest {
 
   private void createStudents() {
     student1UserDetails = createStudentUserDetails(STUDENT_FIRSTNAME, STUDENT_LASTNAME,
-        STUDENT_USERNAME, Gender.MALE, 5, STUDENT1_GOOGLE_ID);
+        STUDENT_USERNAME, Gender.MALE, 5, STUDENT1_GOOGLE_ID, STUDENT1_ACCOUNT_ANSWER);
     student1 = createStudent(student1Id, student1UserDetails);
     studentAuth = createAuthentication(student1UserDetails);
     student2UserDetails = createStudentUserDetails(STUDENT2_FIRSTNAME, STUDENT2_LASTNAME,
-        STUDENT2_USERNAME, Gender.MALE, 10, null);
+        STUDENT2_USERNAME, Gender.MALE, 10, null, STUDENT2_ACCOUNT_ANSWER);
     student2 = createStudent(student2Id, student2UserDetails);
     studentAuth2 = createAuthentication(student2UserDetails);
   }
@@ -235,13 +237,15 @@ public abstract class APIControllerTest {
   }
 
   protected StudentUserDetails createStudentUserDetails(String firstName, String lastName,
-      String username, Gender gender, Integer numberOfLogins, String googleUserId) {
+      String username, Gender gender, Integer numberOfLogins, String googleUserId,
+      String accountAnswer) {
     StudentUserDetails studentUserDetails = new StudentUserDetails();
     studentUserDetails.setFirstname(firstName);
     studentUserDetails.setLastname(lastName);
     studentUserDetails.setUsername(username);
     studentUserDetails.setGender(gender);
     studentUserDetails.setNumberOfLogins(numberOfLogins);
+    studentUserDetails.setAccountAnswer(accountAnswer);
     PersistentGrantedAuthority studentAuthority = new PersistentGrantedAuthority();
     studentAuthority.setAuthority(UserDetailsService.STUDENT_ROLE);
     studentUserDetails.setAuthorities(new GrantedAuthority[] { studentAuthority });
@@ -303,7 +307,8 @@ public abstract class APIControllerTest {
     return run;
   }
 
-  protected ProjectImpl createProject(Long id, String modulePath, User teacher, Integer wiseVersion) {
+  protected ProjectImpl createProject(Long id, String modulePath, User teacher,
+      Integer wiseVersion) {
     ProjectImpl project = new ProjectImpl();
     project.setId(id);
     project.setModulePath(modulePath);

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/StudentForgotAccountAPIControllerTest.java
@@ -1,0 +1,69 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.service.password.PasswordService;
+
+@RunWith(EasyMockRunner.class)
+public class StudentForgotAccountAPIControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private StudentForgotAccountAPIController studentForgotAccountAPIController = new StudentForgotAccountAPIController();
+
+  @Mock
+  private PasswordService passwordService;
+
+  String PASSWORD_INVALID_LENGTH = "1234567";
+  String PASSWORD_INVALID_PATTERN = "abcd1234";
+
+  @Test
+  public void changePassword_InvalidPasswordLength_ReturnError() throws JSONException {
+    expect(userService.retrieveUserByUsername(STUDENT_USERNAME)).andReturn(student1);
+    expect(passwordService.isValidLength(PASSWORD_INVALID_LENGTH)).andReturn(false);
+    replayServices();
+    ResponseEntity<Map<String, Object>> response = studentForgotAccountAPIController.changePassword(
+        STUDENT_USERNAME, STUDENT1_ACCOUNT_ANSWER, PASSWORD_INVALID_LENGTH,
+        PASSWORD_INVALID_LENGTH);
+    assertResponseValues(response, HttpStatus.BAD_REQUEST, "invalidPasswordLength");
+    verifyServices();
+  }
+
+  @Test
+  public void changePassword_InvalidPasswordPattern_ReturnError() throws JSONException {
+    expect(userService.retrieveUserByUsername(STUDENT_USERNAME)).andReturn(student1);
+    expect(passwordService.isValidLength(PASSWORD_INVALID_PATTERN)).andReturn(true);
+    expect(passwordService.isValidPattern(PASSWORD_INVALID_PATTERN)).andReturn(false);
+    replayServices();
+    ResponseEntity<Map<String, Object>> response = studentForgotAccountAPIController.changePassword(
+        STUDENT_USERNAME, STUDENT1_ACCOUNT_ANSWER, PASSWORD_INVALID_PATTERN,
+        PASSWORD_INVALID_PATTERN);
+    assertResponseValues(response, HttpStatus.BAD_REQUEST, "invalidPasswordPattern");
+    verifyServices();
+  }
+
+  private void assertResponseValues(ResponseEntity<Map<String, Object>> response,
+      HttpStatus expectedStatus, String expectedMessageCode) {
+    assertEquals(expectedStatus, response.getStatusCode());
+    assertEquals(expectedMessageCode, response.getBody().get("messageCode"));
+  }
+
+  private void replayServices() {
+    replay(passwordService, userService);
+  }
+
+  private void verifyServices() {
+    verify(passwordService, userService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/TeacherForgotAccountAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/TeacherForgotAccountAPIControllerTest.java
@@ -1,0 +1,77 @@
+package org.wise.portal.presentation.web.controllers.teacher;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.service.password.PasswordService;
+
+@RunWith(EasyMockRunner.class)
+public class TeacherForgotAccountAPIControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private TeacherForgotAccountAPIController teacherForgotAccountAPIController = new TeacherForgotAccountAPIController();
+
+  @Mock
+  private PasswordService passwordService;
+
+  String PASSWORD_INVALID_LENGTH = "1234567";
+  String PASSWORD_INVALID_PATTERN = "abcd1234";
+  String VERIFICATION_CODE = "123456";
+
+  @Test
+  public void changePassword_InvalidPasswordLength_ReturnError() throws JSONException {
+    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
+    expect(passwordService.isValidLength(PASSWORD_INVALID_LENGTH)).andReturn(false);
+    replayServices();
+    setVerificationCode(teacher1, VERIFICATION_CODE);
+    ResponseEntity<Map<String, Object>> response = teacherForgotAccountAPIController.changePassword(
+        TEACHER_USERNAME, VERIFICATION_CODE, PASSWORD_INVALID_LENGTH, PASSWORD_INVALID_LENGTH);
+    assertResponseValues(response, HttpStatus.BAD_REQUEST, "invalidPasswordLength");
+    verifyServices();
+  }
+
+  @Test
+  public void changePassword_InvalidPasswordPattern_ReturnError() throws JSONException {
+    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
+    expect(passwordService.isValidLength(PASSWORD_INVALID_PATTERN)).andReturn(true);
+    expect(passwordService.isValidPattern(PASSWORD_INVALID_PATTERN)).andReturn(false);
+    replayServices();
+    setVerificationCode(teacher1, VERIFICATION_CODE);
+    ResponseEntity<Map<String, Object>> response = teacherForgotAccountAPIController.changePassword(
+        TEACHER_USERNAME, VERIFICATION_CODE, PASSWORD_INVALID_PATTERN, PASSWORD_INVALID_PATTERN);
+    assertResponseValues(response, HttpStatus.BAD_REQUEST, "invalidPasswordPattern");
+    verifyServices();
+  }
+
+  private void setVerificationCode(User user, String verificationCode) {
+    user.getUserDetails().setResetPasswordVerificationCodeRequestTime(new Date());
+    user.getUserDetails().setResetPasswordVerificationCode(verificationCode);
+  }
+
+  private void assertResponseValues(ResponseEntity<Map<String, Object>> response,
+      HttpStatus expectedStatus, String expectedMessageCode) {
+    assertEquals(expectedStatus, response.getStatusCode());
+    assertEquals(expectedMessageCode, response.getBody().get("messageCode"));
+  }
+
+  private void replayServices() {
+    replay(passwordService, userService);
+  }
+
+  private void verifyServices() {
+    verify(passwordService, userService);
+  }
+}

--- a/src/test/java/org/wise/portal/service/password/impl/PasswordServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/password/impl/PasswordServiceImplTest.java
@@ -1,0 +1,37 @@
+package org.wise.portal.service.password.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.service.password.PasswordService;
+
+@RunWith(EasyMockRunner.class)
+public class PasswordServiceImplTest {
+
+  @TestSubject
+  private PasswordService passwordService = new PasswordServiceImpl();
+
+  @Test
+  public void isValidLength_NotLongEnough_ShouldReturnFalse() {
+    assertFalse(passwordService.isValidLength("1234567"));
+  }
+
+  @Test
+  public void isValidLength_IsLongEnough_ShouldReturnTrue() {
+    assertTrue(passwordService.isValidLength("12345678"));
+  }
+
+  @Test
+  public void isValidPattern_NotValid_ShouldReturnFalse() {
+    assertFalse(passwordService.isValidPattern("abcd1234"));
+  }
+
+  @Test
+  public void isValidPattern_IsValid_ShouldReturnTrue() {
+    assertTrue(passwordService.isValidPattern("Abcd1234"));
+  }
+}


### PR DESCRIPTION
Test with
- https://github.com/WISE-Community/WISE-Client/pull/834

## Changes

- Increased server side password validation requirements to require at least 8 characters and at least one lowercase, one uppercase, and one number
- Password change endpoints now return a ResponseEntity which allows us to specify the response status code such as 200 for ok or 400 for bad request as well as send additional custom information such as what type of error occurred

## Test

- Make sure the password change endpoints enforce the new password requirements
- Make sure the password change endpoints send back an error response when an error occurs (they used to send back a success response but with error information)
- Make sure the password change success response still works

Here are the places where users can specify passwords
- student create account
- student forgot password
- teacher create account
- teacher forgot password
- teacher change student password in classroom monitor
- user edit password
- user unlink Google account

Closes #177