### PR TITLE
feat(PeerGrouping): Pair students with different ideas

### DIFF
--- a/src/main/java/org/wise/portal/domain/peergrouping/logic/DifferentIdeasLogic.java
+++ b/src/main/java/org/wise/portal/domain/peergrouping/logic/DifferentIdeasLogic.java
@@ -1,0 +1,27 @@
+package org.wise.portal.domain.peergrouping.logic;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DifferentIdeasLogic {
+
+  private String componentId;
+  private String nodeId;
+
+  public DifferentIdeasLogic(String logic) {
+    Pattern pattern = Pattern.compile("\"(\\w+)\"");
+    Matcher matcher = pattern.matcher(logic);
+    matcher.find();
+    this.nodeId = matcher.group(1);
+    matcher.find();
+    this.componentId = matcher.group(1);
+  }
+
+  public String getComponentId() {
+    return componentId;
+  }
+
+  public String getNodeId() {
+    return nodeId;
+  }
+}

--- a/src/main/java/org/wise/portal/domain/peergrouping/logic/DifferentIdeasLogic.java
+++ b/src/main/java/org/wise/portal/domain/peergrouping/logic/DifferentIdeasLogic.java
@@ -5,16 +5,16 @@ import java.util.regex.Pattern;
 
 public class DifferentIdeasLogic {
 
+  public static String regex = "differentIdeas\\(\"(\\w+)\",\\s*\"(\\w+)\"\\)";
   private String componentId;
   private String nodeId;
 
   public DifferentIdeasLogic(String logic) {
-    Pattern pattern = Pattern.compile("\"(\\w+)\"");
+    Pattern pattern = Pattern.compile(DifferentIdeasLogic.regex);
     Matcher matcher = pattern.matcher(logic);
     matcher.find();
     this.nodeId = matcher.group(1);
-    matcher.find();
-    this.componentId = matcher.group(1);
+    this.componentId = matcher.group(2);
   }
 
   public String getComponentId() {

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupService.java
@@ -25,16 +25,12 @@ package org.wise.portal.service.peergroup;
 
 import java.util.List;
 
-import org.json.JSONException;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.vle.domain.work.StudentWork;
 
-/**
- * @author Hiroki Terashima
- */
 public interface PeerGroupService {
 
   /**
@@ -55,8 +51,8 @@ public interface PeerGroupService {
    * @throws PeerGroupCreationException the PeerGroup cannot be created for other reasons
    * like an error occurred while grouping members
    */
-  PeerGroup getPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping) throws JSONException,
-      PeerGroupCreationException;
+  PeerGroup getPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
+      throws PeerGroupCreationException;
 
   /**
    * Gets all the PeerGroups for the specified PeerGrouping

--- a/src/main/java/org/wise/portal/service/peergroup/PeerGroupThresholdService.java
+++ b/src/main/java/org/wise/portal/service/peergroup/PeerGroupThresholdService.java
@@ -26,9 +26,6 @@ package org.wise.portal.service.peergroup;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
 
-/**
- * @author Hiroki Terashima
- */
 public interface PeerGroupThresholdService {
 
   /**
@@ -38,5 +35,5 @@ public interface PeerGroupThresholdService {
    * @param period Group subset of workgroups in the run to test for PeerGroup members
    * @return boolean
    */
-  public boolean canCreatePeerGroup(PeerGrouping peerGrouping, Group period);
+  public boolean isThresholdSatisfied(PeerGrouping peerGrouping, Group period);
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -23,34 +23,28 @@
  */
 package org.wise.portal.service.peergroup.impl;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
-import java.util.Set;
 
-import org.json.JSONException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.dao.peergroup.PeerGroupDao;
-import org.wise.portal.dao.run.RunDao;
 import org.wise.portal.dao.work.StudentWorkDao;
 import org.wise.portal.domain.peergroup.PeerGroup;
-import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
-import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergroup.PeerGroupThresholdService;
+import org.wise.portal.service.peergrouping.logic.impl.DifferentIdeasLogicServiceImpl;
+import org.wise.portal.service.peergrouping.logic.impl.RandomLogicServiceImpl;
 import org.wise.vle.domain.work.StudentWork;
 
-/**
- * @author Hiroki Terashima
- */
 @Service
 public class PeerGroupServiceImpl implements PeerGroupService {
+
+  @Autowired
+  private DifferentIdeasLogicServiceImpl differentIdeasLogicService;
 
   @Autowired
   private PeerGroupDao<PeerGroup> peerGroupDao;
@@ -59,106 +53,39 @@ public class PeerGroupServiceImpl implements PeerGroupService {
   private PeerGroupThresholdService peerGroupThresholdService;
 
   @Autowired
-  private StudentWorkDao<StudentWork> studentWorkDao;
+  private RandomLogicServiceImpl randomLogicService;
 
   @Autowired
-  private RunDao<Run> runDao;
+  private StudentWorkDao<StudentWork> studentWorkDao;
 
   public PeerGroup getById(Long id) throws ObjectNotFoundException {
     return peerGroupDao.getById(id);
   }
 
-  @Override
   public PeerGroup getPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
-      throws JSONException, PeerGroupCreationException {
+      throws PeerGroupCreationException {
     PeerGroup peerGroup = peerGroupDao.getByWorkgroupAndPeerGrouping(workgroup, peerGrouping);
-    if (peerGrouping.getLogic().contains("manual")) {
-      // use contains check instead of equals until custom logic is implemented for
-      // backwards-compatibility
+    if (peerGrouping.getLogic().equals("manual")) {
       return peerGroup;
     } else {
-      return peerGroup != null ? peerGroup : this.createPeerGroup(workgroup, peerGrouping);
+      return peerGroup != null ? peerGroup : createPeerGroup(workgroup, peerGrouping);
     }
   }
 
   private PeerGroup createPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
       throws PeerGroupCreationException {
-    if (!peerGroupThresholdService.canCreatePeerGroup(peerGrouping, workgroup.getPeriod())) {
-      return null;
-    } else {
-      PeerGroup peerGroup = new PeerGroupImpl(peerGrouping, workgroup.getPeriod(),
-          getPeerGroupMembers(workgroup, peerGrouping));
-      this.peerGroupDao.save(peerGroup);
-      return peerGroup;
+    if (peerGroupThresholdService.isThresholdSatisfied(peerGrouping, workgroup.getPeriod())) {
+      return peerGrouping.getLogic().equals("random")
+        ? randomLogicService.createPeerGroup(workgroup, peerGrouping)
+        : differentIdeasLogicService.createPeerGroup(workgroup, peerGrouping);
     }
+    return null;
   }
 
-  private Set<Workgroup> getPeerGroupMembers(Workgroup workgroup, PeerGrouping peerGrouping)
-      throws PeerGroupCreationException {
-    try {
-      List<Workgroup> workgroupsInPeriod = runDao.getWorkgroupsForRunAndPeriod(
-          workgroup.getRun().getId(), workgroup.getPeriod().getId());
-      workgroupsInPeriod.removeIf(workgroupInPeriod -> workgroupInPeriod.getMembers().size() == 0);
-      List<Workgroup> workgroupsInPeerGroup = peerGroupDao.getWorkgroupsInPeerGroup(peerGrouping,
-          workgroup.getPeriod());
-      Set<Workgroup> workgroupsNotInPeerGroup = getWorkgroupsNotInPeerGroup(workgroupsInPeriod,
-          workgroupsInPeerGroup);
-      if (isLastOnesLeftToPair(workgroupsInPeerGroup, workgroupsInPeriod,
-          peerGrouping.getMaxMembershipCount())) {
-        return workgroupsNotInPeerGroup;
-      } else {
-        return getWorkgroupsInPeerGroupUpToMaxMembership(workgroup, peerGrouping,
-            workgroupsNotInPeerGroup);
-      }
-    } catch (JSONException e) {
-      throw new PeerGroupCreationException();
-    }
-  }
-
-  private boolean isLastOnesLeftToPair(List<Workgroup> workgroupsInPeerGroup,
-      List<Workgroup> workgroupsInPeriod, int maxMembershipCount) {
-    int numWorkgroupsNotInPeerGroup = workgroupsInPeriod.size() - workgroupsInPeerGroup.size();
-    return (numWorkgroupsNotInPeerGroup - maxMembershipCount) <= 1;
-  }
-
-  private Set<Workgroup> getWorkgroupsInPeerGroupUpToMaxMembership(Workgroup workgroup,
-      PeerGrouping peerGrouping, Set<Workgroup> possibleMembers) throws JSONException {
-    Set<Workgroup> members = new HashSet<Workgroup>();
-    members.add(workgroup);
-    possibleMembers.remove(workgroup);
-    addMembersRandomly(peerGrouping, possibleMembers, members);
-    return members;
-  }
-
-  private void addMembersRandomly(PeerGrouping peerGrouping, Set<Workgroup> possibleMembers,
-      Set<Workgroup> members) {
-    List<Workgroup> possibleMembersList = new ArrayList<Workgroup>(possibleMembers);
-    Random random = new Random();
-    while (members.size() < peerGrouping.getMaxMembershipCount()) {
-      int randomInt = random.nextInt(possibleMembersList.size());
-      Workgroup randomWorkgroup = possibleMembersList.get(randomInt);
-      members.add(randomWorkgroup);
-      possibleMembersList.remove(randomWorkgroup);
-    }
-  }
-
-  private Set<Workgroup> getWorkgroupsNotInPeerGroup(List<Workgroup> workgroupsInPeriod,
-      List<Workgroup> workgroupsInPeerGroup) throws JSONException {
-    Set<Workgroup> workgroupsNotInPeerGroup = new HashSet<Workgroup>();
-    for (Workgroup workgroup : workgroupsInPeriod) {
-      if (!workgroupsInPeerGroup.contains(workgroup)) {
-        workgroupsNotInPeerGroup.add(workgroup);
-      }
-    }
-    return workgroupsNotInPeerGroup;
-  }
-
-  @Override
   public List<PeerGroup> getPeerGroups(PeerGrouping peerGrouping) {
     return peerGroupDao.getListByPeerGrouping(peerGrouping);
   }
 
-  @Override
   public List<StudentWork> getStudentWork(PeerGroup peerGroup, String nodeId, String componentId) {
     return studentWorkDao.getStudentWork(peerGroup, nodeId, componentId);
   }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceImpl.java
@@ -32,6 +32,7 @@ import org.wise.portal.dao.peergroup.PeerGroupDao;
 import org.wise.portal.dao.work.StudentWorkDao;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
+import org.wise.portal.domain.peergrouping.logic.DifferentIdeasLogic;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
 import org.wise.portal.service.peergroup.PeerGroupService;
@@ -64,11 +65,20 @@ public class PeerGroupServiceImpl implements PeerGroupService {
 
   public PeerGroup getPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
       throws PeerGroupCreationException {
+    validatePeerGroupingLogic(peerGrouping);
     PeerGroup peerGroup = peerGroupDao.getByWorkgroupAndPeerGrouping(workgroup, peerGrouping);
     if (peerGrouping.getLogic().equals("manual")) {
       return peerGroup;
     } else {
       return peerGroup != null ? peerGroup : createPeerGroup(workgroup, peerGrouping);
+    }
+  }
+
+  private void validatePeerGroupingLogic(PeerGrouping peerGrouping) {
+    String logic = peerGrouping.getLogic();
+    if (!(logic.equals("manual") || logic.equals("random")
+        || logic.matches(DifferentIdeasLogic.regex))) {
+      throw new IllegalArgumentException("Invalid PeerGrouping logic");
     }
   }
 

--- a/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceImpl.java
@@ -35,9 +35,6 @@ import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.peergroup.PeerGroupThresholdService;
 import org.wise.portal.service.run.RunService;
 
-/**
- * @author Hiroki Terashima
- */
 @Service
 public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService {
 
@@ -47,15 +44,15 @@ public class PeerGroupThresholdServiceImpl implements PeerGroupThresholdService 
   @Autowired
   private PeerGroupDao<PeerGroup> peerGroupDao;
 
-  public boolean canCreatePeerGroup(PeerGrouping peerGrouping, Group period) {
-    int numWorkgroupsNotInPeerGroup = getNumNonEmptyWorkgroupsInPeriod(peerGrouping, period) -
-        getNumNonEmptyWorkgroupsInPeerGroup(peerGrouping, period);
+  public boolean isThresholdSatisfied(PeerGrouping peerGrouping, Group period) {
+    int numWorkgroupsNotInPeerGroup = getNumNonEmptyWorkgroupsInPeriod(peerGrouping, period)
+        - getNumNonEmptyWorkgroupsInPeerGroup(peerGrouping, period);
     return numWorkgroupsNotInPeerGroup > 1;
   }
 
   private int getNumNonEmptyWorkgroupsInPeriod(PeerGrouping peerGrouping, Group period) {
-    List<Workgroup> workgroupsInPeriod = runService.getWorkgroups(
-        peerGrouping.getRun().getId(), period.getId());
+    List<Workgroup> workgroupsInPeriod = runService.getWorkgroups(peerGrouping.getRun().getId(),
+        period.getId());
     workgroupsInPeriod.removeIf(workgroupInPeriod -> workgroupInPeriod.getMembers().size() == 0);
     return workgroupsInPeriod.size();
   }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/WorkgroupWithDifferentIdeas.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/WorkgroupWithDifferentIdeas.java
@@ -1,0 +1,27 @@
+package org.wise.portal.service.peergroup.impl;
+
+import org.wise.portal.domain.workgroup.Workgroup;
+
+import lombok.Getter;
+
+@Getter
+public class WorkgroupWithDifferentIdeas implements Comparable<WorkgroupWithDifferentIdeas> {
+  private Workgroup workgroup;
+  private int numDifferentIdeas;
+
+  public WorkgroupWithDifferentIdeas(Workgroup workgroup, int numDifferentIdeas) {
+    this.workgroup = workgroup;
+    this.numDifferentIdeas = numDifferentIdeas;
+  }
+
+  @Override
+  public int compareTo(WorkgroupWithDifferentIdeas o) {
+    if (this.numDifferentIdeas > o.numDifferentIdeas) {
+      return -1;
+    } else if (this.numDifferentIdeas < o.numDifferentIdeas) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/src/main/java/org/wise/portal/service/peergroup/impl/WorkgroupWithDifferentIdeas.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/WorkgroupWithDifferentIdeas.java
@@ -16,6 +16,8 @@ public class WorkgroupWithDifferentIdeas implements Comparable<WorkgroupWithDiff
 
   @Override
   public int compareTo(WorkgroupWithDifferentIdeas o) {
-    return this.numDifferentIdeas - o.numDifferentIdeas;
+    return this.numDifferentIdeas == o.numDifferentIdeas
+      ? this.workgroup.getId().compareTo(o.workgroup.getId())
+      : this.numDifferentIdeas - o.numDifferentIdeas;
   }
 }

--- a/src/main/java/org/wise/portal/service/peergroup/impl/WorkgroupWithDifferentIdeas.java
+++ b/src/main/java/org/wise/portal/service/peergroup/impl/WorkgroupWithDifferentIdeas.java
@@ -16,12 +16,6 @@ public class WorkgroupWithDifferentIdeas implements Comparable<WorkgroupWithDiff
 
   @Override
   public int compareTo(WorkgroupWithDifferentIdeas o) {
-    if (this.numDifferentIdeas > o.numDifferentIdeas) {
-      return -1;
-    } else if (this.numDifferentIdeas < o.numDifferentIdeas) {
-      return 1;
-    } else {
-      return 0;
-    }
+    return this.numDifferentIdeas - o.numDifferentIdeas;
   }
 }

--- a/src/main/java/org/wise/portal/service/peergrouping/PeerGroupingService.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/PeerGroupingService.java
@@ -31,9 +31,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.run.Run;
 
-/**
- * @author Hiroki Terashima
- */
 public interface PeerGroupingService {
 
   /**
@@ -46,16 +43,16 @@ public interface PeerGroupingService {
    * @throws PeerGroupingNotFoundException if PeerGrouping is not found in the
    *   database or curriculum unit for the specified component
    */
-  PeerGrouping getByComponent(Run run, String nodeId, String componentId) throws
-      PeerGroupingNotFoundException;
+  PeerGrouping getByComponent(Run run, String nodeId, String componentId)
+      throws PeerGroupingNotFoundException;
 
   /**
    * Retrieves PeerGrouping from the database for the specified run and tag. If none is found,
-   * creates a new one.
+   * returns null
    *
    * @param run
    * @param tag
-   * @return PeerGrouping
+   * @return PeerGrouping or null
    */
   PeerGrouping getByTag(Run run, String tag);
 

--- a/src/main/java/org/wise/portal/service/peergrouping/logic/PeerGroupLogicService.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/logic/PeerGroupLogicService.java
@@ -1,0 +1,20 @@
+package org.wise.portal.service.peergrouping.logic;
+
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergrouping.PeerGrouping;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.PeerGroupCreationException;
+
+public interface PeerGroupLogicService {
+
+  /**
+   * Creates a new PeerGroup with the Workgroup as a member for the PeerGrouping activity
+   * @param workgroup Workgroup requesting to be put into a new PeerGroup
+   * @param peerGrouping PeerGroup activity to create the new PeerGroup for
+   * @return newly created PeerGroup, or null if the PeerGroup could not be created, for example
+   * if there were not enough pair-able members
+   * @throws PeerGroupCreationException when there was an error during the creation
+   */
+  PeerGroup createPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
+      throws PeerGroupCreationException;
+}

--- a/src/main/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImpl.java
@@ -1,0 +1,121 @@
+package org.wise.portal.service.peergrouping.logic.impl;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.SetUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.wise.portal.dao.annotation.wise5.AnnotationDao;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.peergrouping.PeerGrouping;
+import org.wise.portal.domain.peergrouping.logic.DifferentIdeasLogic;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.impl.WorkgroupWithDifferentIdeas;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+
+@Service
+public class DifferentIdeasLogicServiceImpl extends PeerGroupLogicServiceImpl {
+
+  @Autowired
+  private AnnotationDao<Annotation> annotationDao;
+
+  boolean canCreatePeerGroup(Workgroup workgroup, Set<Workgroup> workgroupsNotInPeerGroup,
+      PeerGrouping peerGrouping) {
+    List<Annotation> annotations = getIdeaDetectedAnnotations(peerGrouping, workgroup.getPeriod());
+    return hasWorkgroupAnnotation(workgroup, annotations)
+        && hasEnoughUnpairedMembersIdeasAnnotation(peerGrouping, annotations,
+            workgroupsNotInPeerGroup);
+  }
+
+  private List<Annotation> getIdeaDetectedAnnotations(PeerGrouping peerGrouping, Group period) {
+    DifferentIdeasLogic logic = new DifferentIdeasLogic(peerGrouping.getLogic());
+    List<Annotation> annotations = annotationDao
+        .getAnnotations(peerGrouping.getRun(), logic.getNodeId(), logic.getComponentId()).stream()
+        .filter(annotation -> annotation.getPeriod().equals(period)
+            && annotation.getType().equals("autoScore"))
+        .collect(Collectors.toList());
+    return annotations;
+  }
+
+  private boolean hasWorkgroupAnnotation(Workgroup workgroup, List<Annotation> annotations) {
+    return getWorkgroupAnnotation(workgroup, annotations).isPresent();
+  }
+
+  private Optional<Annotation> getWorkgroupAnnotation(Workgroup workgroup,
+      List<Annotation> annotations) {
+    return annotations.stream().filter(annotation -> annotation.getToWorkgroup().equals(workgroup))
+        .findFirst();
+  }
+
+  private boolean hasEnoughUnpairedMembersIdeasAnnotation(PeerGrouping peerGrouping,
+      List<Annotation> annotations, Set<Workgroup> workgroupsNotInPeerGroup) {
+    return workgroupsNotInPeerGroup.stream()
+        .filter(workgroup -> hasWorkgroupAnnotation(workgroup, annotations)).count() >= 2;
+  }
+
+  Set<Workgroup> groupMembersUpToMaxMembership(Workgroup workgroup, PeerGrouping peerGrouping,
+      Set<Workgroup> possibleMembers) {
+    Set<Workgroup> members = new HashSet<Workgroup>();
+    members.add(workgroup);
+    possibleMembers.remove(workgroup);
+    TreeSet<WorkgroupWithDifferentIdeas> workgroupsWithDifferentIdeas = getWorkgroupsWithDifferentIdeas(
+        possibleMembers, workgroup, peerGrouping);
+    Iterator<WorkgroupWithDifferentIdeas> iterator = workgroupsWithDifferentIdeas.iterator();
+    while (members.size() < peerGrouping.getMaxMembershipCount()) {
+      members.add(iterator.next().getWorkgroup());
+    }
+    return members;
+  }
+
+  private TreeSet<WorkgroupWithDifferentIdeas> getWorkgroupsWithDifferentIdeas(
+      Set<Workgroup> possibleMembers, Workgroup workgroup, PeerGrouping peerGrouping) {
+    List<Annotation> annotations = getIdeaDetectedAnnotations(peerGrouping, workgroup.getPeriod());
+    Set<String> workgroupIdeas = getDetectedIdeas(workgroup, annotations);
+    return getWorkgroupsWithDifferentIdeas(possibleMembers, workgroupIdeas, annotations);
+  }
+
+  private Set<String> getDetectedIdeas(Workgroup workgroup, List<Annotation> annotations) {
+    Optional<Annotation> workgroupAnnotation = getWorkgroupAnnotation(workgroup, annotations);
+    return workgroupAnnotation.isPresent() ? getDetectedIdeas(workgroupAnnotation.get())
+      : new HashSet<String>();
+  }
+
+  private Set<String> getDetectedIdeas(Annotation annotation) {
+    try {
+      JSONObject dataJson = new JSONObject(annotation.getData());
+      JSONArray ideas = dataJson.getJSONArray("ideas");
+      Set<String> detectedIdeas = new HashSet<String>();
+      for (int i = 0; i < ideas.length(); i++) {
+        JSONObject idea = ideas.getJSONObject(i);
+        if (idea.getBoolean("detected")) {
+          detectedIdeas.add(idea.getString("name"));
+        }
+      }
+      return detectedIdeas;
+    } catch (JSONException e) {
+      return new HashSet<String>();
+    }
+  }
+
+  private TreeSet<WorkgroupWithDifferentIdeas> getWorkgroupsWithDifferentIdeas(
+      Set<Workgroup> possibleMembers, Set<String> workgroupIdeas, List<Annotation> annotations) {
+    TreeSet<WorkgroupWithDifferentIdeas> workgroups = new TreeSet<WorkgroupWithDifferentIdeas>();
+    for (Workgroup possibleMember : possibleMembers) {
+      if (hasWorkgroupAnnotation(possibleMember, annotations)) {
+        Set<String> possibleMemberIdeas = getDetectedIdeas(possibleMember, annotations);
+        Set<String> differentIdeas = SetUtils.disjunction(workgroupIdeas, possibleMemberIdeas);
+        workgroups.add(new WorkgroupWithDifferentIdeas(possibleMember, differentIdeas.size()));
+      }
+    }
+    return workgroups;
+  }
+}

--- a/src/main/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImpl.java
@@ -26,13 +26,13 @@ public abstract class PeerGroupLogicServiceImpl implements PeerGroupLogicService
   public PeerGroup createPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
       throws PeerGroupCreationException {
     List<Workgroup> workgroupsInPeriod = getWorkgroupsInSamePeriod(workgroup);
-    List<Workgroup> workgroupsInPeerGroup = peerGroupDao.getWorkgroupsInPeerGroup(peerGrouping,
+    List<Workgroup> workgroupsInAPeerGroup = peerGroupDao.getWorkgroupsInPeerGroup(peerGrouping,
         workgroup.getPeriod());
-    Set<Workgroup> workgroupsNotInPeerGroup = getWorkgroupsNotInPeerGroup(workgroupsInPeriod,
-        workgroupsInPeerGroup);
-    if (canCreatePeerGroup(workgroup, workgroupsNotInPeerGroup, peerGrouping)) {
+    Set<Workgroup> workgroupsNotInAPeerGroup = getWorkgroupsNotInPeerGroup(workgroupsInPeriod,
+        workgroupsInAPeerGroup);
+    if (canCreatePeerGroup(workgroup, workgroupsNotInAPeerGroup, peerGrouping)) {
       Set<Workgroup> members = getPeerGroupMembers(workgroup, peerGrouping, workgroupsInPeriod,
-          workgroupsInPeerGroup, workgroupsNotInPeerGroup);
+          workgroupsInAPeerGroup, workgroupsNotInAPeerGroup);
       PeerGroup peerGroup = new PeerGroupImpl(peerGrouping, workgroup.getPeriod(), members);
       peerGroupDao.save(peerGroup);
       return peerGroup;
@@ -41,25 +41,25 @@ public abstract class PeerGroupLogicServiceImpl implements PeerGroupLogicService
   }
 
   Set<Workgroup> getPeerGroupMembers(Workgroup workgroup, PeerGrouping peerGrouping,
-      List<Workgroup> workgroupsInPeriod, List<Workgroup> workgroupsInPeerGroup,
-      Set<Workgroup> workgroupsNotInPeerGroup) throws PeerGroupCreationException {
-    if (isLastOnesLeftToPair(workgroupsInPeerGroup, workgroupsInPeriod,
+      List<Workgroup> workgroupsInPeriod, List<Workgroup> workgroupsInAPeerGroup,
+      Set<Workgroup> workgroupsNotInAPeerGroup) throws PeerGroupCreationException {
+    if (isLastOnesLeftToPair(workgroupsInAPeerGroup, workgroupsInPeriod,
         peerGrouping.getMaxMembershipCount())) {
-      return workgroupsNotInPeerGroup;
+      return workgroupsNotInAPeerGroup;
     } else {
-      return groupMembersUpToMaxMembership(workgroup, peerGrouping, workgroupsNotInPeerGroup);
+      return groupMembersUpToMaxMembership(workgroup, peerGrouping, workgroupsNotInAPeerGroup);
     }
   }
 
   Set<Workgroup> getWorkgroupsNotInPeerGroup(List<Workgroup> workgroupsInPeriod,
-      List<Workgroup> workgroupsInPeerGroup) {
-    Set<Workgroup> workgroupsNotInPeerGroup = new HashSet<Workgroup>();
+      List<Workgroup> workgroupsInAPeerGroup) {
+    Set<Workgroup> workgroupsNotInAPeerGroup = new HashSet<Workgroup>();
     for (Workgroup workgroup : workgroupsInPeriod) {
-      if (!workgroupsInPeerGroup.contains(workgroup)) {
-        workgroupsNotInPeerGroup.add(workgroup);
+      if (!workgroupsInAPeerGroup.contains(workgroup)) {
+        workgroupsNotInAPeerGroup.add(workgroup);
       }
     }
-    return workgroupsNotInPeerGroup;
+    return workgroupsNotInAPeerGroup;
   }
 
   List<Workgroup> getWorkgroupsInSamePeriod(Workgroup workgroup) {
@@ -69,20 +69,20 @@ public abstract class PeerGroupLogicServiceImpl implements PeerGroupLogicService
     return workgroups;
   }
 
-  private boolean isLastOnesLeftToPair(List<Workgroup> workgroupsInPeerGroup,
+  private boolean isLastOnesLeftToPair(List<Workgroup> workgroupsInAPeerGroup,
       List<Workgroup> workgroupsInPeriod, int maxMembers) {
-    int numWorkgroupsNotInPeerGroup = workgroupsInPeriod.size() - workgroupsInPeerGroup.size();
-    return (numWorkgroupsNotInPeerGroup - maxMembers) <= 1;
+    int numWorkgroupsNotInAPeerGroup = workgroupsInPeriod.size() - workgroupsInAPeerGroup.size();
+    return (numWorkgroupsNotInAPeerGroup - maxMembers) <= 1;
   }
 
   /**
    * Return true iff a new PeerGroup can be created
    * @param workgroup Workgroup requesting to create PeerGroup
-   * @param workgroupsNotInPeerGroup Set of workgroups that can be paired
+   * @param workgroupsNotInAPeerGroup Set of workgroups that can be paired
    * @param peerGrouping PeerGrouping activity to create PeerGroup for
    * @return true if there are enough workgroups that can be paired
    */
-  abstract boolean canCreatePeerGroup(Workgroup workgroup, Set<Workgroup> workgroupsNotInPeerGroup,
+  abstract boolean canCreatePeerGroup(Workgroup workgroup, Set<Workgroup> workgroupsNotInAPeerGroup,
       PeerGrouping peerGrouping);
 
   /**

--- a/src/main/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImpl.java
@@ -1,0 +1,98 @@
+package org.wise.portal.service.peergrouping.logic.impl;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wise.portal.dao.peergroup.PeerGroupDao;
+import org.wise.portal.dao.run.RunDao;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.peergrouping.PeerGrouping;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.peergroup.PeerGroupCreationException;
+import org.wise.portal.service.peergrouping.logic.PeerGroupLogicService;
+
+public abstract class PeerGroupLogicServiceImpl implements PeerGroupLogicService {
+
+  @Autowired
+  PeerGroupDao<PeerGroup> peerGroupDao;
+
+  @Autowired
+  private RunDao<Run> runDao;
+
+  public PeerGroup createPeerGroup(Workgroup workgroup, PeerGrouping peerGrouping)
+      throws PeerGroupCreationException {
+    List<Workgroup> workgroupsInPeriod = getWorkgroupsInSamePeriod(workgroup);
+    List<Workgroup> workgroupsInPeerGroup = peerGroupDao.getWorkgroupsInPeerGroup(peerGrouping,
+        workgroup.getPeriod());
+    Set<Workgroup> workgroupsNotInPeerGroup = getWorkgroupsNotInPeerGroup(workgroupsInPeriod,
+        workgroupsInPeerGroup);
+    if (canCreatePeerGroup(workgroup, workgroupsNotInPeerGroup, peerGrouping)) {
+      Set<Workgroup> members = getPeerGroupMembers(workgroup, peerGrouping, workgroupsInPeriod,
+          workgroupsInPeerGroup, workgroupsNotInPeerGroup);
+      PeerGroup peerGroup = new PeerGroupImpl(peerGrouping, workgroup.getPeriod(), members);
+      peerGroupDao.save(peerGroup);
+      return peerGroup;
+    }
+    return null;
+  }
+
+  Set<Workgroup> getPeerGroupMembers(Workgroup workgroup, PeerGrouping peerGrouping,
+      List<Workgroup> workgroupsInPeriod, List<Workgroup> workgroupsInPeerGroup,
+      Set<Workgroup> workgroupsNotInPeerGroup) throws PeerGroupCreationException {
+    if (isLastOnesLeftToPair(workgroupsInPeerGroup, workgroupsInPeriod,
+        peerGrouping.getMaxMembershipCount())) {
+      return workgroupsNotInPeerGroup;
+    } else {
+      return groupMembersUpToMaxMembership(workgroup, peerGrouping, workgroupsNotInPeerGroup);
+    }
+  }
+
+  Set<Workgroup> getWorkgroupsNotInPeerGroup(List<Workgroup> workgroupsInPeriod,
+      List<Workgroup> workgroupsInPeerGroup) {
+    Set<Workgroup> workgroupsNotInPeerGroup = new HashSet<Workgroup>();
+    for (Workgroup workgroup : workgroupsInPeriod) {
+      if (!workgroupsInPeerGroup.contains(workgroup)) {
+        workgroupsNotInPeerGroup.add(workgroup);
+      }
+    }
+    return workgroupsNotInPeerGroup;
+  }
+
+  List<Workgroup> getWorkgroupsInSamePeriod(Workgroup workgroup) {
+    List<Workgroup> workgroups = runDao.getWorkgroupsForRunAndPeriod(workgroup.getRun().getId(),
+        workgroup.getPeriod().getId());
+    workgroups.removeIf(workgroupInPeriod -> workgroupInPeriod.getMembers().size() == 0);
+    return workgroups;
+  }
+
+  private boolean isLastOnesLeftToPair(List<Workgroup> workgroupsInPeerGroup,
+      List<Workgroup> workgroupsInPeriod, int maxMembers) {
+    int numWorkgroupsNotInPeerGroup = workgroupsInPeriod.size() - workgroupsInPeerGroup.size();
+    return (numWorkgroupsNotInPeerGroup - maxMembers) <= 1;
+  }
+
+  /**
+   * Return true iff a new PeerGroup can be created
+   * @param workgroup Workgroup requesting to create PeerGroup
+   * @param workgroupsNotInPeerGroup Set of workgroups that can be paired
+   * @param peerGrouping PeerGrouping activity to create PeerGroup for
+   * @return true if there are enough workgroups that can be paired
+   */
+  abstract boolean canCreatePeerGroup(Workgroup workgroup, Set<Workgroup> workgroupsNotInPeerGroup,
+      PeerGrouping peerGrouping);
+
+  /**
+   * Put together members that have different ideas into a PeerGroup
+   * When this method is called, there is enough possibleMembers with detected ideas to pair
+   * @param workgroup Workgroup making request to pair
+   * @param peerGrouping PeerGrouping activity to create PeerGroup for
+   * @param possibleMembers unpaired members
+   * @return Set<Workgroup> members that will be in the PeerGroup
+   */
+  abstract Set<Workgroup> groupMembersUpToMaxMembership(Workgroup workgroup,
+      PeerGrouping peerGrouping, Set<Workgroup> possibleMembers);
+}

--- a/src/main/java/org/wise/portal/service/peergrouping/logic/impl/RandomLogicServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/peergrouping/logic/impl/RandomLogicServiceImpl.java
@@ -1,0 +1,36 @@
+package org.wise.portal.service.peergrouping.logic.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.wise.portal.domain.peergrouping.PeerGrouping;
+import org.wise.portal.domain.workgroup.Workgroup;
+
+@Service
+public class RandomLogicServiceImpl extends PeerGroupLogicServiceImpl {
+
+  boolean canCreatePeerGroup(Workgroup workgroup, Set<Workgroup> workgroupsNotInPeerGroup,
+      PeerGrouping peerGrouping) {
+    return workgroupsNotInPeerGroup.size() >= 2;
+  }
+
+  Set<Workgroup> groupMembersUpToMaxMembership(Workgroup workgroup, PeerGrouping peerGrouping,
+      Set<Workgroup> possibleMembers) {
+    Set<Workgroup> members = new HashSet<Workgroup>();
+    members.add(workgroup);
+    possibleMembers.remove(workgroup);
+    List<Workgroup> possibleMembersList = new ArrayList<Workgroup>(possibleMembers);
+    Random random = new Random();
+    while (members.size() < peerGrouping.getMaxMembershipCount()) {
+      int randomInt = random.nextInt(possibleMembersList.size());
+      Workgroup randomWorkgroup = possibleMembersList.get(randomInt);
+      members.add(randomWorkgroup);
+      possibleMembersList.remove(randomWorkgroup);
+    }
+    return members;
+  }
+}

--- a/src/test/java/org/wise/portal/domain/peergrouping/logic/DifferentIdeasLogicTest.java
+++ b/src/test/java/org/wise/portal/domain/peergrouping/logic/DifferentIdeasLogicTest.java
@@ -1,0 +1,30 @@
+package org.wise.portal.domain.peergrouping.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.easymock.EasyMockRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EasyMockRunner.class)
+public class DifferentIdeasLogicTest {
+
+  private DifferentIdeasLogic logic;
+  private String logicString = "differentIdeas(\"node1\", \"componentX\")";
+
+  @Before
+  public void setup() {
+    this.logic = new DifferentIdeasLogic(logicString);
+  }
+
+  @Test
+  public void getComponentId() {
+    assertEquals("componentX", logic.getComponentId());
+  }
+
+  @Test
+  public void getNodeId() {
+    assertEquals("node1", logic.getNodeId());
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupCreateServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupCreateServiceImplTest.java
@@ -13,9 +13,6 @@ import org.wise.portal.dao.peergroup.PeerGroupDao;
 import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 
-/**
- * @author Hiroki Terashima
- */
 @RunWith(EasyMockRunner.class)
 public class PeerGroupCreateServiceImplTest extends PeerGroupServiceTest {
 
@@ -30,7 +27,7 @@ public class PeerGroupCreateServiceImplTest extends PeerGroupServiceTest {
     peerGroupDao.save(isA(PeerGroupImpl.class));
     expectLastCall();
     replay(peerGroupDao);
-    PeerGroup peerGroup = service.create(peerGrouping, run1Period1);
+    PeerGroup peerGroup = service.create(randomPeerGrouping, run1Period1);
     assertEquals(0, peerGroup.getMembers().size());
     verify(peerGroupDao);
   }

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupInfoServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupInfoServiceImplTest.java
@@ -42,9 +42,6 @@ import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.run.RunService;
 
-/**
- * @author Hiroki Terashima
- */
 @SuppressWarnings("unchecked")
 @RunWith(EasyMockRunner.class)
 public class PeerGroupInfoServiceImplTest extends PeerGroupServiceTest {
@@ -63,14 +60,14 @@ public class PeerGroupInfoServiceImplTest extends PeerGroupServiceTest {
     expectGetPeerGroups();
     expectGetWorkgroups();
     replay(peerGroupService, runService);
-    Map<String, Object> peerGroupInfo = service.getPeerGroupInfo(peerGrouping);
+    Map<String, Object> peerGroupInfo = service.getPeerGroupInfo(randomPeerGrouping);
     assertEquals(1, ((List<PeerGroup>) peerGroupInfo.get("peerGroups")).size());
     assertEquals(4, ((List<Workgroup>) peerGroupInfo.get("workgroupsNotInPeerGroup")).size());
     verify(peerGroupService, runService);
   }
 
   private void expectGetPeerGroups() {
-    expect(peerGroupService.getPeerGroups(peerGrouping)).andReturn(peerGroups);
+    expect(peerGroupService.getPeerGroups(randomPeerGrouping)).andReturn(peerGroups);
   }
 
   private void expectGetWorkgroups() {

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupMembershipServiceImplTest.java
@@ -17,9 +17,6 @@ import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.workgroup.Workgroup;
 
-/**
- * @author Hiroki Terashima
- */
 @RunWith(EasyMockRunner.class)
 public class PeerGroupMembershipServiceImplTest extends PeerGroupServiceTest {
 
@@ -66,7 +63,7 @@ public class PeerGroupMembershipServiceImplTest extends PeerGroupServiceTest {
   }
 
   private void expectPeerGroup(Workgroup workgroup, PeerGroup peerGroup) {
-    expect(peerGroupDao.getByWorkgroupAndPeerGrouping(workgroup, peerGrouping)).andReturn(
-        peerGroup);
+    expect(peerGroupDao.getByWorkgroupAndPeerGrouping(workgroup, randomPeerGrouping))
+        .andReturn(peerGroup);
   }
 }

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupServiceTest.java
@@ -38,13 +38,9 @@ import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.WISEServiceTest;
 
-/**
- * @author Hiroki Terashima
- * @author Geoffrey Kwan
- */
 public class PeerGroupServiceTest extends WISEServiceTest {
 
-  PeerGrouping peerGrouping, manualPeerGrouping;
+  protected PeerGrouping differentIdeasPeergrouping, manualPeerGrouping, randomPeerGrouping;
 
   PeerGroup peerGroup1, peerGroup2, peerGroup3;
 
@@ -53,12 +49,14 @@ public class PeerGroupServiceTest extends WISEServiceTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    peerGrouping = createPeerGrouping(run1, "tag1", "random", 3, 50, 2);
-    peerGroup1 = new PeerGroupImpl(peerGrouping, run1Period1,
+    differentIdeasPeergrouping = createPeerGrouping(run1, "tag1",
+        "differentIdeas(\"node1\",\"componentA\")", 2, 50, 2);
+    manualPeerGrouping = createPeerGrouping(run1, "tag1", "manual", 2, 50, 2);
+    randomPeerGrouping = createPeerGrouping(run1, "tag1", "random", 3, 50, 2);
+    peerGroup1 = new PeerGroupImpl(randomPeerGrouping, run1Period1,
         new HashSet<Workgroup>(Arrays.asList(run1Workgroup1, run1Workgroup2)));
     peerGroups.add(peerGroup1);
-    peerGroup2 = new PeerGroupImpl(peerGrouping, run1Period1, new HashSet<Workgroup>());
-    manualPeerGrouping = createPeerGrouping(run1, "tag1", "manual", 2, 50, 2);
+    peerGroup2 = new PeerGroupImpl(randomPeerGrouping, run1Period1, new HashSet<Workgroup>());
   }
 
   private PeerGrouping createPeerGrouping(Run run, String peerGroupingTag, String logicName,

--- a/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
+++ b/src/test/java/org/wise/portal/service/peergroup/impl/PeerGroupThresholdServiceTest.java
@@ -42,9 +42,6 @@ import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.service.run.RunService;
 import org.wise.vle.domain.work.StudentWork;
 
-/**
- * @author Hiroki Terashima
- */
 @RunWith(EasyMockRunner.class)
 public class PeerGroupThresholdServiceTest extends PeerGroupServiceTest {
 
@@ -65,7 +62,7 @@ public class PeerGroupThresholdServiceTest extends PeerGroupServiceTest {
     expectTwoWorkgroupsInPeerGroup();
     expectThreeWorkgroupsInPeriod();
     replayAll();
-    assertFalse(service.canCreatePeerGroup(peerGrouping, run1Period1));
+    assertFalse(service.isThresholdSatisfied(randomPeerGrouping, run1Period1));
     verifyAll();
   }
 
@@ -74,21 +71,22 @@ public class PeerGroupThresholdServiceTest extends PeerGroupServiceTest {
     expectNoWorkgroupsInPeerGroup();
     expectThreeWorkgroupsInPeriod();
     replayAll();
-    assertTrue(service.canCreatePeerGroup(peerGrouping, run1Period1));
+    assertTrue(service.isThresholdSatisfied(randomPeerGrouping, run1Period1));
     verifyAll();
   }
 
   private void expectNoWorkgroupsInPeerGroup() {
-    expect(peerGroupDao.getListByPeerGrouping(peerGrouping)).andReturn(Arrays.asList());
+    expect(peerGroupDao.getListByPeerGrouping(randomPeerGrouping)).andReturn(Arrays.asList());
   }
 
   private void expectTwoWorkgroupsInPeerGroup() {
-    expect(peerGroupDao.getListByPeerGrouping(peerGrouping)).andReturn(Arrays.asList(peerGroup1));
+    expect(peerGroupDao.getListByPeerGrouping(randomPeerGrouping))
+        .andReturn(Arrays.asList(peerGroup1));
   }
 
   private void expectThreeWorkgroupsInPeriod() {
-    expect(runService.getWorkgroups(run1Id, run1Period1.getId())).andReturn(Arrays.asList(
-        run1Workgroup1, run1Workgroup2, run1Workgroup3));
+    expect(runService.getWorkgroups(run1Id, run1Period1.getId()))
+        .andReturn(Arrays.asList(run1Workgroup1, run1Workgroup2, run1Workgroup3));
   }
 
   private void verifyAll() {

--- a/src/test/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImplTest.java
@@ -39,7 +39,7 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
   PeerGrouping peerGrouping = new PeerGroupingImpl();
   private Run run = new RunImpl();
   Set<Workgroup> workgroupsNotInPeerGroup;
-  Annotation workgroup1Ideas, workgroup2Ideas, workgroup3Ideas, workgroup4Ideas;
+  Annotation workgroup1Ideas, workgroup2Ideas, workgroup3Ideas, workgroup4Ideas, workgroup5Ideas;
   String ideas1And2 = createIdeaString(true, true, false, false);
   String ideas3 = createIdeaString(false, false, true, false);
   String ideas3And4 = createIdeaString(false, false, true, true);
@@ -56,10 +56,12 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
     workgroupsNotInPeerGroup.add(workgroup2);
     workgroupsNotInPeerGroup.add(workgroup3);
     workgroupsNotInPeerGroup.add(workgroup4);
+    workgroupsNotInPeerGroup.add(workgroup5);
     workgroup1Ideas = createIdeasAnnotation(workgroup1, ideas1And2);
     workgroup2Ideas = createIdeasAnnotation(workgroup2, ideas3);
     workgroup3Ideas = createIdeasAnnotation(workgroup3, ideas3And4);
     workgroup4Ideas = createIdeasAnnotation(workgroup4, ideas4);
+    workgroup5Ideas = createIdeasAnnotation(workgroup5, ideas3And4);
     workgroup1IdeasOnly = new ArrayList<Annotation>();
     workgroup1IdeasOnly.add(workgroup1Ideas);
     classroomIdeaAnnotations = new ArrayList<Annotation>();
@@ -67,6 +69,7 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
     classroomIdeaAnnotations.add(workgroup2Ideas);
     classroomIdeaAnnotations.add(workgroup3Ideas);
     classroomIdeaAnnotations.add(workgroup4Ideas);
+    classroomIdeaAnnotations.add(workgroup5Ideas);
   }
 
   private String createIdeaString(boolean idea1Detected, boolean idea2Detected,
@@ -123,7 +126,7 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
     assertEquals(maxMembers, peerGroupMembers.size());
     Iterator<Workgroup> iterator = peerGroupMembers.iterator();
     assertEquals(1, iterator.next().getId().longValue());
-    assertEquals(3, iterator.next().getId().longValue());
+    assertEquals(5, iterator.next().getId().longValue());
     verify(annotationDao);
   }
 }

--- a/src/test/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImplTest.java
@@ -1,0 +1,126 @@
+package org.wise.portal.service.peergrouping.logic.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.dao.annotation.wise5.AnnotationDao;
+import org.wise.portal.domain.peergrouping.PeerGrouping;
+import org.wise.portal.domain.peergrouping.impl.PeerGroupingImpl;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.run.impl.RunImpl;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+
+@RunWith(EasyMockRunner.class)
+public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImplTest {
+
+  @TestSubject
+  private PeerGroupLogicServiceImpl service = new DifferentIdeasLogicServiceImpl();
+
+  @Mock
+  private AnnotationDao<Annotation> annotationDao;
+
+  List<Annotation> workgroup1IdeasOnly, classroomIdeaAnnotations;
+  private String componentId = "componentA";
+  List<Annotation> emptyAnnotations = new ArrayList<Annotation>();
+  private String nodeId = "node1";
+  PeerGrouping peerGrouping = new PeerGroupingImpl();
+  private Run run = new RunImpl();
+  Set<Workgroup> workgroupsNotInPeerGroup;
+  Annotation workgroup1Ideas, workgroup2Ideas, workgroup3Ideas, workgroup4Ideas;
+  String ideas1And2 = createIdeaString(true, true, false, false);
+  String ideas3 = createIdeaString(false, false, true, false);
+  String ideas3And4 = createIdeaString(false, false, true, true);
+  String ideas4 = createIdeaString(false, false, false, true);
+
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    peerGrouping.setRun(run);
+    peerGrouping.setLogic("differentIdeas(\"" + nodeId + "\", \"" + componentId + "\"");
+    workgroupsNotInPeerGroup = new HashSet<Workgroup>();
+    workgroupsNotInPeerGroup.add(workgroup1);
+    workgroupsNotInPeerGroup.add(workgroup2);
+    workgroupsNotInPeerGroup.add(workgroup3);
+    workgroupsNotInPeerGroup.add(workgroup4);
+    workgroup1Ideas = createIdeasAnnotation(workgroup1, ideas1And2);
+    workgroup2Ideas = createIdeasAnnotation(workgroup2, ideas3);
+    workgroup3Ideas = createIdeasAnnotation(workgroup3, ideas3And4);
+    workgroup4Ideas = createIdeasAnnotation(workgroup4, ideas4);
+    workgroup1IdeasOnly = new ArrayList<Annotation>();
+    workgroup1IdeasOnly.add(workgroup1Ideas);
+    classroomIdeaAnnotations = new ArrayList<Annotation>();
+    classroomIdeaAnnotations.add(workgroup1Ideas);
+    classroomIdeaAnnotations.add(workgroup2Ideas);
+    classroomIdeaAnnotations.add(workgroup3Ideas);
+    classroomIdeaAnnotations.add(workgroup4Ideas);
+  }
+
+  private String createIdeaString(boolean idea1Detected, boolean idea2Detected,
+      boolean idea3Detected, boolean idea4Detected) {
+    return "[{\"name\":\"1\",\"detected\":" + idea1Detected + "}," + "{\"name\":\"2\",\"detected\":"
+        + idea2Detected + "}," + "{\"name\":\"3\",\"detected\":" + idea3Detected + "},"
+        + "{\"name\":\"4\",\"detected\":" + idea4Detected + "}]";
+  }
+
+  private Annotation createIdeasAnnotation(Workgroup workgroup, String ideas) {
+    Annotation annotation = new Annotation();
+    annotation.setToWorkgroup(workgroup);
+    annotation.setPeriod(period1);
+    annotation.setType("autoScore");
+    annotation.setData("{\"ideas\":" + ideas + "}");
+    return annotation;
+  }
+
+  @Test
+  public void canCreatePeerGroup_WorkgroupHasNoIdeas_ReturnFalse() {
+    expect(annotationDao.getAnnotations(run, nodeId, componentId)).andReturn(emptyAnnotations);
+    replay(annotationDao);
+    assertFalse(service.canCreatePeerGroup(workgroup1, workgroupsNotInPeerGroup, peerGrouping));
+    verify(annotationDao);
+  }
+
+  @Test
+  public void canCreatePeerGroup_NotEnoughUnpairedMembersWithIdeas_ReturnFalse() {
+    expect(annotationDao.getAnnotations(run, nodeId, componentId)).andReturn(workgroup1IdeasOnly);
+    replay(annotationDao);
+    assertFalse(service.canCreatePeerGroup(workgroup1, workgroupsNotInPeerGroup, peerGrouping));
+    verify(annotationDao);
+  }
+
+  @Test
+  public void canCreatePeerGroup_EnoughUnpairedMembersWithIdeas_ReturnTrue() {
+    expect(annotationDao.getAnnotations(run, nodeId, componentId))
+        .andReturn(classroomIdeaAnnotations);
+    replay(annotationDao);
+    assertTrue(service.canCreatePeerGroup(workgroup1, workgroupsNotInPeerGroup, peerGrouping));
+    verify(annotationDao);
+  }
+
+  @Test
+  public void groupMembersUpToMaxMembership_MaximizeDifferentIdeas() {
+    expect(annotationDao.getAnnotations(run, nodeId, componentId))
+        .andReturn(classroomIdeaAnnotations);
+    replay(annotationDao);
+    int maxMembers = peerGrouping.getMaxMembershipCount();
+    Set<Workgroup> peerGroupMembers = service.groupMembersUpToMaxMembership(workgroup1,
+        peerGrouping, possibleMembers);
+    assertEquals(maxMembers, peerGroupMembers.size());
+    Iterator<Workgroup> iterator = peerGroupMembers.iterator();
+    assertEquals(1, iterator.next().getId().longValue());
+    assertEquals(3, iterator.next().getId().longValue());
+    verify(annotationDao);
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/logic/impl/DifferentIdeasLogicServiceImplTest.java
@@ -49,7 +49,8 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
   public void setup() throws Exception {
     super.setup();
     peerGrouping.setRun(run);
-    peerGrouping.setLogic("differentIdeas(\"" + nodeId + "\", \"" + componentId + "\"");
+    peerGrouping.setLogic("differentIdeas(\"" + nodeId + "\", \"" + componentId + "\")");
+    peerGrouping.setMaxMembershipCount(2);
     workgroupsNotInPeerGroup = new HashSet<Workgroup>();
     workgroupsNotInPeerGroup.add(workgroup1);
     workgroupsNotInPeerGroup.add(workgroup2);
@@ -86,7 +87,8 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
 
   @Test
   public void canCreatePeerGroup_WorkgroupHasNoIdeas_ReturnFalse() {
-    expect(annotationDao.getAnnotations(run, nodeId, componentId)).andReturn(emptyAnnotations);
+    expect(annotationDao.getAnnotationsByParams(null, run, run1Period1, null, null, nodeId,
+        componentId, null, null, null, "autoScore")).andReturn(emptyAnnotations);
     replay(annotationDao);
     assertFalse(service.canCreatePeerGroup(workgroup1, workgroupsNotInPeerGroup, peerGrouping));
     verify(annotationDao);
@@ -94,7 +96,8 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
 
   @Test
   public void canCreatePeerGroup_NotEnoughUnpairedMembersWithIdeas_ReturnFalse() {
-    expect(annotationDao.getAnnotations(run, nodeId, componentId)).andReturn(workgroup1IdeasOnly);
+    expect(annotationDao.getAnnotationsByParams(null, run, run1Period1, null, null, nodeId,
+        componentId, null, null, null, "autoScore")).andReturn(workgroup1IdeasOnly);
     replay(annotationDao);
     assertFalse(service.canCreatePeerGroup(workgroup1, workgroupsNotInPeerGroup, peerGrouping));
     verify(annotationDao);
@@ -102,8 +105,8 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
 
   @Test
   public void canCreatePeerGroup_EnoughUnpairedMembersWithIdeas_ReturnTrue() {
-    expect(annotationDao.getAnnotations(run, nodeId, componentId))
-        .andReturn(classroomIdeaAnnotations);
+    expect(annotationDao.getAnnotationsByParams(null, run, run1Period1, null, null, nodeId,
+        componentId, null, null, null, "autoScore")).andReturn(classroomIdeaAnnotations);
     replay(annotationDao);
     assertTrue(service.canCreatePeerGroup(workgroup1, workgroupsNotInPeerGroup, peerGrouping));
     verify(annotationDao);
@@ -111,8 +114,8 @@ public class DifferentIdeasLogicServiceImplTest extends PeerGroupLogicServiceImp
 
   @Test
   public void groupMembersUpToMaxMembership_MaximizeDifferentIdeas() {
-    expect(annotationDao.getAnnotations(run, nodeId, componentId))
-        .andReturn(classroomIdeaAnnotations);
+    expect(annotationDao.getAnnotationsByParams(null, run, run1Period1, null, null, nodeId,
+        componentId, null, null, null, "autoScore")).andReturn(classroomIdeaAnnotations);
     replay(annotationDao);
     int maxMembers = peerGrouping.getMaxMembershipCount();
     Set<Workgroup> peerGroupMembers = service.groupMembersUpToMaxMembership(workgroup1,

--- a/src/test/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImplTest.java
@@ -14,7 +14,7 @@ public class PeerGroupLogicServiceImplTest extends PeerGroupServiceTest {
   HashSet<Workgroup> members = new HashSet<Workgroup>();
   Group period1 = new PersistentGroup();
   HashSet<Workgroup> possibleMembers = new HashSet<Workgroup>();
-  Workgroup workgroup1, workgroup2, workgroup3, workgroup4;
+  Workgroup workgroup1, workgroup2, workgroup3, workgroup4, workgroup5;
 
   @Before
   public void setup() throws Exception {
@@ -23,10 +23,12 @@ public class PeerGroupLogicServiceImplTest extends PeerGroupServiceTest {
     workgroup2 = createWorkgroup(2L);
     workgroup3 = createWorkgroup(3L);
     workgroup4 = createWorkgroup(4L);
+    workgroup5 = createWorkgroup(5L);
     members.add(workgroup1);
     possibleMembers.add(workgroup2);
     possibleMembers.add(workgroup3);
     possibleMembers.add(workgroup4);
+    possibleMembers.add(workgroup5);
   }
 
   private Workgroup createWorkgroup(Long id) {

--- a/src/test/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/logic/impl/PeerGroupLogicServiceImplTest.java
@@ -1,0 +1,41 @@
+package org.wise.portal.service.peergrouping.logic.impl;
+
+import java.util.HashSet;
+
+import org.junit.Before;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.group.impl.PersistentGroup;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
+import org.wise.portal.service.peergroup.impl.PeerGroupServiceTest;
+
+public class PeerGroupLogicServiceImplTest extends PeerGroupServiceTest {
+
+  HashSet<Workgroup> members = new HashSet<Workgroup>();
+  Group period1 = new PersistentGroup();
+  HashSet<Workgroup> possibleMembers = new HashSet<Workgroup>();
+  Workgroup workgroup1, workgroup2, workgroup3, workgroup4;
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+    workgroup1 = createWorkgroup(1L);
+    workgroup2 = createWorkgroup(2L);
+    workgroup3 = createWorkgroup(3L);
+    workgroup4 = createWorkgroup(4L);
+    members.add(workgroup1);
+    possibleMembers.add(workgroup2);
+    possibleMembers.add(workgroup3);
+    possibleMembers.add(workgroup4);
+  }
+
+  private Workgroup createWorkgroup(Long id) {
+    Workgroup workgroup = new WorkgroupImpl();
+    workgroup.setId(id);
+    PersistentGroup group = new PersistentGroup();
+    group.setName(id.toString());
+    workgroup.setGroup(group);
+    workgroup.setPeriod(period1);
+    return workgroup;
+  }
+}

--- a/src/test/java/org/wise/portal/service/peergrouping/logic/impl/RandomLogicServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/peergrouping/logic/impl/RandomLogicServiceImplTest.java
@@ -1,0 +1,35 @@
+package org.wise.portal.service.peergrouping.logic.impl;
+
+import static org.junit.Assert.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.domain.workgroup.Workgroup;
+
+@RunWith(EasyMockRunner.class)
+public class RandomLogicServiceImplTest extends PeerGroupLogicServiceImplTest {
+
+  @TestSubject
+  private RandomLogicServiceImpl service = new RandomLogicServiceImpl();
+
+  @Test
+  public void canCreatePeerGroup_ReturnTrueIFFAtLeastTwoWorkgroupsInPeerGroup() {
+    assertEquals(true, service.canCreatePeerGroup(workgroup1, possibleMembers, randomPeerGrouping));
+    assertEquals(false,
+        service.canCreatePeerGroup(workgroup1, new HashSet<>(), randomPeerGrouping));
+  }
+
+  @Test
+  public void groupMembersUpToMaxMembership_AddMembersUpToMaxMembershipCount() {
+    int maxMembers = 2;
+    Set<Workgroup> peerGroupMembers = service.groupMembersUpToMaxMembership(workgroup1,
+        randomPeerGrouping, possibleMembers);
+    assertEquals(maxMembers, peerGroupMembers.size());
+    assertTrue(peerGroupMembers.contains(workgroup1));
+  }
+}


### PR DESCRIPTION
## Changes
- Add ```differentIdeas("nodeId", "componentId")``` term in PeerGrouping.logic that pairs students based on different ideas
- Refactor code

## Test Prep
1. Update database
   - ```alter table peer_groupings modify logic varchar(255) null;```
   - ```update peer_groupings set logic="manual" where logic = "[{\"name\":\"manual\"}]";```
2. Create a CRater component with detected ideas ("ComponentX"), e.g. "MusicalInstruments_Speed_score-ki_idea-ki_nonscor"
3. Add new PeerGrouping to unit content (via JSON editing), and set the logic's nodeId and componentId to point to ComponentX
```
"peerGroupings": [
...
  {
    "logic": "differentIdeas(\"NODE_ID\",\"COMPONENT_ID\")",
    "maxMembershipCount": 2,
    "name": "Different Idea",
    "tag": "dg0uytsun8"
  }
...
]
``` 
4. Create a new component that uses PeerGroup (e.g. PeerChat, Show Group Work) and choose the above "Different Idea" as its Grouping Logic

## Test DifferentIdeas Logic
- When the student gets to the new component, they should be paired into PeerGrouping with another workgroup if they have at least one different idea. The pairing should maximize different ideas if possible. 

```
Workgroup1: A, B, C
Workgroup2: A, B, C, D
Workgroup3: B, C, D, E
```
In this case, Workgroup1 should be paired with Workgroup3 since they have 2 different ideas.

## Test Random Logic
- Random logic should work as before. The related code has been refactored, but no new feature was added as far as this logic is concerned.

Closes #179