### PR TITLE
feat(PeerGroup): Add endpoint to get latest StudentWorkAnnotation for ReferenceComponent

### DIFF
--- a/src/main/java/org/wise/portal/dao/annotation/wise5/AnnotationDao.java
+++ b/src/main/java/org/wise/portal/dao/annotation/wise5/AnnotationDao.java
@@ -9,6 +9,7 @@ import org.wise.vle.domain.work.NotebookItem;
 import org.wise.vle.domain.work.StudentWork;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Hiroki Terashima
@@ -25,4 +26,7 @@ public interface AnnotationDao<T extends Annotation> extends SimpleDao<T> {
   List<Annotation> getAnnotations(Run run, String nodeId, String componentId);
 
   List<Annotation> getAnnotations(Run run, Group period, String nodeId, String componentId);
+
+  List<Annotation> getAnnotationsToWorkgroups(Set<Workgroup> workgroups, String nodeId,
+      String componentId);
 }

--- a/src/main/java/org/wise/portal/dao/annotation/wise5/impl/HibernateAnnotationDao.java
+++ b/src/main/java/org/wise/portal/dao/annotation/wise5/impl/HibernateAnnotationDao.java
@@ -2,6 +2,7 @@ package org.wise.portal.dao.annotation.wise5.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -24,9 +25,6 @@ import org.wise.vle.domain.annotation.wise5.Annotation;
 import org.wise.vle.domain.work.NotebookItem;
 import org.wise.vle.domain.work.StudentWork;
 
-/**
- * @author Hiroki Terashima
- */
 @Repository("wise5AnnotationDao")
 public class HibernateAnnotationDao extends AbstractHibernateDao<Annotation>
     implements AnnotationDao<Annotation> {
@@ -115,5 +113,21 @@ public class HibernateAnnotationDao extends AbstractHibernateDao<Annotation>
     cq.select(annotationRoot).where(predicates.toArray(new Predicate[predicates.size()]));
     TypedQuery<Annotation> query = entityManager.createQuery(cq);
     return (List<Annotation>) (Object) query.getResultList();
+  }
+
+  public List<Annotation> getAnnotationsToWorkgroups(Set<Workgroup> workgroups, String nodeId,
+      String componentId) {
+    Session session = this.getHibernateTemplate().getSessionFactory().getCurrentSession();
+    CriteriaBuilder cb = session.getCriteriaBuilder();
+    CriteriaQuery<Annotation> cq = cb.createQuery(Annotation.class);
+    Root<Annotation> annotationRoot = cq.from(Annotation.class);
+    List<Predicate> predicates = new ArrayList<Predicate>();
+    predicates.add(cb.in(annotationRoot.get("toWorkgroup")).value(workgroups));
+    predicates.add(cb.equal(annotationRoot.get("nodeId"), nodeId));
+    predicates.add(cb.equal(annotationRoot.get("componentId"), componentId));
+    cq.select(annotationRoot).where(predicates.toArray(new Predicate[predicates.size()]))
+        .orderBy(cb.asc(annotationRoot.get("serverSaveTime")));
+    TypedQuery<Annotation> query = entityManager.createQuery(cq);
+    return (List<Annotation>) query.getResultList();
   }
 }

--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
@@ -32,7 +32,6 @@ import lombok.Getter;
 /**
  * ProjectComponent defines activities that students work on, like MultipleChoice, OpenResponse,
  * etc.
- * @author Hiroki Terashima
  */
 public class ProjectComponent {
 
@@ -72,5 +71,9 @@ public class ProjectComponent {
 
   public JSONArray getJSONArray(String key) throws JSONException {
     return this.componentJSON.getJSONArray(key);
+  }
+
+  public JSONObject getJSONObject(String key) throws JSONException {
+    return this.componentJSON.getJSONObject(key);
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationController.java
@@ -27,14 +27,14 @@ import lombok.Getter;
 
 @RestController
 @Secured("ROLE_USER")
-@RequestMapping("/api/peer-group/{peerGroupId}/{nodeId}/{componentId}/student-work-annotation")
+@RequestMapping("/api/peer-group/{peerGroupId}/{nodeId}/{componentId}/student-data")
 public class PeerGroupStudentWorkAnnotationController extends AbstractPeerGroupWorkController {
 
   @Autowired
   private AnnotationService annotationService;
 
-  @GetMapping("/dynamic-prompt/reference-component/latest-auto-score")
-  List<StudentWorkAnnotation> getListWithLatestAutoScoreForDynamicPromptReferenceComponent(
+  @GetMapping("/dynamic-prompt")
+  List<StudentWorkAnnotation> getStudentDataForDynamicPrompt(
       @PathVariable("peerGroupId") PeerGroupImpl peerGroup, @PathVariable String nodeId,
       @PathVariable String componentId, Authentication auth) throws Exception {
     if (isUserInPeerGroup(auth, peerGroup)) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationController.java
@@ -1,0 +1,72 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
+import org.wise.portal.domain.project.impl.ProjectComponent;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.presentation.web.controllers.student.AbstractPeerGroupWorkController;
+import org.wise.portal.service.vle.wise5.AnnotationService;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+import org.wise.vle.domain.work.StudentWorkAnnotation;
+
+import lombok.Getter;
+
+@RestController
+@Secured("ROLE_USER")
+@RequestMapping("/api/peer-group/{peerGroupId}/{nodeId}/{componentId}/student-work-annotation")
+public class PeerGroupStudentWorkAnnotationController extends AbstractPeerGroupWorkController {
+
+  @Autowired
+  private AnnotationService annotationService;
+
+  @GetMapping("/dynamic-prompt/reference-component/latest-auto-score")
+  List<StudentWorkAnnotation> getListWithLatestAutoScoreForDynamicPromptReferenceComponent(
+      @PathVariable("peerGroupId") PeerGroupImpl peerGroup, @PathVariable String nodeId,
+      @PathVariable String componentId, Authentication auth) throws Exception {
+    if (isUserInPeerGroup(auth, peerGroup)) {
+      DynamicPrompt dynamicPrompt = getDynamicPrompt(peerGroup.getPeerGrouping().getRun(), nodeId,
+          componentId);
+      List<Annotation> annotations = annotationService.getLatest(peerGroup.getMembers(),
+          dynamicPrompt.getReferenceNodeId(), dynamicPrompt.getReferenceComponentId(), "autoScore");
+      return annotations.stream().map(annotation -> new StudentWorkAnnotation(annotation))
+          .collect(Collectors.toList());
+    } else {
+      throw new AccessDeniedException("Not permitted");
+    }
+  }
+
+  private DynamicPrompt getDynamicPrompt(Run run, String nodeId, String componentId)
+      throws IOException, JSONException, ObjectNotFoundException {
+    ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
+    JSONObject dynamicPromptJSON = projectComponent.getJSONObject("dynamicPrompt");
+    return new DynamicPrompt(dynamicPromptJSON);
+  }
+}
+
+@Getter
+class DynamicPrompt {
+  String peerGroupingTag;
+  String referenceComponentId;
+  String referenceNodeId;
+
+  public DynamicPrompt(JSONObject content) throws JSONException {
+    this.peerGroupingTag = content.getString("peerGroupingTag");
+    JSONObject referenceComponentJSON = content.getJSONObject("referenceComponent");
+    this.referenceNodeId = referenceComponentJSON.getString("nodeId");
+    this.referenceComponentId = referenceComponentJSON.getString("componentId");
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/AbstractPeerGroupWorkController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/AbstractPeerGroupWorkController.java
@@ -1,0 +1,20 @@
+package org.wise.portal.presentation.web.controllers.student;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.peergroup.PeerGroup;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.service.vle.wise5.StudentWorkService;
+
+public abstract class AbstractPeerGroupWorkController extends ClassmateDataController {
+
+  @Autowired
+  protected StudentWorkService studentWorkService;
+
+  protected boolean isUserInPeerGroup(Authentication auth, PeerGroup peerGroup)
+      throws ObjectNotFoundException {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    return peerGroup.isMember(user);
+  }
+}

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/PeerGroupWorkController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/PeerGroupWorkController.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.json.JSONException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.Authentication;
@@ -13,31 +12,24 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.wise.portal.dao.ObjectNotFoundException;
-import org.wise.portal.domain.authentication.impl.StudentUserDetails;
-import org.wise.portal.domain.peergroup.PeerGroup;
 import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.project.impl.ProjectComponent;
 import org.wise.portal.domain.run.Run;
-import org.wise.portal.domain.user.User;
-import org.wise.portal.service.vle.wise5.StudentWorkService;
 import org.wise.vle.domain.work.StudentWork;
 
 @RestController
 @Secured("ROLE_STUDENT")
 @RequestMapping("/api/classmate/peer-group-work")
-public class PeerGroupWorkController extends ClassmateDataController {
+public class PeerGroupWorkController extends AbstractPeerGroupWorkController {
 
   String SHOW_PEER_GROUP_WORK_TYPE = "ShowGroupWork";
-
-  @Autowired
-  protected StudentWorkService studentWorkService;
 
   @GetMapping("{peerGroupId}/{showPeerGroupWorkNodeId}/{showPeerGroupWorkComponentId}/{showWorkNodeId}/{showWorkComponentId}")
   public List<StudentWork> getPeerGroupWork(Authentication auth,
       @PathVariable("peerGroupId") PeerGroupImpl peerGroup,
       @PathVariable String showPeerGroupWorkNodeId,
-      @PathVariable String showPeerGroupWorkComponentId,
-      @PathVariable String showWorkNodeId, @PathVariable String showWorkComponentId)
+      @PathVariable String showPeerGroupWorkComponentId, @PathVariable String showWorkNodeId,
+      @PathVariable String showWorkComponentId)
       throws ObjectNotFoundException, JSONException, IOException {
     if (isUserInPeerGroup(auth, peerGroup)) {
       Run run = peerGroup.getPeerGrouping().getRun();
@@ -50,14 +42,9 @@ public class PeerGroupWorkController extends ClassmateDataController {
     throw new AccessDeniedException(NOT_PERMITTED);
   }
 
-  private boolean isUserInPeerGroup(Authentication auth, PeerGroup peerGroup)
-      throws ObjectNotFoundException {
-    User user = userService.retrieveUser((StudentUserDetails) auth.getPrincipal());
-    return peerGroup.isMember(user);
-  }
-
   private boolean isValidShowPeerGroupWorkComponent(Run run, String nodeId, String componentId,
-      String showWorkNodeId, String showWorkComponentId) throws JSONException, IOException, ObjectNotFoundException {
+      String showWorkNodeId, String showWorkComponentId)
+      throws JSONException, IOException, ObjectNotFoundException {
     ProjectComponent projectComponent = getProjectComponent(run, nodeId, componentId);
     return projectComponent.getString("type").equals(SHOW_PEER_GROUP_WORK_TYPE)
         && projectComponent.getString("showWorkNodeId").equals(showWorkNodeId)

--- a/src/main/java/org/wise/portal/service/vle/wise5/AnnotationService.java
+++ b/src/main/java/org/wise/portal/service/vle/wise5/AnnotationService.java
@@ -1,0 +1,16 @@
+package org.wise.portal.service.vle.wise5;
+
+import java.util.List;
+import java.util.Set;
+
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+
+public interface AnnotationService {
+
+  /**
+   * Get latest annotations of a certain type on a component for a set of workgroups
+   */
+  List<Annotation> getLatest(Set<Workgroup> workgroups, String nodeId, String componentId,
+      String type);
+}

--- a/src/main/java/org/wise/portal/service/vle/wise5/impl/AnnotationServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/vle/wise5/impl/AnnotationServiceImpl.java
@@ -1,0 +1,34 @@
+package org.wise.portal.service.vle.wise5.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.wise.portal.dao.annotation.wise5.AnnotationDao;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.vle.wise5.AnnotationService;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+
+@Service
+public class AnnotationServiceImpl implements AnnotationService {
+
+  @Autowired
+  private AnnotationDao<Annotation> annotationDao;
+
+  @Override
+  public List<Annotation> getLatest(Set<Workgroup> workgroups, String nodeId, String componentId,
+      String type) {
+    List<Annotation> annotations = annotationDao.getAnnotationsToWorkgroups(workgroups, nodeId,
+        componentId);
+    HashMap<Long, Annotation> workgroupToAnnotation = new HashMap<Long, Annotation>();
+    for (Annotation annotation : annotations) {
+      if (annotation.getType().equals(type)) {
+        workgroupToAnnotation.put(annotation.getToWorkgroup().getId(), annotation);
+      }
+    }
+    return new ArrayList<Annotation>(workgroupToAnnotation.values());
+  }
+}

--- a/src/main/java/org/wise/vle/domain/work/StudentWorkAnnotation.java
+++ b/src/main/java/org/wise/vle/domain/work/StudentWorkAnnotation.java
@@ -1,0 +1,22 @@
+package org.wise.vle.domain.work;
+
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudentWorkAnnotation {
+
+  private Annotation annotation;
+  private StudentWork studentWork;
+  private Workgroup workgroup;
+
+  public StudentWorkAnnotation(Annotation annotation) {
+    this.annotation = annotation;
+    this.studentWork = annotation.getStudentWork();
+    this.workgroup = annotation.getToWorkgroup();
+  }
+}

--- a/src/test/java/org/wise/portal/dao/annotation/impl/HibernateAnnotationDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/annotation/impl/HibernateAnnotationDaoTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,6 +56,22 @@ public class HibernateAnnotationDaoTest extends WISEHibernateTest {
     assertTrue(annotations.contains(annotation2));
   }
 
+  @Test
+  public void getAnnotationsToWorkgroup_ShouldReturnAnnotations() {
+    Annotation annotation1 = createAnnotation(run1, run1Period1, teacherWorkgroup1, workgroup1,
+        COMMENT_TYPE, NODE_ID1, COMPONENT_ID1, DUMMY_ANNOTATION_DATA);
+    Annotation annotation2 = createAnnotation(run1, run1Period1, teacherWorkgroup1, workgroup2,
+        COMMENT_TYPE, NODE_ID1, COMPONENT_ID1, DUMMY_ANNOTATION_DATA);
+    Set<Workgroup> workgroups = new HashSet<Workgroup>();
+    workgroups.add(workgroup1);
+    workgroups.add(workgroup2);
+    List<Annotation> annotations = annotationDao.getAnnotationsToWorkgroups(workgroups, NODE_ID1,
+        COMPONENT_ID1);
+    assertEquals(2, annotations.size());
+    assertTrue(annotations.contains(annotation1));
+    assertTrue(annotations.contains(annotation2));
+  }
+
   private void createAndRetrieveAnnotations(String createAnnotationNodeId,
       String createAnnotationComponentId, String retrieveAnnotationNodeId,
       String retrieveAnnotationComponentId, Integer expectedCount) {
@@ -82,5 +100,4 @@ public class HibernateAnnotationDaoTest extends WISEHibernateTest {
     annotationDao.save(annotation);
     return annotation;
   }
-
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/APIControllerTest.java
@@ -95,8 +95,9 @@ public abstract class APIControllerTest {
   protected Long workgroup3Id = 3L;
 
   protected String run1Node1Id = "run1Node1";
-
+  protected String run1Node2Id = "run1Node2";
   protected String run1Component1Id = "run1Component1";
+  protected String run1Component2Id = "run1Component2";
 
   @Mock
   protected Environment appProperties;

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupAPIControllerTest.java
@@ -12,14 +12,15 @@ import org.wise.portal.domain.peergroup.impl.PeerGroupImpl;
 import org.wise.portal.domain.peergrouping.PeerGrouping;
 import org.wise.portal.domain.peergrouping.impl.PeerGroupingImpl;
 import org.wise.portal.domain.workgroup.Workgroup;
-import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.presentation.web.controllers.student.AbstractClassmateDataControllerTest;
 import org.wise.portal.service.peergroup.PeerGroupCreationException;
 import org.wise.portal.service.peergroup.PeerGroupInfoService;
 import org.wise.portal.service.peergroup.PeerGroupService;
 import org.wise.portal.service.peergrouping.PeerGroupingNotFoundException;
 import org.wise.portal.service.peergrouping.PeerGroupingService;
 
-public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTest {
+public abstract class AbstractPeerGroupAPIControllerTest
+    extends AbstractClassmateDataControllerTest {
 
   @Mock
   protected PeerGroupService peerGroupService;
@@ -70,8 +71,7 @@ public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTe
   }
 
   protected void expectPeerGroupingByTagFound() {
-    expect(peerGroupingService.getByTag(run1, peerGrouping1Tag))
-        .andReturn(peerGrouping);
+    expect(peerGroupingService.getByTag(run1, peerGrouping1Tag)).andReturn(peerGrouping);
   }
 
   protected void expectPeerGroupCreationException() throws Exception {
@@ -79,17 +79,25 @@ public abstract class AbstractPeerGroupAPIControllerTest extends APIControllerTe
         .andThrow(new PeerGroupCreationException());
   }
 
+  protected void expectUserNotInPeerGroup() {
+    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student2);
+  }
+
+  protected void expectUserInPeerGroup() {
+    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student1);
+  }
+
   protected void expectUserHasRunWritePermission(boolean hasPermission) {
     expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(hasPermission);
   }
 
   protected void verifyAll() {
-    verify(peerGroupingService, peerGroupInfoService, peerGroupService, runService,
-       userService, workgroupService);
+    verify(peerGroupingService, peerGroupInfoService, peerGroupService, projectService, runService,
+        userService, workgroupService);
   }
 
   protected void replayAll() {
-    replay(peerGroupingService, peerGroupInfoService, peerGroupService, runService,
+    replay(peerGroupingService, peerGroupInfoService, peerGroupService, projectService, runService,
         userService, workgroupService);
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupWorkControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/AbstractPeerGroupWorkControllerTest.java
@@ -1,0 +1,25 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import static org.easymock.EasyMock.*;
+
+import org.easymock.Mock;
+import org.wise.portal.service.vle.wise5.StudentWorkService;
+
+public abstract class AbstractPeerGroupWorkControllerTest
+    extends AbstractPeerGroupAPIControllerTest {
+
+  @Mock
+  protected StudentWorkService studentWorkService;
+
+  @Override
+  protected void replayAll() {
+    super.replayAll();
+    replay(studentWorkService);
+  }
+
+  @Override
+  protected void verifyAll() {
+    super.verifyAll();
+    verify(studentWorkService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationControllerTest.java
@@ -34,8 +34,8 @@ public class PeerGroupStudentWorkAnnotationControllerTest
     expectUserNotInPeerGroup();
     replayAll();
     try {
-      controller.getListWithLatestAutoScoreForDynamicPromptReferenceComponent(peerGroup1,
-          run1Node2Id, run1Component2Id, studentAuth);
+      controller.getStudentDataForDynamicPrompt(peerGroup1, run1Node2Id, run1Component2Id,
+          studentAuth);
       fail("Expected AccessDeniedException, but was not thrown");
     } catch (AccessDeniedException e) {
     } catch (Exception e) {
@@ -51,8 +51,8 @@ public class PeerGroupStudentWorkAnnotationControllerTest
     expectInvalidDynamicPromptContent();
     replayAll();
     try {
-      controller.getListWithLatestAutoScoreForDynamicPromptReferenceComponent(peerGroup1,
-          run1Node2Id, run1Component2Id, studentAuth);
+      controller.getStudentDataForDynamicPrompt(peerGroup1, run1Node2Id, run1Component2Id,
+          studentAuth);
       fail("Expected Exception, but was not thrown");
     } catch (Exception e) {
     }
@@ -75,8 +75,7 @@ public class PeerGroupStudentWorkAnnotationControllerTest
         .andReturn(Arrays.asList(createAnnotation(workgroup1), createAnnotation(workgroup2)));
     replayAll();
     List<StudentWorkAnnotation> studentWorkAnnotation = controller
-        .getListWithLatestAutoScoreForDynamicPromptReferenceComponent(peerGroup1, run1Node2Id,
-            run1Component2Id, studentAuth);
+        .getStudentDataForDynamicPrompt(peerGroup1, run1Node2Id, run1Component2Id, studentAuth);
     assertEquals(2, studentWorkAnnotation.size());
     assertEquals(workgroup1, studentWorkAnnotation.get(0).getWorkgroup());
     assertEquals(workgroup2, studentWorkAnnotation.get(1).getWorkgroup());

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationControllerTest.java
@@ -1,0 +1,113 @@
+package org.wise.portal.presentation.web.controllers.peergroup;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.security.access.AccessDeniedException;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.vle.wise5.AnnotationService;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+import org.wise.vle.domain.work.StudentWork;
+import org.wise.vle.domain.work.StudentWorkAnnotation;
+
+@RunWith(EasyMockRunner.class)
+public class PeerGroupStudentWorkAnnotationControllerTest
+    extends AbstractPeerGroupWorkControllerTest {
+
+  @TestSubject
+  private PeerGroupStudentWorkAnnotationController controller = new PeerGroupStudentWorkAnnotationController();
+
+  @Mock
+  private AnnotationService annotationService;
+
+  @Test
+  public void getListForDynamicPromptReferenceComponent_UserNotInPeerGroup_AccessDenied() {
+    expectUserNotInPeerGroup();
+    replayAll();
+    try {
+      controller.getListWithLatestAutoScoreForDynamicPromptReferenceComponent(peerGroup1,
+          run1Node2Id, run1Component2Id, studentAuth);
+      fail("Expected AccessDeniedException, but was not thrown");
+    } catch (AccessDeniedException e) {
+    } catch (Exception e) {
+      fail("Expected AccessDeniedException, but was not thrown");
+    }
+    verifyAll();
+  }
+
+  @Test
+  public void getListForDynamicPromptReferenceComponent_InvalidDynamicPromptContent_Exception()
+      throws IOException {
+    expectUserInPeerGroup();
+    expectInvalidDynamicPromptContent();
+    replayAll();
+    try {
+      controller.getListWithLatestAutoScoreForDynamicPromptReferenceComponent(peerGroup1,
+          run1Node2Id, run1Component2Id, studentAuth);
+      fail("Expected Exception, but was not thrown");
+    } catch (Exception e) {
+    }
+    verifyAll();
+  }
+
+  private void expectInvalidDynamicPromptContent() throws IOException {
+    String project_sans_reference_component = "{\"nodes\": [{\"id\": \"" + run1Node2Id
+        + "\",\"type\": \"node\"," + "\"components\": [{\"id\": \"" + run1Component2Id + "\"}]}]}";
+    expect(projectService.getProjectContent(project1)).andReturn(project_sans_reference_component);
+  }
+
+  @Test
+  public void getListForDynamicPromptReferenceComponent_ReturnReferenceComponentWork()
+      throws Exception {
+    expectUserInPeerGroup();
+    expectValidDynamicPromptContent();
+    expect(annotationService.getLatest(peerGroup1.getMembers(), run1Node1Id, run1Component1Id,
+        "autoScore"))
+        .andReturn(Arrays.asList(createAnnotation(workgroup1), createAnnotation(workgroup2)));
+    replayAll();
+    List<StudentWorkAnnotation> studentWorkAnnotation = controller
+        .getListWithLatestAutoScoreForDynamicPromptReferenceComponent(peerGroup1, run1Node2Id,
+            run1Component2Id, studentAuth);
+    assertEquals(2, studentWorkAnnotation.size());
+    assertEquals(workgroup1, studentWorkAnnotation.get(0).getWorkgroup());
+    assertEquals(workgroup2, studentWorkAnnotation.get(1).getWorkgroup());
+    verifyAll();
+  }
+
+  private void expectValidDynamicPromptContent() throws IOException {
+    String project_with_reference_component = "{\"nodes\": [{\"id\": \"" + run1Node2Id
+        + "\",\"type\": \"node\"," + "\"components\": [{\"id\": \"" + run1Component2Id
+        + "\",\"dynamicPrompt\":{\"peerGroupingTag\":\"" + peerGrouping1Tag
+        + "\", \"referenceComponent\": {\"nodeId\":\"" + run1Node1Id + "\",\"componentId\":\""
+        + run1Component1Id + "\"}}}]}]}";
+    expect(projectService.getProjectContent(project1)).andReturn(project_with_reference_component);
+  }
+
+  private Annotation createAnnotation(Workgroup workgroup) {
+    Annotation annotation = new Annotation();
+    annotation.setToWorkgroup(workgroup);
+    annotation.setStudentWork(new StudentWork());
+    return annotation;
+  }
+
+  @Override
+  public void replayAll() {
+    super.replayAll();
+    replay(annotationService);
+  }
+
+  @Override
+  public void verifyAll() {
+    super.verifyAll();
+    verify(annotationService);
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupWorkAPIControllerTest.java
@@ -31,7 +31,7 @@ public class PeerGroupWorkAPIControllerTest extends AbstractPeerGroupAPIControll
     expectUserNotInPeerGroup();
     replayAll();
     try {
-      controller.getPeerGroupWork(peerGroup1, run1Node1Id, run1Component1Id,  studentAuth);
+      controller.getPeerGroupWork(peerGroup1, run1Node1Id, run1Component1Id, studentAuth);
       fail("Expected AccessDeniedException, but was not thrown");
     } catch (AccessDeniedException e) {
     }
@@ -44,8 +44,8 @@ public class PeerGroupWorkAPIControllerTest extends AbstractPeerGroupAPIControll
     expectUserInPeerGroup();
     expectGetStudentWork();
     replayAll();
-    assertNotNull(controller.getPeerGroupWork(peerGroup1,  run1Node1Id, run1Component1Id,
-        studentAuth));
+    assertNotNull(
+        controller.getPeerGroupWork(peerGroup1, run1Node1Id, run1Component1Id, studentAuth));
     verifyAll();
   }
 
@@ -70,10 +70,10 @@ public class PeerGroupWorkAPIControllerTest extends AbstractPeerGroupAPIControll
     expectPeerGroupingNotFound();
     replayAll();
     try {
-      controller.getPeerGroupWork(run1, workgroup1, run1Node1Id, run1Component1Id,
-          teacherAuth);
+      controller.getPeerGroupWork(run1, workgroup1, run1Node1Id, run1Component1Id, teacherAuth);
       fail("PeerGroupingNotFoundException expected, but was not thrown");
-    } catch (PeerGroupingNotFoundException e) {}
+    } catch (PeerGroupingNotFoundException e) {
+    }
     verifyAll();
   }
 
@@ -85,10 +85,10 @@ public class PeerGroupWorkAPIControllerTest extends AbstractPeerGroupAPIControll
     expectPeerGroupCreationException();
     replayAll();
     try {
-      controller.getPeerGroupWork(run1, workgroup1, run1Node1Id, run1Component1Id,
-          teacherAuth);
+      controller.getPeerGroupWork(run1, workgroup1, run1Node1Id, run1Component1Id, teacherAuth);
       fail("PeerGroupCreationException expected, but was not thrown");
-    } catch (PeerGroupCreationException e) {}
+    } catch (PeerGroupCreationException e) {
+    }
     verifyAll();
   }
 
@@ -100,14 +100,14 @@ public class PeerGroupWorkAPIControllerTest extends AbstractPeerGroupAPIControll
     expectPeerGroupFound();
     expectGetStudentWork();
     replayAll();
-    assertNotNull(controller.getPeerGroupWork(run1, workgroup1, run1Node1Id, run1Component1Id,
-        teacherAuth));
+    assertNotNull(
+        controller.getPeerGroupWork(run1, workgroup1, run1Node1Id, run1Component1Id, teacherAuth));
     verifyAll();
   }
 
   private void expectRetrieveTeacherUser() {
-    expect(userService.retrieveUserByUsername(teacher1UserDetails.getUsername())).andReturn(
-        teacher1);
+    expect(userService.retrieveUserByUsername(teacher1UserDetails.getUsername()))
+        .andReturn(teacher1);
   }
 
   private void expectPeerGroupFound() throws Exception {
@@ -126,13 +126,5 @@ public class PeerGroupWorkAPIControllerTest extends AbstractPeerGroupAPIControll
   private void expectGetStudentWork() {
     expect(peerGroupService.getStudentWork(peerGroup1, run1Node1Id, run1Component1Id))
         .andReturn(peerGroup1StudentWork);
-  }
-
-  private void expectUserNotInPeerGroup() {
-    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student2);
-  }
-
-  private void expectUserInPeerGroup() {
-    expect(userService.retrieveUserByUsername(studentAuth.getName())).andReturn(student1);
   }
 }

--- a/src/test/java/org/wise/portal/service/vle/wise5/impl/AnnotationServiceImplTest.java
+++ b/src/test/java/org/wise/portal/service/vle/wise5/impl/AnnotationServiceImplTest.java
@@ -1,0 +1,58 @@
+package org.wise.portal.service.vle.wise5.impl;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.dao.annotation.wise5.AnnotationDao;
+import org.wise.portal.domain.workgroup.Workgroup;
+import org.wise.portal.service.WISEServiceTest;
+import org.wise.vle.domain.annotation.wise5.Annotation;
+
+@RunWith(EasyMockRunner.class)
+public class AnnotationServiceImplTest extends WISEServiceTest {
+
+  @TestSubject
+  private AnnotationServiceImpl service = new AnnotationServiceImpl();
+
+  @Mock
+  private AnnotationDao<Annotation> annotationDao;
+
+  @Test
+  public void getLatest_ReturnLatestAnnotations() {
+    Annotation annotation1 = createAutoScoreAnnotation(run1Workgroup1, run1Node1Id,
+        run1Component1Id);
+    Annotation annotation2 = createAutoScoreAnnotation(run1Workgroup2, run1Node1Id,
+        run1Component1Id);
+    Annotation annotation3 = createAutoScoreAnnotation(run1Workgroup1, run1Node1Id,
+        run1Component1Id);
+    HashSet<Workgroup> workgroups = new HashSet<Workgroup>();
+    workgroups.add(run1Workgroup1);
+    workgroups.add(run1Workgroup2);
+    expect(annotationDao.getAnnotationsToWorkgroups(workgroups, run1Node1Id, run1Component1Id))
+        .andReturn(Arrays.asList(annotation1, annotation2, annotation3));
+    replay(annotationDao);
+    assertEquals(2,
+        service.getLatest(workgroups, run1Node1Id, run1Component1Id, "autoScore").size());
+    verify(annotationDao);
+  }
+
+  private Annotation createAutoScoreAnnotation(Workgroup toWorkgroup, String nodeId,
+      String componentId) {
+    Annotation annotation = new Annotation();
+    annotation.setToWorkgroup(toWorkgroup);
+    annotation.setNodeId(nodeId);
+    annotation.setComponentId(componentId);
+    annotation.setType("autoScore");
+    return annotation;
+  }
+}


### PR DESCRIPTION
## Changes
- Add new GET endpoint: ```/api/peer-group/{peerGroupId}/{nodeId}/{componentId}/student-data/dynamic-prompt```
   - Given the PeerGroupId, NodeId, and ComponentId, this endpoint returns latest list of **StudentWorkAnnotations** of the PeerGroup members for the the DynamicPrompt's ReferenceComponent that is authored in the NodeId/ComponentId content.
   - **StudentWorkAnnotation** is a composite object consisting of:
      - Workgroup: workgroup that did the work
      - StudentWork: work by workgroup
      - Annotation: annotation for the StudentWork 
- Define new AbstractPeerGroupWorkController that is common to PeerGroupWorkController and PeerGroupStudentWorkAnnotationController

## Test
1. Make a GET request to the endpoint, and specify the following for each param:
   - peerGroupId: PeerGroupId for a component (e.g. PeerChat) that has DynamicPromptReferenceComponent
   - nodeId: NodeID containing DynamicPromptReferenceComponent
   - componentId: ComponentId containing DynamicPromptReferenceComponent
    
This should return a list of **StudentWorkAnnotation**, one for each member of the PeerGroup.

2. Test the endpoint with a PeerGroupId that you are not in. It should return AccessDenied page.

3. Test the endpoint with non-existing nodeId/componentId. It should should return an error page.

4. Show group work works as before. No feature was added, just refactoring (see "Changes" section above)

Closes #181