### PR TITLE
fix(Authoring): Check real mime type when author uploads a file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,16 @@
       <artifactId>google-api-services-classroom</artifactId>
       <version>v1-rev274-1.22.0</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>2.5.0</version>
+    </dependency>
   </dependencies>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/ProjectAssetAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/ProjectAssetAPIController.java
@@ -121,20 +121,20 @@ public class ProjectAssetAPIController {
       allowedTypes += ","
           + appProperties.getProperty("trustedAuthorAllowedProjectAssetContentTypes");
     }
-    return allowedTypes.contains(getRealMimeType(file));
+    try {
+      return allowedTypes.contains(getRealMimeType(file));
+    } catch (IOException e) {
+      return false;
+    }
   }
 
-  public String getRealMimeType(MultipartFile file) {
+  private String getRealMimeType(MultipartFile file) throws IOException {
     AutoDetectParser parser = new AutoDetectParser();
     Detector detector = parser.getDetector();
-    try {
-      Metadata metadata = new Metadata();
-      TikaInputStream stream = TikaInputStream.get(file.getInputStream());
-      org.apache.tika.mime.MediaType mediaType = detector.detect(stream, metadata);
-      return mediaType.toString();
-    } catch (IOException e) {
-      return MimeTypes.OCTET_STREAM;
-    }
+    Metadata metadata = new Metadata();
+    TikaInputStream stream = TikaInputStream.get(file.getInputStream());
+    org.apache.tika.mime.MediaType mediaType = detector.detect(stream, metadata);
+    return mediaType.toString();
   }
 
   @PostMapping("/{projectId}/delete")


### PR DESCRIPTION
## Changes

Check a file's real MIME type when an author uploads a file to the File Manager.

## Test

1. Download the Burp Suite Community Edition (no need to enter email, just click "Go straight to downloads")
https://portswigger.net/burp/communitydownload

2. Install Burp Suite Community Edition

3. Launch Burp Suite Community Edition

4. Leave "Temporary project" selected
    - Click "Next"

5. Use Burp defaults
    - Click "Start Burp"

6. Configure the proxy
    - Click Proxy tab
    - Click Options tab
    - Under Proxy Listeners, highlight the 127.0.0.1:8080 line
    - Click "Edit"
    - Change port from 8080 to 8081

7. Launch the browser
    - Click Intercept tab
    - Click "Open browser"

8. Upload a file that should not be allowed
    - In the Burp browser go to localhost:81
    - Log in as a teacher
    - Open a unit in the Authoring Tool
    - Go to the File Manager view
    - Go back to the Burp application and click "Intercept is off" to turn intercept on
    - Go back to the Burp browser and drag and drop a php file into the File Manager
    - Go back to the Burp application and it should have intercepted the upload request
    - Change
        - Content-Type: application/octet-stream
        - to
        - Content-Type: image/jpeg
    - Click "Forward" button at the top left
    - The file should be rejected. Previously the file would be accepted.

Closes #186