### PR TITLE
feat(Authoring): Run virus scanner on asset upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,11 @@
       <artifactId>tika-core</artifactId>
       <version>2.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>xyz.capybara</groupId>
+      <artifactId>clamav-client</artifactId>
+      <version>2.1.2</version>
+    </dependency>
   </dependencies>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/beforeInstall.sh
+++ b/scripts/beforeInstall.sh
@@ -141,3 +141,19 @@ echo "Set log file max size to 1G"
 sed 's/{/{\n        maxsize 1G/g' -i /etc/logrotate.d/rsyslog
 sed 's/{/{\n        maxsize 1G/g' -i /etc/logrotate.d/nginx
 sed 's/{/{\n  maxsize 1G/g' -i /etc/logrotate.d/tomcat9
+
+echo "Installing Clam AV"
+apt-get install clamav clamav-daemon -y
+systemctl stop clamav-freshclam
+
+echo "Updating Clam AV database"
+freshclam
+
+echo "Updating Clam AV configuration"
+echo -e "TCPSocket 3310\nTCPAddr 127.0.0.1" | tee -a /etc/clamav/clamd.conf
+
+echo "Starting Clam AV"
+systemctl enable clamav-freshclam
+systemctl start clamav-freshclam
+systemctl enable clamav-daemon
+systemctl start clamav-daemon

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/ProjectAssetAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/ProjectAssetAPIController.java
@@ -137,13 +137,14 @@ public class ProjectAssetAPIController {
   }
 
   private boolean isScanOk(ClamavClient clamavClient, MultipartFile file) throws IOException {
-    boolean result = false;
     try {
-      result = clamavClient.scan(file.getInputStream()) instanceof ScanResult.OK;
+      return clamavClient.scan(file.getInputStream()) instanceof ScanResult.OK;
     } catch (ClamavException e) {
       e.printStackTrace();
+      // There was an exception which could be caused by not being able to connect to the Clam AV
+      // server so we will say the scan is OK to prevent blocking the author from uploading
+      return true;
     }
-    return result;
   }
 
   private boolean isUserAllowedToUpload(User user, MultipartFile file) {
@@ -167,7 +168,7 @@ public class ProjectAssetAPIController {
       projectMaxTotalAssetsSize = Long
           .parseLong(appProperties.getProperty("project_max_total_assets_size", "15728640"));
     }
-    return sizeOfAssetsDirectory + file.getSize() > projectMaxTotalAssetsSize;
+    return sizeOfAssetsDirectory + file.getSize() < projectMaxTotalAssetsSize;
   }
 
   private String getRealMimeType(MultipartFile file) throws IOException {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/ProjectAssetAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/ProjectAssetAPIController.java
@@ -15,7 +15,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.mime.MimeTypes;
 import org.apache.tika.parser.AutoDetectParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -38,6 +37,10 @@ import org.wise.portal.service.project.ProjectService;
 import org.wise.portal.service.user.UserService;
 import org.wise.vle.utils.FileManager;
 
+import xyz.capybara.clamav.ClamavClient;
+import xyz.capybara.clamav.ClamavException;
+import xyz.capybara.clamav.commands.scan.result.ScanResult;
+
 /**
  * Project Asset API endpoint
  *
@@ -57,6 +60,11 @@ public class ProjectAssetAPIController {
 
   @Autowired
   protected Environment appProperties;
+
+  private String CLAMAV_ADDRESS = "127.0.0.1";
+  private String EXCEEDED_MAX_PROJECT_SIZE_MESSAGE = "Exceeded project max asset size.\n"
+      + "Please delete unused assets.\n\nContact WISE if your project needs more disk space.";
+  private String UPLOADING_THIS_FILE_NOT_ALLOWED_MESSAGE = "Uploading this file is not allowed.";
 
   @GetMapping("/{projectId}")
   @ResponseBody
@@ -82,8 +90,9 @@ public class ProjectAssetAPIController {
       result.put("error", new ArrayList<Object>());
       String projectAssetsDirPath = getProjectAssetsDirectoryPath(project);
       File projectAssetsDir = new File(projectAssetsDirPath);
+      ClamavClient clamavClient = getClamavClient();
       for (MultipartFile file : files) {
-        addAsset(project, projectAssetsDir, file, user, result);
+        addAsset(project, projectAssetsDir, file, user, result, clamavClient);
       }
       result.put("assetDirectoryInfo", projectService.getDirectoryInfo(projectAssetsDir));
       return result;
@@ -91,29 +100,50 @@ public class ProjectAssetAPIController {
     return null;
   }
 
+  private ClamavClient getClamavClient() {
+    ClamavClient clamavClient = null;
+    try {
+      clamavClient = new ClamavClient(CLAMAV_ADDRESS);
+    } catch (ClamavException e) {
+      e.printStackTrace();
+    }
+    return clamavClient;
+  }
+
   @SuppressWarnings("unchecked")
   private void addAsset(Project project, File projectAssetsDir, MultipartFile file, User user,
-      Map<String, Object> result) throws IOException {
-    long sizeOfAssetsDirectory = FileUtils.sizeOfDirectory(projectAssetsDir);
-    Long projectMaxTotalAssetsSize = project.getMaxTotalAssetsSize();
-    if (projectMaxTotalAssetsSize == null) {
-      projectMaxTotalAssetsSize = new Long(
-          appProperties.getProperty("project_max_total_assets_size", "15728640"));
-    }
+      Map<String, Object> result, ClamavClient clamavClient) throws IOException {
     HashMap<String, String> fileObject = new HashMap<String, String>();
     fileObject.put("filename", file.getOriginalFilename());
-    if (!isUserAllowedToUpload(user, file)) {
-      fileObject.put("message", "Upload file not allowed.");
-      ((ArrayList<HashMap<String, String>>) result.get("error")).add(fileObject);
-    } else if (sizeOfAssetsDirectory + file.getSize() > projectMaxTotalAssetsSize) {
-      fileObject.put("message", "Exceeded project max asset size.\n"
-          + "Please delete unused assets.\n\nContact WISE if your project needs more disk space.");
-      ((ArrayList<HashMap<String, String>>) result.get("error")).add(fileObject);
+    boolean isSuccess = false;
+    if (clamavClient == null || isScanOk(clamavClient, file)) {
+      if (!isUserAllowedToUpload(user, file)) {
+        fileObject.put("message", UPLOADING_THIS_FILE_NOT_ALLOWED_MESSAGE);
+      } else if (!isEnoughProjectDiskSpace(project, projectAssetsDir, file)) {
+        fileObject.put("message", EXCEEDED_MAX_PROJECT_SIZE_MESSAGE);
+      } else {
+        Path path = Paths.get(projectAssetsDir.getPath(), file.getOriginalFilename());
+        file.transferTo(path);
+        isSuccess = true;
+      }
     } else {
-      Path path = Paths.get(projectAssetsDir.getPath(), file.getOriginalFilename());
-      file.transferTo(path);
-      ((ArrayList<HashMap<String, String>>) result.get("success")).add(fileObject);
+      fileObject.put("message", UPLOADING_THIS_FILE_NOT_ALLOWED_MESSAGE);
     }
+    if (isSuccess) {
+      ((ArrayList<HashMap<String, String>>) result.get("success")).add(fileObject);
+    } else {
+      ((ArrayList<HashMap<String, String>>) result.get("error")).add(fileObject);
+    }
+  }
+
+  private boolean isScanOk(ClamavClient clamavClient, MultipartFile file) throws IOException {
+    boolean result = false;
+    try {
+      result = clamavClient.scan(file.getInputStream()) instanceof ScanResult.OK;
+    } catch (ClamavException e) {
+      e.printStackTrace();
+    }
+    return result;
   }
 
   private boolean isUserAllowedToUpload(User user, MultipartFile file) {
@@ -127,6 +157,17 @@ public class ProjectAssetAPIController {
     } catch (IOException e) {
       return false;
     }
+  }
+
+  private boolean isEnoughProjectDiskSpace(Project project, File projectAssetsDir,
+      MultipartFile file) {
+    long sizeOfAssetsDirectory = FileUtils.sizeOfDirectory(projectAssetsDir);
+    Long projectMaxTotalAssetsSize = project.getMaxTotalAssetsSize();
+    if (projectMaxTotalAssetsSize == null) {
+      projectMaxTotalAssetsSize = Long
+          .parseLong(appProperties.getProperty("project_max_total_assets_size", "15728640"));
+    }
+    return sizeOfAssetsDirectory + file.getSize() > projectMaxTotalAssetsSize;
   }
 
   private String getRealMimeType(MultipartFile file) throws IOException {

--- a/src/main/resources/application-dockerdev-sample.properties
+++ b/src/main/resources/application-dockerdev-sample.properties
@@ -191,3 +191,6 @@ google.tokens.dir=
 
 # backwards compatibility purpose only.
 system-wide-salt=secret
+
+# IP Address of Clam AV server for virus scanning
+# clamav.server.address=127.0.0.1

--- a/src/main/resources/application_sample.properties
+++ b/src/main/resources/application_sample.properties
@@ -192,3 +192,6 @@ google.tokens.dir=
 
 # backwards compatibility purpose only.
 system-wide-salt=secret
+
+# IP Address of Clam AV server for virus scanning
+# clamav.server.address=127.0.0.1


### PR DESCRIPTION
## Changes

Run virus scanner on files that are uploaded by an author.

## Test

Install and start up Clam AV (you can look at the changes to scripts/beforeInstall.sh and perform the equivalent for your system)
1. Install Clam AV
2. Run freshclam to update the virus definitions
3. Update the clamav configuration file. For TCPAddr you may need to find your local IP and use that instead of 127.0.0.1 since we use Docker locally and Docker might intercept connections to 127.0.0.1.
4. You will also need to change the CLAMAV_ADDRESS in ProjectAssetAPIController.java from 127.0.0.1 to your local IP.
```
private String CLAMAV_ADDRESS = "127.0.0.1";
```
5. Start Clam AV


Download mock virus files from https://www.eicar.org/download-anti-malware-testfile/ (if your browser prevents downloading the files, you can try downloading using wget).
- eicar.com.txt
- eicarcom2.zip


Test uploading files on WISE
- Try uploading the two mock virus files to WISE. You should not be able to upload them and should receive an error.
- Try uploading files that are allowed. They should be allowed.
- Try uploading a mock virus file and a file that is allowed at the same time using drag and drop. The allowed file should be uploaded but the mock virus file should return an error.
- Try uploading files until the project asset limit for the project no longer has any more space. You should not be able to upload files past the project asset disk space limit.

Closes #190 