### PR TITLE
feat(QuestionBank): Add endpoint to get latest StudentWorkAnnotation

### DIFF
--- a/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/peergroup/PeerGroupStudentWorkAnnotationControllerTest.java
@@ -30,7 +30,7 @@ public class PeerGroupStudentWorkAnnotationControllerTest
   private AnnotationService annotationService;
 
   @Test
-  public void getListForDynamicPromptReferenceComponent_UserNotInPeerGroup_AccessDenied() {
+  public void getStudentDataForDynamicPrompt_UserNotInPeerGroup_AccessDenied() {
     expectUserNotInPeerGroup();
     replayAll();
     try {
@@ -45,7 +45,7 @@ public class PeerGroupStudentWorkAnnotationControllerTest
   }
 
   @Test
-  public void getListForDynamicPromptReferenceComponent_InvalidDynamicPromptContent_Exception()
+  public void getStudentDataForDynamicPrompt_InvalidDynamicPromptContent_Exception()
       throws IOException {
     expectUserInPeerGroup();
     expectInvalidDynamicPromptContent();
@@ -66,8 +66,7 @@ public class PeerGroupStudentWorkAnnotationControllerTest
   }
 
   @Test
-  public void getListForDynamicPromptReferenceComponent_ReturnReferenceComponentWork()
-      throws Exception {
+  public void getStudentDataForDynamicPrompt_ReturnReferenceComponentWork() throws Exception {
     expectUserInPeerGroup();
     expectValidDynamicPromptContent();
     expect(annotationService.getLatest(peerGroup1.getMembers(), run1Node1Id, run1Component1Id,


### PR DESCRIPTION
(This PR is similar to #182)

## Changes
- Add new GET endpoint: ```/api/peer-group/{peerGroupId}/{nodeId}/{componentId}/student-data/question-bank```
   - Given the PeerGroupId, NodeId, and ComponentId, this endpoint returns latest list of **StudentWorkAnnotations** of the PeerGroup members for the the QuestionBank's ReferenceComponent that is authored in the NodeId/ComponentId content.
   - **StudentWorkAnnotation** is a composite object consisting of:
      - Workgroup: workgroup that did the work
      - StudentWork: work by workgroup
      - Annotation: annotation for the StudentWork 

## Test
1. Make a GET request to the endpoint, and specify the following for each param:
   - peerGroupId: PeerGroupId for a component (e.g. PeerChat) that has a Question Bank reference component
   - nodeId: NodeID containing Question Bank reference component
   - componentId: ComponentId containing Question Bank reference component
    
This should return a list of **StudentWorkAnnotation**, one for each member of the PeerGroup.

2. Test the endpoint with a PeerGroupId that you are not in. It should return AccessDenied page.
3. Test the endpoint with non-existing nodeId/componentId. It should should return an error page.

Closes #193