### PR TITLE
chore(Google Login): Change GoogleUserNotFound redirect url

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/filters/WISEAuthenticationFailureHandler.java
+++ b/src/main/java/org/wise/portal/presentation/web/filters/WISEAuthenticationFailureHandler.java
@@ -75,15 +75,14 @@ public class WISEAuthenticationFailureHandler extends SimpleUrlAuthenticationFai
         Integer numberOfRecentFailedLoginAttempts = 1;
         Date currentTime = new Date();
         if (ControllerUtil.isRecentFailedLoginWithinTimeLimit(user)) {
-          numberOfRecentFailedLoginAttempts =
-            userDetails.getNumberOfRecentFailedLoginAttempts() + 1;
+          numberOfRecentFailedLoginAttempts = userDetails.getNumberOfRecentFailedLoginAttempts() + 1;
         }
         userDetails.setNumberOfRecentFailedLoginAttempts(numberOfRecentFailedLoginAttempts);
         userDetails.setRecentFailedLoginTime(currentTime);
         userService.updateUser(user);
       }
     } else if (request.getServletPath().contains("google-login")) {
-      response.sendRedirect(appProperties.getProperty("wise.hostname") + "/login/googleUserNotFound");
+      response.sendRedirect(appProperties.getProperty("wise.hostname") + "/join?googleUserNotFound=true");
       return;
     }
 
@@ -119,7 +118,7 @@ public class WISEAuthenticationFailureHandler extends SimpleUrlAuthenticationFai
     if (isReCaptchaRequired) {
       if (failedMessage.equals("Please verify that you are not a robot.")) {
         url = authenticationFailureUrl + "&requireCaptcha=true&reCaptchaFailed=true";
-      }  else {
+      } else {
         url = authenticationFailureUrl + "&requireCaptcha=true";
       }
     }


### PR DESCRIPTION
## Changes
- When user tries to login with Google but the user is not found in the database, change the redirect url from ```/login/googleUserNotFound``` to ```/join?googleUserNotFound=true```

## Test
- Try to log in with a Google user that is not associated with a WISE user. You should be redirect to ```/join?googleUserNotFound=true```

Closes #195