### PR TITLE
fix(Admin): Escape fields to prevent cross-site scripting

### DIFF
--- a/src/main/webapp/portal/admin/news/managenewsitems.jsp
+++ b/src/main/webapp/portal/admin/news/managenewsitems.jsp
@@ -108,8 +108,8 @@ function editNewsItem(newsItemId) {
 			<tr>
 				<td><fmt:formatDate value="${news.date}" type="both" dateStyle="short" timeStyle="short" /></td>
 				<td>${news.type}</td>
-				<td>${news.title}</td>
-				<td>${news.news}</td>
+				<td>${fn:escapeXml(news.title)}</td>
+				<td>${fn:escapeXml(news.news)}</td>
 				<td>
 					<a onclick="editNewsItem('${news.id}');"><spring:message code="edit" /></a>
 					<a onclick="removeNewsItem('${news.id}','${news.title}');"><spring:message code="remove" /></a>

--- a/src/main/webapp/portal/admin/project/import.jsp
+++ b/src/main/webapp/portal/admin/project/import.jsp
@@ -33,11 +33,20 @@
 				importableProjects.map(function(importableProject) {
 					$("#importableWISEProjects").append(
 							"<option value='" + importableProject.id + "'>"
-							+ importableProject.name
+							+ escapeCharacters(importableProject.name)
 							+ "</option>");
 				});
 			});
 		});
+
+		function escapeCharacters(str) {
+			return str
+					.replaceAll("<", "&lt;")
+					.replaceAll(">", "&gt;")
+					.replaceAll('"', "&quot;")
+					.replaceAll("'", "&apos;")
+		}
+
 		function importableWISEProjectSubmit() {
 			var importableWISEProjectId = $("#importableWISEProjects option:selected").attr("id");
 			$.ajax({});
@@ -55,16 +64,16 @@
 		<c:if test="${msg != null}">
 			<div style="width:500px;font-size:1.2em;font-weight:bold;border:2px solid lightgreen">
 					${msg}<br/><br/>
-				Project Name: ${newProject.name}<br/>
+				Project Name: ${fn:escapeXml(newProject.name)}<br/>
 				Project ID: ${newProject.id}<br/>
 				<c:if test="${newProject.metadata != null && newProject.metadata.author != null}">
-					Author: ${newProject.metadata.author}<br/>
+					Author: ${fn:escapeXml(newProject.metadata.author)}<br/>
 				</c:if>
 				<c:if test="${newProject.metadata != null && newProject.metadata.subject != null}">
-					Subject: ${newProject.metadata.subject}<br/>
+					Subject: ${fn:escapeXml(newProject.metadata.subject)}<br/>
 				</c:if>
 				<c:if test="${newProject.metadata != null && newProject.metadata.keywords != null}">
-					Keywords: ${newProject.metadata.keywords}<br/>
+					Keywords: ${fn:escapeXml(newProject.metadata.keywords)}<br/>
 				</c:if>
 				<br/><br/>
 				<a href="${contextPath}/admin/project/manageallprojects.html?projectLookupType=id&projectLookupValue=${newProject.id}">Manage Project</a>

--- a/src/main/webapp/portal/admin/project/manageallprojects.jsp
+++ b/src/main/webapp/portal/admin/project/manageallprojects.jsp
@@ -106,7 +106,7 @@ function updateMaxTotalAssetsSize(projectId, newMaxTotalAssetsSize) {
 	<c:forEach var="project" items="${internal_project_list}">
 	<tr>
 		<td>${project.id}</td>
-		<td><a target=_blank href="${contextPath}/previewproject.html?projectId=${project.id}">${project.name}</a><br/>
+		<td><a target=_blank href="${contextPath}/previewproject.html?projectId=${project.id}">${fn:escapeXml(project.name)}</a><br/>
 			<span style="font-size:.4em">${project.modulePath}</span>
 		</td>
 	    <td>Is Current:

--- a/src/main/webapp/portal/admin/run/manageprojectruns.jsp
+++ b/src/main/webapp/portal/admin/run/manageprojectruns.jsp
@@ -302,7 +302,7 @@
                             <c:forEach var="run" items="${runList}">
                                 <tr id="runTitleRow_${run.id}" class="runRow">
                                     <td>
-                                        <div class="runTitle">${run.name}</div>
+                                        <div class="runTitle">${fn:escapeXml(run.name)}</div>
                                         <c:set var="ownership" value="owned" />
                                         <c:forEach var="sharedowner" items="${run.sharedowners}">
                                             <c:if test="${sharedowner == user}">

--- a/src/main/webapp/portal/projectInfo.jsp
+++ b/src/main/webapp/portal/projectInfo.jsp
@@ -73,7 +73,7 @@
 <body style="background:#FFFFFF;">
 <div class="projectSummary">
 	<div class="projectInfoDisplay">
-		<div class="panelHeader">${project.name} (<spring:message code="id_label" /> ${project.id})
+		<div class="panelHeader">${fn:escapeXml(project.name)} (<spring:message code="id_label" /> ${project.id})
 			<span class="basicPreview"><a href="<c:url value="/previewproject.html"><c:param name="projectId" value="${project.id}"/></c:url>" target="_blank"><img class="icon" alt="preview" src="${contextPath}/<spring:theme code="screen"/>" /><span><spring:message code="preview"/></span></a></span>
 		</div>
 		<div class="projectThumb" thumbUrl="${projectThumbPath}"><img src='${contextPath}/<spring:theme code="project_thumb"/>' alt='thumb'></div>


### PR DESCRIPTION
## Changes

In the Admin page, escaped fields that display user entered data.

## Test

- Create a project with the title `Hello<script>alert('attack')</script>World`
- Create a run with the project and remember the run ID
- Go to the Admin page and search for the run ID. When the run results are displayed, you should not see an alert popup
- Go to the Admin page and search for the project ID. When the project results are displayed, you should not see an alert popup
- Go to the Admin page and click Work with News Items
  - Add News Item with Title set to `Hello<script>alert('attack1')</script>World` and Message set to `Hello<script>alert('attack2')</script>World` and click Submit
  - Reload the Work with News Items page and make sure there are no alert popups

Closes #203