### PR TITLE
fix(Share Unit): Teacher owner loses authoring permission

### DIFF
--- a/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/project/impl/ProjectServiceImpl.java
@@ -138,6 +138,7 @@ public class ProjectServiceImpl implements ProjectService {
     projectDao.save(project);
   }
 
+  @Transactional
   public void addSharedTeacherToProject(AddSharedTeacherParameters addSharedTeacherParameters) {
     Project project = addSharedTeacherParameters.getProject();
     String sharedOwnerUsername = addSharedTeacherParameters.getSharedOwnerUsername();
@@ -161,6 +162,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
   }
 
+  @Transactional
   public SharedOwner addSharedTeacher(Long projectId, String username)
       throws ObjectNotFoundException, TeacherAlreadySharedWithProjectException {
     Project project = getById(projectId);
@@ -180,6 +182,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
   }
 
+  @Transactional
   public void removeSharedTeacherFromProject(Project project, User user) {
     removeSharedTeacherAndPermissions(project, user);
     projectDao.save(project);
@@ -572,11 +575,13 @@ public class ProjectServiceImpl implements ProjectService {
     return new SharedOwner(userId, username, firstName, lastName, permissions);
   }
 
+  @Transactional
   public void removeSharedTeacher(Long projectId, String username) throws ObjectNotFoundException {
     removeSharedTeacherFromProject(getById(projectId),
         userService.retrieveUserByUsername(username));
   }
 
+  @Transactional
   public void addSharedTeacherPermission(Long projectId, Long userId, Integer permissionId)
       throws ObjectNotFoundException {
     User user = userService.retrieveById(userId);
@@ -586,6 +591,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
   }
 
+  @Transactional
   public void removeSharedTeacherPermission(Long projectId, Long userId, Integer permissionId)
       throws ObjectNotFoundException {
     User user = userService.retrieveById(userId);

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -380,6 +380,7 @@ public class RunServiceImpl implements RunService {
     aclService.removePermission(run, BasePermission.ADMINISTRATION, user);
   }
 
+  @Transactional
   public SharedOwner addSharedTeacher(Long runId, String username)
       throws ObjectNotFoundException, TeacherAlreadySharedWithRunException {
     User user = userDao.retrieveByUsername(username);
@@ -423,6 +424,7 @@ public class RunServiceImpl implements RunService {
     return null;
   }
 
+  @Transactional
   public void addSharedTeacherPermission(Long runId, Long userId, Integer permissionId)
       throws ObjectNotFoundException {
     User user = userDao.getById(userId);
@@ -432,6 +434,7 @@ public class RunServiceImpl implements RunService {
     }
   }
 
+  @Transactional
   public void removeSharedTeacherPermission(Long runId, Long userId, Integer permissionId)
       throws ObjectNotFoundException {
     User user = userDao.getById(userId);
@@ -441,6 +444,7 @@ public class RunServiceImpl implements RunService {
     }
   }
 
+  @Transactional
   public void removeSharedTeacher(String username, Long runId) throws ObjectNotFoundException {
     Run run = retrieveById(runId);
     User user = userDao.retrieveByUsername(username);


### PR DESCRIPTION
## Changes

Added `@Transactional` in these locations
- Add shared teacher to project
- Remove shared teacher from project
- Add shared teacher permission to project
- Remove shared teacher permission from project
- Add shared teacher to run
- Remove shared teacher from run
- Add shared teacher permission to run
- Remove shared teacher permission from run



## Test

We haven't found a reliable way to reproduce the problem so this is an attempt to fix the problem. Here is how to attempt to reproduce the problem.

Sign in as a teacher

Go to the Unit Library
Add and remove shared teachers
Add and remove shared teacher permissions

Go to the Class Schedule
Add and remove shared teachers
Add and remove shared teacher permissions

Make sure the teacher owner can still make changes to the unit

Here is how you can check the permissions in the database

Log in to the local Docker MySQL database
```
docker run -it --network wise-docker-dev_default --rm mysql:8 mysql -hwise-mysql -uroot -p wise_database
```

Run this query to look up permissions for a project (replace \<project id\> with your project id)
```
select * from acl_object_identity where object_id_class=1 and object_id_identity=<project id>;
```
Remember the id from the result and then run this query (replace \<id from previous query\>)
```
select * from acl_entry where acl_object_identity=<id from previous query>;
```

Run this query to look up permissions for a run (replace \<run id\> with your run id)
```
select * from acl_object_identity where object_id_class=2 and object_id_identity=<run id>;
```
Remember the id from the result and then run this query (replace \<id from previous query\>)
```
select * from acl_entry where acl_object_identity=<id from previous query>;
```

Here's an example of looking up the permissions for project id 25. Notice in the result of the first query, the id is 72 so we use 72 in the second query. The result of the second query shows that sid 1 has permission mask 16 (full access) and sid 22 has mask 1 (read) and 2 (write) permissions. Basically you want to make sure the teacher owner mask 16 row does not get deleted.
```
mysql> select * from acl_object_identity where object_id_class=1 and object_id_identity=25;
+----+--------------------+------------------------+----------------------------------------+---------+-----------------+-----------+---------------+
| id | object_id_identity | object_id_identity_num | entries_inheriting                     | OPTLOCK | object_id_class | owner_sid | parent_object |
+----+--------------------+------------------------+----------------------------------------+---------+-----------------+-----------+---------------+
| 72 |                 25 |                   NULL | 0x01                                   |    NULL |               1 |         1 |          NULL |
+----+--------------------+------------------------+----------------------------------------+---------+-----------------+-----------+---------------+
1 row in set (0.00 sec)

mysql> select * from acl_entry where acl_object_identity=72;
+------+-----------+------------------------------+------------------------------+--------------------+------+---------+-----+---------------------+
| id   | ace_order | audit_failure                | audit_success                | granting           | mask | OPTLOCK | sid | acl_object_identity |
+------+-----------+------------------------------+------------------------------+--------------------+------+---------+-----+---------------------+
| 2025 |         0 | 0x00                         | 0x00                         | 0x01               |   16 |    NULL |   1 |                  72 |
| 2026 |         1 | 0x00                         | 0x00                         | 0x01               |    1 |    NULL |  22 |                  72 |
| 2027 |         2 | 0x00                         | 0x00                         | 0x01               |    2 |    NULL |  22 |                  72 |
+------+-----------+------------------------------+------------------------------+--------------------+------+---------+-----+---------------------+
3 rows in set (0.00 sec)
```

To look up who an sid refers to you can use this query (replace \<sid\>)
```
select * from acl_sid where id=<sid>;
```

Here is an example where you can see the username in the sid column.
```
mysql> select * from acl_sid where id=1;
+----+-----------+-----+---------+
| id | principal | sid | OPTLOCK |
+----+-----------+-----+---------+
|  1 |         1 | gk  |    NULL |
+----+-----------+-----+---------+
1 row in set (0.00 sec)
```



Closes #211