### PR TITLE
feat(PeerGroupWork): Return StudentWorkAnnotation for MC Reference Component

### DIFF
--- a/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
+++ b/src/main/java/org/wise/portal/domain/project/impl/ProjectComponent.java
@@ -43,10 +43,14 @@ public class ProjectComponent {
   @Getter
   ProjectNode node;
 
+  @Getter
+  String type;
+
   public ProjectComponent(ProjectNode node, JSONObject componentJSON) throws JSONException {
     this.node = node;
     this.componentJSON = componentJSON;
     this.id = componentJSON.getString("id");
+    this.type = componentJSON.getString("type");
   }
 
   public String getString(String key) throws JSONException {

--- a/src/main/java/org/wise/vle/domain/work/StudentWorkAnnotation.java
+++ b/src/main/java/org/wise/vle/domain/work/StudentWorkAnnotation.java
@@ -19,4 +19,9 @@ public class StudentWorkAnnotation {
     this.studentWork = annotation.getStudentWork();
     this.workgroup = annotation.getToWorkgroup();
   }
+
+  public StudentWorkAnnotation(StudentWork studentWork) {
+    this.studentWork = studentWork;
+    this.workgroup = studentWork.getWorkgroup();
+  }
 }


### PR DESCRIPTION
## Changes
- Add support to fetch student work on a Multiple Choice Reference Component (for Dynamic Prompt and Question Bank)

## Test
- Test with https://github.com/WISE-Community/WISE-Client/pull/1410 
- PeerGroup's work on a MC Reference Component is returned properly when a GET request to the ```/api/peer-group/{peerGroupId}/{nodeId}/{componentId}/student-data/[dynamic-prompt|question-bank]``` endpoint is made

Closes #234