### PR TITLE
fix(Manage Students): Student can end up in multiple workgroups

### DIFF
--- a/src/main/java/org/wise/portal/dao/run/RunDao.java
+++ b/src/main/java/org/wise/portal/dao/run/RunDao.java
@@ -106,8 +106,6 @@ public interface RunDao<T extends Run> extends SimpleDao<T> {
    */
   List<Run> getRunsByActivity();
 
-  List<Workgroup> getWorkgroupsForRun(Long runId);
-
   List<Workgroup> getWorkgroupsForRunAndPeriod(Long runId, Long periodId);
 
   long getMaxRunId();

--- a/src/main/java/org/wise/portal/dao/run/impl/HibernateRunDao.java
+++ b/src/main/java/org/wise/portal/dao/run/impl/HibernateRunDao.java
@@ -95,17 +95,6 @@ public class HibernateRunDao extends AbstractHibernateDao<Run> implements RunDao
   }
 
   @SuppressWarnings("unchecked")
-  public List<Workgroup> getWorkgroupsForRun(Long runId) {
-    CriteriaBuilder cb = getCriteriaBuilder();
-    CriteriaQuery<WorkgroupImpl> cq = cb.createQuery(WorkgroupImpl.class);
-    Root<WorkgroupImpl> workgroupRoot = cq.from(WorkgroupImpl.class);
-    cq.select(workgroupRoot).where(cb.equal(workgroupRoot.get("run").get("id"), runId));
-    TypedQuery<WorkgroupImpl> query = entityManager.createQuery(cq);
-    List<WorkgroupImpl> workgroupResultList = query.getResultList();
-    return (List<Workgroup>) (Object) workgroupResultList;
-  }
-
-  @SuppressWarnings("unchecked")
   public List<Workgroup> getWorkgroupsForRunAndPeriod(Long runId, Long periodId) {
     CriteriaBuilder cb = getCriteriaBuilder();
     CriteriaQuery<WorkgroupImpl> cq = cb.createQuery(WorkgroupImpl.class);

--- a/src/main/java/org/wise/portal/dao/workgroup/WorkgroupDao.java
+++ b/src/main/java/org/wise/portal/dao/workgroup/WorkgroupDao.java
@@ -48,4 +48,6 @@ public interface WorkgroupDao<T extends Workgroup> extends SimpleDao<T> {
    * @return a <code>Workgroup</code> <code>List</code>
    */
   List<T> getListByUser(User user);
+
+  List<Workgroup> getListByRun(Run run);
 }

--- a/src/main/java/org/wise/portal/dao/workgroup/impl/HibernateWorkgroupDao.java
+++ b/src/main/java/org/wise/portal/dao/workgroup/impl/HibernateWorkgroupDao.java
@@ -56,11 +56,11 @@ public class HibernateWorkgroupDao extends AbstractHibernateDao<Workgroup>
 
   @PersistenceContext
   private EntityManager entityManager;
- 
+
   private CriteriaBuilder getCriteriaBuilder() {
     Session session = this.getHibernateTemplate().getSessionFactory().getCurrentSession();
-    return session.getCriteriaBuilder(); 
-  } 
+    return session.getCriteriaBuilder();
+  }
 
   private static final String FIND_ALL_QUERY = "from WorkgroupImpl";
 
@@ -87,8 +87,8 @@ public class HibernateWorkgroupDao extends AbstractHibernateDao<Workgroup>
     predicates.add(cb.equal(runImplRoot.get("id"), run.getId()));
     predicates.add(cb.equal(runImplRoot.get("id"), workgroupImplRoot.get("run")));
     predicates.add(cb.equal(workgroupImplRoot.get("group"), persistentGroupRoot.get("id")));
-    predicates.add(
-        cb.isMember(userImplRoot.get("id"), persistentGroupRoot.<Set<User>>get("members")));
+    predicates
+        .add(cb.isMember(userImplRoot.get("id"), persistentGroupRoot.<Set<User>> get("members")));
     cq.select(workgroupImplRoot).where(predicates.toArray(new Predicate[predicates.size()]));
     TypedQuery<WorkgroupImpl> query = entityManager.createQuery(cq);
     List<WorkgroupImpl> runResultList = query.getResultList();
@@ -105,11 +105,23 @@ public class HibernateWorkgroupDao extends AbstractHibernateDao<Workgroup>
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.equal(userImplRoot.get("id"), user.getId()));
     predicates.add(cb.equal(workgroupImplRoot.get("group"), persistentGroupRoot.get("id")));
-    predicates.add(
-        cb.isMember(userImplRoot.get("id"), persistentGroupRoot.<Set<User>>get("members")));
+    predicates
+        .add(cb.isMember(userImplRoot.get("id"), persistentGroupRoot.<Set<User>> get("members")));
     cq.select(workgroupImplRoot).where(predicates.toArray(new Predicate[predicates.size()]));
     TypedQuery<WorkgroupImpl> query = entityManager.createQuery(cq);
     List<WorkgroupImpl> runResultList = query.getResultList();
     return (List<Workgroup>) (Object) runResultList;
   }
+
+  @SuppressWarnings("unchecked")
+  public List<Workgroup> getListByRun(Run run) {
+    CriteriaBuilder cb = getCriteriaBuilder();
+    CriteriaQuery<WorkgroupImpl> cq = cb.createQuery(WorkgroupImpl.class);
+    Root<WorkgroupImpl> workgroupRoot = cq.from(WorkgroupImpl.class);
+    cq.select(workgroupRoot).where(cb.equal(workgroupRoot.get("run").get("id"), run.getId()));
+    TypedQuery<WorkgroupImpl> query = entityManager.createQuery(cq);
+    List<WorkgroupImpl> workgroupResultList = query.getResultList();
+    return (List<Workgroup>) (Object) workgroupResultList;
+  }
+
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupController.java
@@ -44,8 +44,7 @@ public class CreateWorkgroupController {
       @PathVariable Long periodId, @RequestBody List<Long> userIds) throws ObjectNotFoundException {
     Run run = runService.retrieveById(runId);
     Group period = groupService.retrieveById(periodId);
-    if (runService.hasWritePermission(auth, run) && isPeriodInRun(run, period)
-        && areAllStudentsInPeriod(run, period, userIds)) {
+    if (isAllowed(auth, run, period, userIds)) {
       removeUsersFromAllWorkgroupsInRun(run, userIds);
       HashSet<User> newGroupMembers = createNewGroupMembers(userIds);
       Workgroup newWorkgroup = workgroupService.createWorkgroup("Student", newGroupMembers, run,
@@ -55,6 +54,12 @@ public class CreateWorkgroupController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
           "Error: Could not create workgroup");
     }
+  }
+
+  private boolean isAllowed(Authentication auth, Run run, Group period, List<Long> userIds)
+      throws ObjectNotFoundException {
+    return runService.hasWritePermission(auth, run) && isPeriodInRun(run, period)
+        && areAllStudentsInPeriod(run, period, userIds);
   }
 
   private boolean isPeriodInRun(Run run, Group period) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupController.java
@@ -1,17 +1,18 @@
 package org.wise.portal.presentation.web.controllers.teacher.management;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.AccessDeniedException;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.run.Run;
@@ -39,26 +40,53 @@ public class CreateWorkgroupController {
   private UserService userService;
 
   @PostMapping("/api/teacher/run/{runId}/workgroup/create/{periodId}")
-  long createWorkgroup(Authentication auth, @PathVariable Long runId,
+  protected Long createWorkgroup(Authentication auth, @PathVariable Long runId,
       @PathVariable Long periodId, @RequestBody List<Long> userIds) throws ObjectNotFoundException {
     Run run = runService.retrieveById(runId);
-    if (runService.hasWritePermission(auth, run)) {
-      HashSet<User> newGroupMembers = new HashSet<User>();
-      for (Long userId : userIds) {
-        User user = userService.retrieveById(userId);
-        List<Workgroup> workgroups = workgroupService.getWorkgroupListByRunAndUser(run, user);
-        if (workgroups.size() > 0) {
-          Workgroup workgroup = workgroups.get(0); // student can be in only one workgroup per run
-          workgroupService.removeMembers(workgroup, Collections.singleton(user));
-        }
-        newGroupMembers.add(user);
-      }
-      Group period = groupService.retrieveById(periodId);
-      Workgroup newWorkgroup =
-          workgroupService.createWorkgroup("Student", newGroupMembers, run, period);
+    Group period = groupService.retrieveById(periodId);
+    if (runService.hasWritePermission(auth, run) && isPeriodInRun(run, period)
+        && areAllStudentsInPeriod(run, period, userIds)) {
+      removeUsersFromAllWorkgroupsInRun(run, userIds);
+      HashSet<User> newGroupMembers = createNewGroupMembers(userIds);
+      Workgroup newWorkgroup = workgroupService.createWorkgroup("Student", newGroupMembers, run,
+          period);
       return newWorkgroup.getId();
     } else {
-      throw new AccessDeniedException("User does not have permission to change period");
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Error: Could not create workgroup");
     }
+  }
+
+  private boolean isPeriodInRun(Run run, Group period) {
+    return run.getPeriods().contains(period);
+  }
+
+  private boolean areAllStudentsInPeriod(Run run, Group period, List<Long> userIds)
+      throws ObjectNotFoundException {
+    Set<User> studentsInPeriod = period.getMembers();
+    for (Long userId : userIds) {
+      User user = userService.retrieveById(userId);
+      if (!studentsInPeriod.contains(user)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void removeUsersFromAllWorkgroupsInRun(Run run, List<Long> userIds)
+      throws ObjectNotFoundException {
+    for (Long userId : userIds) {
+      User user = userService.retrieveById(userId);
+      workgroupService.removeUserFromAllWorkgroupsInRun(run, user);
+    }
+  }
+
+  private HashSet<User> createNewGroupMembers(List<Long> userIds) throws ObjectNotFoundException {
+    HashSet<User> newGroupMembers = new HashSet<User>();
+    for (Long userId : userIds) {
+      User user = userService.retrieveById(userId);
+      newGroupMembers.add(user);
+    }
+    return newGroupMembers;
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.impl.ChangeWorkgroupParameters;
+import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.run.impl.RunImpl;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.service.run.RunService;
@@ -36,16 +38,22 @@ public class WorkgroupMembershipAPIController {
       @PathVariable Long userId, @RequestBody JsonNode postedParams) throws Exception {
     Workgroup workgroup = null;
     if (runService.hasWritePermission(auth, run)) {
-      ChangeWorkgroupParameters params = new ChangeWorkgroupParameters();
-      params.setRun(run);
-      params.setStudent(userService.retrieveById(userId));
-      Long toWorkgroupId = postedParams.get("workgroupIdTo").asLong();
-      params.setWorkgroupTo(workgroupService.retrieveById(toWorkgroupId));
+      ChangeWorkgroupParameters params = createChangeWorkgroupParameters(run, userId, postedParams);
       workgroup = workgroupService.updateWorkgroupMembership(params);
     }
     if (workgroup == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Error: Could not move student");
     }
     return workgroup.getId();
+  }
+
+  private ChangeWorkgroupParameters createChangeWorkgroupParameters(Run run, Long userId,
+      JsonNode postedParams) throws ObjectNotFoundException {
+    ChangeWorkgroupParameters params = new ChangeWorkgroupParameters();
+    params.setRun(run);
+    params.setStudent(userService.retrieveById(userId));
+    Long toWorkgroupId = postedParams.get("workgroupIdTo").asLong();
+    params.setWorkgroupTo(workgroupService.retrieveById(toWorkgroupId));
+    return params;
   }
 }

--- a/src/main/java/org/wise/portal/service/run/RunService.java
+++ b/src/main/java/org/wise/portal/service/run/RunService.java
@@ -33,7 +33,6 @@ import org.springframework.security.acls.model.Permission;
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
 import org.wise.portal.dao.ObjectNotFoundException;
-import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.impl.AddSharedTeacherParameters;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.run.impl.RunParameters;
@@ -401,7 +400,7 @@ public interface RunService {
    * @param runId
    * @return boolean
    */
-  boolean canDecreaseMaxStudentsPerTeam(Long runId);
+  boolean canDecreaseMaxStudentsPerTeam(Long runId) throws ObjectNotFoundException;
 
   /**
    * Returns a <code>List<Run></code> list of runs that were run within the given

--- a/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/run/impl/RunServiceImpl.java
@@ -558,8 +558,8 @@ public class RunServiceImpl implements RunService {
     }
   }
 
-  public List<Workgroup> getWorkgroups(Long runId) {
-    return runDao.getWorkgroupsForRun(runId);
+  public List<Workgroup> getWorkgroups(Long runId) throws ObjectNotFoundException {
+    return workgroupService.getWorkgroupsForRun(retrieveById(runId));
   }
 
   public List<Workgroup> getWorkgroups(Long runId, Long periodId) {
@@ -631,7 +631,7 @@ public class RunServiceImpl implements RunService {
     return aclService.hasSpecificPermission(run, permission, user.getUserDetails());
   }
 
-  public boolean canDecreaseMaxStudentsPerTeam(Long runId) {
+  public boolean canDecreaseMaxStudentsPerTeam(Long runId) throws ObjectNotFoundException {
     List<Workgroup> workgroups = getWorkgroups(runId);
     if (workgroups != null) {
       for (Workgroup workgroup : workgroups) {

--- a/src/main/java/org/wise/portal/service/workgroup/WorkgroupService.java
+++ b/src/main/java/org/wise/portal/service/workgroup/WorkgroupService.java
@@ -55,6 +55,8 @@ public interface WorkgroupService {
    */
   List<Workgroup> getWorkgroupListByRunAndUser(Run run, User user);
 
+  List<Workgroup> getWorkgroupsForRun(Run run);
+
   /**
    * Adds members to an already-existing workgroup. If a member is
    * already in the group, do not add again. Also update the workgroup name.
@@ -89,8 +91,9 @@ public interface WorkgroupService {
    * @return updated workgroup
    * @throws Exception when update fails
    */
-  Workgroup updateWorkgroupMembership(ChangeWorkgroupParameters params)
-      throws Exception;
+  Workgroup updateWorkgroupMembership(ChangeWorkgroupParameters params);
+
+  void removeUserFromAllWorkgroupsInRun(Run run, User user);
 
   /**
    * Creates a <code>Workgroup</code> with given parameters

--- a/src/test/java/org/wise/portal/dao/run/impl/HibernateRunDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/run/impl/HibernateRunDaoTest.java
@@ -108,27 +108,6 @@ public class HibernateRunDaoTest extends WISEHibernateTest {
   }
 
   @Test
-  public void getWorkgroupsForRun_OnePeriod_Success() throws Exception {
-    Long runId = run1.getId();
-    List<Workgroup> workgroups = runDao.getWorkgroupsForRun(runId);
-    assertEquals(3, workgroups.size());
-    addUserToRun(student3, run1, run1Period1);
-    workgroups = runDao.getWorkgroupsForRun(runId);
-    assertEquals(4, workgroups.size());
-  }
-
-  @Test
-  public void getWorkgroupsForRun_TwoPeriods_Success() throws Exception {
-    Long runId = run1.getId();
-    List<Workgroup> workgroups = runDao.getWorkgroupsForRun(runId);
-    assertEquals(3, workgroups.size());
-    addUserToRun(student3, run1, run1Period1);
-    addUserToRun(student4, run1, run1Period2);
-    workgroups = runDao.getWorkgroupsForRun(runId);
-    assertEquals(5, workgroups.size());
-  }
-
-  @Test
   public void getWorkgroupsForRunAndPeriod_OnePeriod_Success() throws Exception {
     Long runId = run1.getId();
     Long period1Id = run1Period1.getId();

--- a/src/test/java/org/wise/portal/dao/workgroup/impl/HibernateWorkgroupDaoTest.java
+++ b/src/test/java/org/wise/portal/dao/workgroup/impl/HibernateWorkgroupDaoTest.java
@@ -53,6 +53,7 @@ import org.wise.portal.junit.AbstractTransactionalDbTests;
 @RunWith(SpringRunner.class)
 public class HibernateWorkgroupDaoTest extends AbstractTransactionalDbTests {
 
+  Group period1, period2;
   Run run;
   User student1, student2;
 
@@ -67,15 +68,17 @@ public class HibernateWorkgroupDaoTest extends AbstractTransactionalDbTests {
     Date startTime = Calendar.getInstance().getTime();
     String runCode = "Panda123";
     User teacher = createTeacherUser("Mrs", "Puff", "MrsPuff", "Mrs. Puff", "boat", "Bikini Bottom",
-      "Water State", "Pacific Ocean", "mrspuff@bikinibottom.com", "Boating School",
-      Schoollevel.COLLEGE, "1234567890");
+        "Water State", "Pacific Ocean", "mrspuff@bikinibottom.com", "Boating School",
+        Schoollevel.COLLEGE, "1234567890");
     run = createProjectAndRun(id, projectName, teacher, startTime, runCode);
-    Group period1 = createPeriod("Period 1");
+    period1 = createPeriod("Period 1");
+    period2 = createPeriod("Period 2");
     Set<Group> periods = new TreeSet<Group>();
     periods.add(period1);
+    periods.add(period2);
     run.setPeriods(periods);
     student1 = createStudentUser("Spongebob", "Squarepants", "SpongebobS0101", "burger", 1, 1,
-      Gender.MALE);
+        Gender.MALE);
     Set<User> members1 = new HashSet<User>();
     members1.add(student1);
     createWorkgroup(members1, run, period1);
@@ -106,5 +109,23 @@ public class HibernateWorkgroupDaoTest extends AbstractTransactionalDbTests {
     List<Workgroup> workgroups = workgroupDao.getListByUser(student1);
     assertEquals(1, workgroups.size());
     assertTrue(workgroups.get(0).getMembers().contains(student1));
+  }
+
+  @Test
+  public void getListByRun_OnePeriod_ReturnsAllWorkgroups() throws Exception {
+    List<Workgroup> workgroups = workgroupDao.getListByRun(run);
+    assertEquals(1, workgroups.size());
+    addUserToRun(student2, run, period1);
+    workgroups = workgroupDao.getListByRun(run);
+    assertEquals(2, workgroups.size());
+  }
+
+  @Test
+  public void getListByRun_TwoPeriods_ReturnsAllWorkgroups() throws Exception {
+    List<Workgroup> workgroups = workgroupDao.getListByRun(run);
+    assertEquals(1, workgroups.size());
+    addUserToRun(student2, run, period2);
+    workgroups = workgroupDao.getListByRun(run);
+    assertEquals(2, workgroups.size());
   }
 }

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/management/CreateWorkgroupControllerTest.java
@@ -1,26 +1,28 @@
 package org.wise.portal.presentation.web.controllers.teacher.management;
 
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.fail;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.easymock.EasyMockRunner;
 import org.easymock.TestSubject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.server.ResponseStatusException;
 import org.wise.portal.dao.ObjectNotFoundException;
 import org.wise.portal.domain.group.Group;
 import org.wise.portal.domain.run.Run;
 import org.wise.portal.domain.workgroup.Workgroup;
 import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.presentation.web.controllers.APIControllerTest;
-
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.fail;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 
 @RunWith(EasyMockRunner.class)
 public class CreateWorkgroupControllerTest extends APIControllerTest {
@@ -36,8 +38,8 @@ public class CreateWorkgroupControllerTest extends APIControllerTest {
     try {
       List<Long> userIds = Stream.of(2L).collect(Collectors.toList());
       controller.createWorkgroup(teacherAuth, runId3, run1Period1.getId(), userIds);
-      fail("AccessDeniedException expected but was not thrown");
-    } catch (AccessDeniedException e) {
+      fail("ResponseStatusException expected but was not thrown");
+    } catch (ResponseStatusException e) {
     }
     verify(runService);
   }
@@ -45,17 +47,17 @@ public class CreateWorkgroupControllerTest extends APIControllerTest {
   @Test
   public void createWorkgroup_UserInWorkgroup_CallRemoveMembers() throws ObjectNotFoundException {
     expect(runService.retrieveById(runId1)).andReturn(run1);
+    expect(groupService.retrieveById(run1Period1Id)).andReturn(run1Period1);
     expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(true);
     expect(userService.retrieveById(student1.getId())).andReturn(student1);
-    expect(workgroupService.getWorkgroupListByRunAndUser(run1, student1))
-      .andReturn(Stream.of(workgroup1).collect(Collectors.toList()));
-    workgroupService.removeMembers(workgroup1, Collections.singleton(student1));
+    expect(userService.retrieveById(student1.getId())).andReturn(student1);
+    workgroupService.removeUserFromAllWorkgroupsInRun(run1, student1);
     expectLastCall();
-    expect(groupService.retrieveById(run1Period1.getId())).andReturn(run1Period1);
+    expect(userService.retrieveById(student1.getId())).andReturn(student1);
     Workgroup newWorkgroup = new WorkgroupImpl();
     newWorkgroup.setId(2L);
-    expect(workgroupService.createWorkgroup(isA(String.class), isA(HashSet.class), isA(Run.class), isA(Group.class)))
-      .andReturn(newWorkgroup);
+    expect(workgroupService.createWorkgroup(isA(String.class), isA(HashSet.class), isA(Run.class),
+        isA(Group.class))).andReturn(newWorkgroup);
     replay(runService, userService, workgroupService, groupService);
     List<Long> userIds = Stream.of(student1.getId()).collect(Collectors.toList());
     controller.createWorkgroup(teacherAuth, runId1, run1Period1.getId(), userIds);

--- a/src/test/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/teacher/run/WorkgroupMembershipAPIControllerTest.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.easymock.EasyMock.*;
+import static org.junit.Assert.fail;
 
 import org.easymock.EasyMockRunner;
 import org.easymock.TestSubject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.web.server.ResponseStatusException;
 import org.wise.portal.domain.impl.ChangeWorkgroupParameters;
 import org.wise.portal.domain.workgroup.impl.WorkgroupImpl;
 import org.wise.portal.presentation.web.controllers.APIControllerTest;
@@ -16,21 +19,58 @@ import org.wise.portal.presentation.web.controllers.APIControllerTest;
 @RunWith(EasyMockRunner.class)
 public class WorkgroupMembershipAPIControllerTest extends APIControllerTest {
 
+  JsonNode postedParams;
+
   @TestSubject
   private WorkgroupMembershipAPIController controller = new WorkgroupMembershipAPIController();
 
+  @Before
+  public void init() throws Exception {
+    String paramString = "{\"workgroupIdTo\":\"2\",\"periodId\":\"1\"}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    postedParams = objectMapper.readTree(paramString);
+  }
+
   @Test
   public void moveUserBetweenWorkgroups_allParamsSet_updateMembership() throws Exception {
-    String paramString = "{\"workgroupIdFrom\":\"1\",\"workgroupIdTo\":\"2\",\"periodId\":\"1\"}";
-    ObjectMapper objectMapper = new ObjectMapper();
-    JsonNode postedParams = objectMapper.readTree(paramString);
+    expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(true);
     expect(userService.retrieveById(student1Id)).andReturn(student1);
-    expect(workgroupService.retrieveById(1L)).andReturn(workgroup1);
     expect(workgroupService.retrieveById(2L)).andReturn(workgroup2);
     expect(workgroupService.updateWorkgroupMembership(isA(ChangeWorkgroupParameters.class)))
-      .andReturn(new WorkgroupImpl());
-    replay(userService, workgroupService);
-    controller.moveUserBetweenWorkgroups(run1, student1Id, postedParams);
-    verify(userService, workgroupService);
+        .andReturn(new WorkgroupImpl());
+    replay(runService, userService, workgroupService);
+    controller.moveUserBetweenWorkgroups(teacherAuth, run1, student1Id, postedParams);
+    verify(runService, userService, workgroupService);
   }
+
+  @Test
+  public void moveUserBetweenWorkgroups_teacherDoesNotHavePermission_throwsException()
+      throws Exception {
+    expect(runService.hasWritePermission(teacherAuth, run3)).andReturn(false);
+    replay(runService);
+    try {
+      controller.moveUserBetweenWorkgroups(teacherAuth, run3, student1Id, postedParams);
+      fail("Expected ResponseStatusException");
+    } catch (ResponseStatusException e) {
+    }
+    verify(runService);
+  }
+
+  @Test
+  public void moveUserBetweenWorkgroups_workgroupServiceUnableToMoveUser_throwsException()
+      throws Exception {
+    expect(runService.hasWritePermission(teacherAuth, run1)).andReturn(true);
+    expect(userService.retrieveById(student1Id)).andReturn(student1);
+    expect(workgroupService.retrieveById(2L)).andReturn(workgroup2);
+    expect(workgroupService.updateWorkgroupMembership(isA(ChangeWorkgroupParameters.class)))
+        .andReturn(null);
+    replay(runService, userService, workgroupService);
+    try {
+      controller.moveUserBetweenWorkgroups(teacherAuth, run1, student1Id, postedParams);
+      fail("Expected ResponseStatusException");
+    } catch (ResponseStatusException e) {
+    }
+    verify(runService, userService, workgroupService);
+  }
+
 }


### PR DESCRIPTION
## Changes

Move student to another workgroup
- The request only requires the to workgroup id. It no longer requires the from workgroup id or the period id because it removes the student from all workgroups in the run and figures out the period from the to workgroup.
- Now checks that the signed in teacher has permission to make the modification on the run
- Now checks that the to workgroup is in the run and the student is in the same period as the to workgroup
- Now removes the student from all other workgroups in the run before adding them to the workgroup
- Now throws a ResponseStatusException if there are any errors

Create new workgroup
- Now checks that the period is in the run
- Now checks that all students being put into the new workgroup are in the period
- Now removes the students from all other workgroups in the run before adding them to the new workgroup
- Now throws a ResponseStatusException if there are any errors

## Test

- Test with and use test instructions in https://github.com/WISE-Community/WISE-Client/pull/1438

Closes #238