### PR TITLE
fix(Student Data): Student data does not save if in multiple workgroups in a run

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -781,11 +781,9 @@ public class InformationController {
   }
 
   /**
-   * Gets the workgroup for the currently-logged in user so that she may view the VLE.
-   *
+   * Gets the workgroup for the logged in user
    * @param run
-   * @return Workgroup for the currently-logged in user
-   * @throws ObjectNotFoundException
+   * @return Workgroup for the logged in user
    */
   private Workgroup getWorkgroup(Run run) {
     Workgroup workgroup = null;
@@ -793,10 +791,8 @@ public class InformationController {
     if (context.getAuthentication().getPrincipal() instanceof UserDetails) {
       UserDetails userDetails = (UserDetails) context.getAuthentication().getPrincipal();
       User user = userService.retrieveUser(userDetails);
-
       List<Workgroup> workgroupListByRunAndUser = workgroupService.getWorkgroupListByRunAndUser(run,
           user);
-
       workgroup = workgroupListByRunAndUser.get(0);
     }
     return workgroup;

--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -205,8 +205,8 @@ public class InformationController {
 
   @GetMapping("/config/studentRun/{runId}")
   public void getConfigWISE5StudentRun(HttpServletRequest request, HttpServletResponse response,
-      @PathVariable("runId") RunImpl run) throws ObjectNotFoundException, IOException,
-      JSONException {
+      @PathVariable("runId") RunImpl run)
+      throws ObjectNotFoundException, IOException, JSONException {
     JSONObject config = new JSONObject();
     config.put("mode", "studentRun");
     getRunConfigParameters(request, config, run);
@@ -411,8 +411,8 @@ public class InformationController {
       JSONArray studentsNotInWorkgroup = new JSONArray();
       for (User user : period.getMembers()) {
         if (!workgroupService.isUserInAnyWorkgroupForRun(user, run)) {
-          JSONObject userJSONInfo =
-              createUserJSONInfo(user, isAllowedToViewStudentNames(run, loggedInUser));
+          JSONObject userJSONInfo = createUserJSONInfo(user,
+              isAllowedToViewStudentNames(run, loggedInUser));
           studentsNotInWorkgroup.put(userJSONInfo);
         }
       }
@@ -797,12 +797,7 @@ public class InformationController {
       List<Workgroup> workgroupListByRunAndUser = workgroupService.getWorkgroupListByRunAndUser(run,
           user);
 
-      if (workgroupListByRunAndUser.size() == 1) {
-        workgroup = workgroupListByRunAndUser.get(0);
-      } else if (workgroupListByRunAndUser.size() > 1) {
-        // this user is in more than one workgroup so we will just get the last one
-        workgroup = workgroupListByRunAndUser.get(workgroupListByRunAndUser.size() - 1);
-      }
+      workgroup = workgroupListByRunAndUser.get(0);
     }
     return workgroup;
   }


### PR DESCRIPTION
## Changes

If a student is in multiple workgroups for a run, they will use the oldest workgroup. They used to use the newest workgroup which would prevent student data from being saved because the StudentPostDataController checks for the oldest workgroup.

## Test

1. As the teacher, put a student into multiple workgroups for a run using one of the methods [here](https://github.com/WISE-Community/WISE-Client/issues/1437)
2. As the student, launch the run
3. Enter some work and click save or move to another step to auto save
4. Refresh the VLE
5. The student work should be repopulated. It used to not save and not repopulate.

Closes #240