### PR TITLE
fix(Manage Students): Remove student does not remove from all workgroups

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/RemoveStudentRunController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/teacher/management/RemoveStudentRunController.java
@@ -28,7 +28,7 @@ public class RemoveStudentRunController {
   private UserService userService;
 
   @DeleteMapping("/api/teacher/run/{runId}/student/{studentId}/remove")
-  void changeWorkgroupPeriod(Authentication auth, @PathVariable Long runId,
+  public void removeStudent(Authentication auth, @PathVariable Long runId,
       @PathVariable Long studentId) throws ObjectNotFoundException {
     Run run = runService.retrieveById(runId);
     if (runService.hasWritePermission(auth, run)) {

--- a/src/main/java/org/wise/portal/service/student/impl/StudentServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/student/impl/StudentServiceImpl.java
@@ -24,6 +24,7 @@
 package org.wise.portal.service.student.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -122,18 +123,21 @@ public class StudentServiceImpl implements StudentService {
   }
 
   public void removeStudentFromRun(User studentUser, Run run) {
-    if (run.isStudentAssociatedToThisRun(studentUser)) {
-      StudentRunInfo studentRunInfo = getStudentRunInfo(studentUser, run);
-      Group period = run.getPeriodOfStudent(studentUser);
-      Set<User> membersToRemove = new HashSet<User>();
-      membersToRemove.add(studentUser);
-      groupService.removeMembers(period, membersToRemove);
-      Workgroup workgroup = studentRunInfo.getWorkgroup();
-      if (workgroup != null) {
-        Set<User> membersToRemoveFromWorkgroup = new HashSet<User>();
-        membersToRemoveFromWorkgroup.add(studentUser);
-        workgroupService.removeMembers(workgroup, membersToRemoveFromWorkgroup);
-      }
+    removeStudentFromWorkgroupsInRun(studentUser, run);
+    removeStudentFromPeriodInRun(studentUser, run);
+  }
+
+  private void removeStudentFromWorkgroupsInRun(User studentUser, Run run) {
+    List<Workgroup> workgroups = workgroupService.getWorkgroupListByRunAndUser(run, studentUser);
+    for (Workgroup workgroup : workgroups) {
+      workgroupService.removeMembers(workgroup, Collections.singleton(studentUser));
+    }
+  }
+
+  private void removeStudentFromPeriodInRun(User studentUser, Run run) {
+    Group period = run.getPeriodOfStudent(studentUser);
+    if (period != null) {
+      groupService.removeMembers(period, Collections.singleton(studentUser));
     }
   }
 


### PR DESCRIPTION
## Changes

Remove student now removes the student from all the workgroups in the run instead of just one workgroup.

## Test

- Test with and use testing instructions in https://github.com/WISE-Community/WISE-Client/pull/1450

Closes #242