### PR TITLE
feat(Multiple Languages): Add POST endpoint to save translations to a unit

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIController.java
@@ -39,7 +39,7 @@ public class TranslateProjectAPIController {
       @RequestBody ObjectNode translations) throws IOException {
     User user = userService.retrieveUserByUsername(auth.getName());
     if (projectService.canAuthorProject(project, user)) {
-      translateProjectService.saveTranslations(project, locale, translations.toPrettyString());
+      translateProjectService.saveTranslations(project, locale, translations.toString());
     }
   }
 }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIController.java
@@ -1,0 +1,45 @@
+package org.wise.portal.presentation.web.controllers.author.project;
+
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.wise.portal.domain.project.impl.ProjectImpl;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.service.project.ProjectService;
+import org.wise.portal.service.project.translation.TranslateProjectService;
+import org.wise.portal.service.user.UserService;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@Controller
+@RequestMapping("/api/author/project/translate")
+@Secured({ "ROLE_AUTHOR" })
+public class TranslateProjectAPIController {
+
+  @Autowired
+  protected ProjectService projectService;
+
+  @Autowired
+  protected UserService userService;
+
+  @Autowired
+  protected TranslateProjectService translateProjectService;
+
+  @PostMapping("{projectId}/{locale}")
+  @ResponseBody
+  protected void saveTranslations(Authentication auth,
+      @PathVariable("projectId") ProjectImpl project, @PathVariable("locale") String locale,
+      @RequestBody ObjectNode translations) throws IOException {
+    User user = userService.retrieveUserByUsername(auth.getName());
+    if (projectService.canAuthorProject(project, user)) {
+      translateProjectService.saveTranslations(project, locale, translations.toPrettyString());
+    }
+  }
+}

--- a/src/main/java/org/wise/portal/service/project/translation/TranslateProjectService.java
+++ b/src/main/java/org/wise/portal/service/project/translation/TranslateProjectService.java
@@ -1,0 +1,10 @@
+package org.wise.portal.service.project.translation;
+
+import java.io.IOException;
+import org.wise.portal.domain.project.Project;
+
+public interface TranslateProjectService {
+
+  public void saveTranslations(Project project, String locale, String translations)
+      throws IOException;
+}

--- a/src/main/java/org/wise/portal/service/project/translation/impl/TranslateProjectServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/project/translation/impl/TranslateProjectServiceImpl.java
@@ -1,0 +1,31 @@
+package org.wise.portal.service.project.translation.impl;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import org.wise.portal.domain.project.Project;
+import org.wise.portal.service.project.translation.TranslateProjectService;
+
+@Service
+public class TranslateProjectServiceImpl implements TranslateProjectService {
+
+  @Autowired
+  private Environment appProperties;
+
+  public void saveTranslations(Project project, String locale, String translations)
+      throws IOException {
+    String translationFilePath = appProperties.getProperty("curriculum_base_dir")
+        + project.getModulePath().replace("project.json", "translations." + locale + ".json");
+    Writer writer = new BufferedWriter(
+        new OutputStreamWriter(new FileOutputStream(new File(translationFilePath)), "UTF-8"));
+    writer.write(translations);
+    writer.close();
+  }
+}

--- a/src/test/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIControllerTest.java
@@ -29,7 +29,7 @@ public class TranslateProjectAPIControllerTest extends APIControllerTest {
   public void saveTranslations_() throws Exception {
     expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
     expect(projectService.canAuthorProject(project1, teacher1)).andReturn(true);
-    translateProjectService.saveTranslations(project1, "es", "{ }");
+    translateProjectService.saveTranslations(project1, "es", "{}");
     expectLastCall();
     replay(projectService, translateProjectService, userService);
     controller.saveTranslations(teacherAuth, project1, "es",

--- a/src/test/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/author/project/TranslateProjectAPIControllerTest.java
@@ -1,0 +1,39 @@
+package org.wise.portal.presentation.web.controllers.author.project;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+import org.wise.portal.service.project.translation.TranslateProjectService;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@RunWith(EasyMockRunner.class)
+public class TranslateProjectAPIControllerTest extends APIControllerTest {
+
+  @TestSubject
+  private TranslateProjectAPIController controller = new TranslateProjectAPIController();
+
+  @Mock
+  private TranslateProjectService translateProjectService;
+
+  @Test
+  public void saveTranslations_() throws Exception {
+    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
+    expect(projectService.canAuthorProject(project1, teacher1)).andReturn(true);
+    translateProjectService.saveTranslations(project1, "es", "{ }");
+    expectLastCall();
+    replay(projectService, translateProjectService, userService);
+    controller.saveTranslations(teacherAuth, project1, "es",
+        new ObjectNode(new JsonNodeFactory(false)));
+    verify(projectService, translateProjectService, userService);
+  }
+}


### PR DESCRIPTION
## Changes
- Add POST endpoint to save translations for a unit: ```/api/author/project/translate/{projectId}/{locale}```

## Test
- Test with https://github.com/WISE-Community/WISE-Client/pull/1602