### PR TITLE
feat(Tag): Use tag objects instead of strings in project

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/archive/ArchiveProjectController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/archive/ArchiveProjectController.java
@@ -48,7 +48,7 @@ public class ArchiveProjectController {
     User user = userService.retrieveUserByUsername(auth.getName());
     UserTag archivedTag = getOrCreateArchivedTag(user);
     userTagsService.applyTag(project, archivedTag);
-    return ResponseEntityGenerator.createSuccess(createProjectResponse(user, project));
+    return ResponseEntityGenerator.createSuccess(createProjectResponse(user, project, archivedTag));
   }
 
   @PutMapping("/projects/archived")
@@ -60,7 +60,8 @@ public class ArchiveProjectController {
     for (Project project : projects) {
       userTagsService.applyTag(project, archivedTag);
     }
-    return ResponseEntityGenerator.createSuccess(createProjectsResponse(user, projects));
+    return ResponseEntityGenerator
+        .createSuccess(createProjectsResponse(user, projects, archivedTag));
   }
 
   private UserTag getOrCreateArchivedTag(User user) {
@@ -79,7 +80,7 @@ public class ArchiveProjectController {
     if (archivedTag != null) {
       userTagsService.removeTag(project, archivedTag);
     }
-    return ResponseEntityGenerator.createSuccess(createProjectResponse(user, project));
+    return ResponseEntityGenerator.createSuccess(createProjectResponse(user, project, archivedTag));
   }
 
   @DeleteMapping("/projects/archived")
@@ -93,7 +94,8 @@ public class ArchiveProjectController {
         userTagsService.removeTag(project, archivedTag);
       }
     }
-    return ResponseEntityGenerator.createSuccess(createProjectsResponse(user, projects));
+    return ResponseEntityGenerator
+        .createSuccess(createProjectsResponse(user, projects, archivedTag));
   }
 
   private List<Project> getProjects(List<Long> projectIds) throws ObjectNotFoundException {
@@ -104,17 +106,19 @@ public class ArchiveProjectController {
     return projects;
   }
 
-  private Map<String, Object> createProjectResponse(User user, Project project) {
+  private Map<String, Object> createProjectResponse(User user, Project project, UserTag tag) {
     Map<String, Object> response = new HashMap<String, Object>();
     response.put("id", project.getId());
     response.put("archived", userTagsService.hasTag(user, project, ARCHIVED_TAG));
+    response.put("tag", tag);
     return response;
   }
 
-  private List<Map<String, Object>> createProjectsResponse(User user, List<Project> projects) {
+  private List<Map<String, Object>> createProjectsResponse(User user, List<Project> projects,
+      UserTag tag) {
     List<Map<String, Object>> response = new ArrayList<Map<String, Object>>();
     for (Project project : projects) {
-      response.add(createProjectResponse(user, project));
+      response.add(createProjectResponse(user, project, tag));
     }
     return response;
   }

--- a/src/main/java/org/wise/portal/presentation/web/controllers/tag/UserTagController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/tag/UserTagController.java
@@ -1,5 +1,6 @@
 package org.wise.portal.presentation.web.controllers.tag;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,7 +44,10 @@ public class UserTagController {
   @GetMapping("/user/tags")
   protected ResponseEntity<List<Map<String, Object>>> getTags(Authentication auth) {
     User user = userService.retrieveUserByUsername(auth.getName());
-    List<Map<String, Object>> tags = userTagsService.getTags(user).stream().map(tag -> {
+    List<UserTag> userTags = userTagsService.getTags(user);
+    Collections.sort(userTags,
+        (tag1, tag2) -> tag1.getText().toLowerCase().compareTo(tag2.getText().toLowerCase()));
+    List<Map<String, Object>> tags = userTags.stream().map(tag -> {
       return tag.toMap();
     }).collect(Collectors.toList());
     return ResponseEntityGenerator.createSuccess(tags);

--- a/src/main/java/org/wise/portal/service/usertags/UserTagsService.java
+++ b/src/main/java/org/wise/portal/service/usertags/UserTagsService.java
@@ -23,7 +23,7 @@ public interface UserTagsService {
 
   void removeTag(Project project, UserTag tag);
 
-  List<String> getTagsList(User user, Project project);
+  List<UserTag> getTagsList(User user, Project project);
 
   List<UserTag> getTags(User user);
 

--- a/src/main/java/org/wise/portal/service/usertags/impl/UserTagsServiceImpl.java
+++ b/src/main/java/org/wise/portal/service/usertags/impl/UserTagsServiceImpl.java
@@ -80,10 +80,10 @@ public class UserTagsServiceImpl implements UserTagsService {
     return aclTargetObjectIdentityDao.retrieveByObjectIdentity(objectIdentity);
   }
 
-  public List<String> getTagsList(User user, Project project) {
-    List<String> tagsList = getTags(user, project).stream().map(tag -> tag.getText())
-        .collect(Collectors.toList());
-    Collections.sort(tagsList);
+  public List<UserTag> getTagsList(User user, Project project) {
+    List<UserTag> tagsList = getTags(user, project).stream().collect(Collectors.toList());
+    Collections.sort(tagsList,
+        (tag1, tag2) -> tag1.getText().toLowerCase().compareTo(tag2.getText().toLowerCase()));
     return tagsList;
   }
 


### PR DESCRIPTION
## Changes
- Changed project tags to be objects instead of just the string text
- When archiving or restoring a unit, also return the archived tag object in the response

## Test
- Test with https://github.com/WISE-Community/WISE-Client/pull/1716
