### PR TITLE
feat(AI Chat): Add authoring config param for whether chat gpt is enabled

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/author/project/AuthorAPIController.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -398,6 +399,7 @@ public class AuthorAPIController {
     config.put("projectAssetURL", contextPath + "/api/author/project/asset/" + project.getId());
     config.put("projectBaseURL", projectBaseURL);
     config.put("previewProjectURL", contextPath + "/preview/unit/" + project.getId());
+    config.put("chatGptEnabled", !StringUtils.isEmpty(appProperties.getProperty("OPENAI_API_KEY")));
     config.put("cRaterRequestURL", contextPath + "/api/c-rater");
     config.put("importStepsURL",
         contextPath + "/api/author/project/importSteps/" + project.getId());


### PR DESCRIPTION
## Changes
- Added chatGptEnabled param to authoring config

## Test
- Test with https://github.com/WISE-Community/WISE-Client/pull/1732
- If OPENAI_API_KEY is
  - not in application.properties, chatGptEnabled should be false
  - in application.properties but is empty, chatGptEnabled should be false
  - is set to a string in application.properties, chatGptEnabled should be true
