### PR TITLE
fix(Unit Library): Fix tags returned in projects

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/project/ProjectAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/project/ProjectAPIController.java
@@ -18,6 +18,7 @@ import org.wise.portal.domain.portal.Portal;
 import org.wise.portal.domain.project.Project;
 import org.wise.portal.domain.project.impl.ProjectImpl;
 import org.wise.portal.domain.user.User;
+import org.wise.portal.domain.usertag.UserTag;
 import org.wise.portal.presentation.web.controllers.ControllerUtil;
 import org.wise.portal.service.portal.PortalService;
 import org.wise.portal.service.project.ProjectService;
@@ -127,10 +128,18 @@ public class ProjectAPIController {
     JSONArray projectsJSON = new JSONArray();
     for (Project project : projectList) {
       JSONObject projectJSON = ControllerUtil.getProjectJSON(project);
-      projectJSON.put("tags", userTagsService.getTagsList(user, project));
+      projectJSON.put("tags", convertTagsToJsonArray(userTagsService.getTagsList(user, project)));
       projectsJSON.put(projectJSON);
     }
     return projectsJSON;
+  }
+
+  private JSONArray convertTagsToJsonArray(List<UserTag> tags) {
+    JSONArray tagsJSONArray = new JSONArray();
+    for (UserTag tag : tags) {
+      tagsJSONArray.put(tag.toMap());
+    }
+    return tagsJSONArray;
   }
 
   private JSONObject populateProjectMetadata(JSONObject projectLibraryGroup) throws JSONException {


### PR DESCRIPTION
## Changes
- Return the proper tag representation in projects. It used to return tags as the string representation of the Java object like UserTag@d39r28r but now it should return a JSON object.

## Test
- Test with https://github.com/WISE-Community/WISE-Client/pull/1782