### PR TITLE
build(Tomcat): Remove deployment of legacy.war

### DIFF
--- a/scripts/afterInstall.sh
+++ b/scripts/afterInstall.sh
@@ -2,8 +2,6 @@
 
 export HOME=/home/ubuntu
 export BUILD_DIR=$HOME/build-folder
-export LEGACY_BUILD_DIR=$HOME/legacy-build-folder
-export BUILD_FILES=$HOME/wise-build-files
 export CATALINA_HOME=/opt/tomcat
 
 exec &>> $HOME/deploy.log
@@ -18,23 +16,7 @@ echo "Moving wise.war to $CATALINA_HOME/webapps/ROOT.war"
 mv wise.war $CATALINA_HOME/webapps/ROOT.war
 chown tomcat:tomcat $CATALINA_HOME/webapps/ROOT.war
 
-echo "Changing to $LEGACY_BUILD_DIR directory"
-cd $LEGACY_BUILD_DIR
-
-echo "Copying legacy.war to $LEGACY_BUILD_DIR"
-cp $BUILD_FILES/legacy.war $LEGACY_BUILD_DIR
-
-echo "Injecting application-legacy.properties into legacy.war"
-zip -g legacy.war WEB-INF/classes/application.properties
-
-echo "Moving legacy.war to $CATALINA_HOME/webapps/legacy.war"
-mv legacy.war $CATALINA_HOME/webapps/legacy.war
-chown tomcat:tomcat $CATALINA_HOME/webapps/legacy.war
-
 echo "Deleting build folder"
 rm -rf $BUILD_DIR
-
-echo "Deleting legacy build folder"
-rm -rf $LEGACY_BUILD_DIR
 
 echo "Finishing deployment at $(date)"

--- a/scripts/beforeInstall.sh
+++ b/scripts/beforeInstall.sh
@@ -2,7 +2,6 @@
 
 export HOME=/home/ubuntu
 export BUILD_DIR=$HOME/build-folder
-export LEGACY_BUILD_DIR=$HOME/legacy-build-folder
 export BUILD_FILES=$HOME/wise-build-files
 export CATALINA_HOME=/opt/tomcat
 
@@ -110,15 +109,11 @@ systemctl restart nginx
 
 echo "Creating additional folders for WISE"
 mkdir -p $BUILD_DIR/WEB-INF/classes
-mkdir -p $LEGACY_BUILD_DIR/WEB-INF/classes
 sudo -u ubuntu -g ubuntu mkdir $HOME/backup
 sudo -u ubuntu -g tomcat mkdir $HOME/googleTokens
 
 echo "Copying application.properties file to the build folder"
 cp $BUILD_FILES/api/$ENV/application.properties $BUILD_DIR/WEB-INF/classes/application.properties
-
-echo "Copying application-legacy.properties file to the legacy build folder"
-cp $BUILD_FILES/api/$ENV/application-legacy.properties $LEGACY_BUILD_DIR/WEB-INF/classes/application.properties
 
 echo "Installing network drive package"
 apt-get install nfs-common -y


### PR DESCRIPTION
## Changes
- Removed deployment of legacy.war

## Test
- When launching a WISE-API server, make sure the legacy.war is not placed in /opt/tomcat/webapps