### PR TITLE
fix(CM): Admin can't launch CM for other teachers' runs

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java
@@ -796,7 +796,9 @@ public class InformationController {
       User user = userService.retrieveUser(userDetails);
       List<Workgroup> workgroupListByRunAndUser = workgroupService.getWorkgroupListByRunAndUser(run,
           user);
-      workgroup = workgroupListByRunAndUser.get(0);
+      if (workgroupListByRunAndUser.size() > 0) {
+        workgroup = workgroupListByRunAndUser.get(0);
+      }
     }
     return workgroup;
   }


### PR DESCRIPTION
## Changes
Fixes issue where admin could not open CM by another teacher via directly changing run ID in the URL.

This pull request includes a small change to the `InformationController.java` file. The change ensures that the method `getWorkgroup` checks if the `workgroupListByRunAndUser` list is not empty before accessing its first element, which prevents potential `IndexOutOfBoundsException`.

- [`src/main/java/org/wise/portal/presentation/web/controllers/InformationController.java`](diffhunk://#diff-387eda6cd9d3ed804b795c2a5a878dd1b57502a3075b9fb42f66060205f8d4c7R799-R802): Added a condition to check if `workgroupListByRunAndUser` is not empty before accessing its first element.