### PR TITLE
feat(Analytics): Add Google Tag Manager support

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -163,6 +163,7 @@ public class UserAPIController {
     config.put("contextPath", contextPath);
     config.put("currentTime", System.currentTimeMillis());
     config.put("googleAnalyticsId", appProperties.getProperty("google_analytics_id"));
+    config.put("googleTagManagerId", appProperties.getProperty("google_tag_manager_id"));
     config.put("googleClientId", googleClientId);
     config.put("isGoogleClassroomEnabled", isGoogleClassroomEnabled());
     config.put("logOutURL", contextPath + "/api/logout");

--- a/src/main/java/org/wise/portal/spring/impl/WebConfig.java
+++ b/src/main/java/org/wise/portal/spring/impl/WebConfig.java
@@ -71,6 +71,9 @@ public class WebConfig implements WebMvcConfigurer {
   @Value("${google_analytics_id:}")
   private String googleAnalyticsId;
 
+  @Value("${google_tag_manager_id:}")
+  private String googleTagManagerId;
+
   @Autowired
   private ObjectMapper objectMapper;
 

--- a/src/main/resources/application-dockerdev-sample.properties
+++ b/src/main/resources/application-dockerdev-sample.properties
@@ -35,6 +35,7 @@ spring.servlet.multipart.max-request-size=100MB
 # recaptcha_public_key - [key or leave empty] public key for recaptcha
 # recaptcha_private_key - [key or leave empty] private key for recaptcha
 # google_analytics_id - [key or leave empty] key for tracking visitors with google analytics. Go here to get your own key: http://analytics.google.com
+# google_tag_manager_id - [key or leave empty] key for tracking visitors with google tag manager. Go here to set up your tag manager account: https://tagmanager.google.com/
 # cRater_verification_url - [url or leave empty] cRater verification url
 # cRater_scoring_url - [url or leave empty] cRater scoring url
 # cRater_client_id - [id or leave empty] cRater client token id
@@ -57,6 +58,7 @@ maxWorkgroupSize=3
 isRealTimeEnabled=true
 isBatchCreateUserAccountsEnabled=true
 google_analytics_id=
+google_tag_manager_id=
 userAgentParseKey=
 recaptcha_public_key=
 recaptcha_private_key=

--- a/src/main/resources/application_sample.properties
+++ b/src/main/resources/application_sample.properties
@@ -35,6 +35,7 @@ spring.servlet.multipart.max-request-size=100MB
 # recaptcha_public_key - [key or leave empty] public key for recaptcha
 # recaptcha_private_key - [key or leave empty] private key for recaptcha
 # google_analytics_id - [key or leave empty] key for tracking visitors with google analytics. Go here to get your own key: http://analytics.google.com
+# google_tag_manager_id - [key or leave empty] key for tracking visitors with google tag manager. Go here to set up your tag manager account: https://tagmanager.google.com/
 # cRater_verification_url - [url or leave empty] cRater verification url
 # cRater_scoring_url - [url or leave empty] cRater scoring url
 # cRater_client_id - [id or leave empty] cRater client token id
@@ -57,6 +58,7 @@ maxWorkgroupSize=3
 isRealTimeEnabled=true
 isBatchCreateUserAccountsEnabled=true
 google_analytics_id=
+google_tag_manager_id=
 userAgentParseKey=
 recaptcha_public_key=
 recaptcha_private_key=

--- a/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
@@ -76,6 +76,7 @@ public class UserAPIControllerTest extends APIControllerTest {
     expect(request.getContextPath()).andReturn("wise");
     replay(request);
     expect(appProperties.getProperty("google_analytics_id")).andReturn("UA-XXXXXX-1");
+    expect(appProperties.getProperty("google_tag_manager_id")).andReturn("GTM-XXXXXXXX");
     expect(appProperties.getProperty("recaptcha_public_key")).andReturn("recaptcha-123-abc");
     expect(appProperties.getProperty("wise4.hostname")).andReturn("http://localhost:8080/legacy");
     expect(appProperties.getProperty("discourse_url")).andReturn("http://localhost:9292");
@@ -87,6 +88,7 @@ public class UserAPIControllerTest extends APIControllerTest {
     assertEquals("wise/api/logout", config.get("logOutURL"));
     assertFalse((boolean) config.get("isGoogleClassroomEnabled"));
     assertEquals("UA-XXXXXX-1", config.get("googleAnalyticsId"));
+    assertEquals("GTM-XXXXXXXX", config.get("googleTagManagerId"));
     verify(request);
     verify(appProperties);
   }


### PR DESCRIPTION
## Description
Add support for a Google Tag Manager ID to properties files.

## Test
- Review GTM setup
- Pairs with [feat(Analytics): Add Google Tag Manager support #2128](https://github.com/WISE-Community/WISE-Client/pull/2128)