### PR TITLE
refactor(UserAPIController): Extract RunInfoController

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/run/RunInfoAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/run/RunInfoAPIController.java
@@ -27,18 +27,18 @@ import org.wise.portal.service.user.UserService;
  * @author Aaron Detre
  */
 @RestController
-@RequestMapping("/api/run-info")
+@RequestMapping("/api/run")
 public class RunInfoAPIController {
- 
+
   @Autowired
   private RunService runService;
- 
+
   @Autowired
   private UserService userService;
 
   @Secured("ROLE_USER")
-  @GetMapping("/run/info-by-id")
-  HashMap<String, Object> getRunInfoById(Authentication auth, @RequestParam("runId") Long runId) {
+  @GetMapping("/info-by-id")
+  HashMap<String, Object> getRunInfoById(Authentication auth, @RequestParam Long runId) {
     try {
       User user = userService.retrieveUserByUsername(auth.getName());
       Run run = runService.retrieveById(runId);
@@ -49,7 +49,7 @@ public class RunInfoAPIController {
     }
     return createRunNotFoundInfo();
   }
-  
+
   private HashMap<String, Object> getRunInfo(Run run) {
     HashMap<String, Object> info = new HashMap<String, Object>();
     info.put("id", String.valueOf(run.getId()));
@@ -79,8 +79,8 @@ public class RunInfoAPIController {
     return info;
   }
 
-  @GetMapping("/run/info")
-  HashMap<String, Object> getRunInfoByRunCode(@RequestParam("runCode") String runCode) {
+  @GetMapping("/info")
+  HashMap<String, Object> getRunInfoByRunCode(@RequestParam String runCode) {
     try {
       return getRunInfo(runService.retrieveRunByRuncode(runCode));
     } catch (ObjectNotFoundException e) {
@@ -89,4 +89,3 @@ public class RunInfoAPIController {
   }
 
 }
-

--- a/src/main/java/org/wise/portal/presentation/web/controllers/run/RunInfoAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/run/RunInfoAPIController.java
@@ -1,0 +1,92 @@
+package org.wise.portal.presentation.web.controllers.run;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.group.Group;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.domain.user.User;
+import org.wise.portal.service.run.RunService;
+import org.wise.portal.service.user.UserService;
+
+/**
+ * Run Info REST API
+ *
+ * @author Hiroki Terashima
+ * @author Geoffrey Kwan
+ * @author Jonathan Lim-Breitbart
+ * @author Aaron Detre
+ */
+@RestController
+@RequestMapping("/api/run-info")
+public class RunInfoAPIController {
+ 
+  @Autowired
+  private RunService runService;
+ 
+  @Autowired
+  private UserService userService;
+
+  @Secured("ROLE_USER")
+  @GetMapping("/run/info-by-id")
+  HashMap<String, Object> getRunInfoById(Authentication auth, @RequestParam("runId") Long runId) {
+    try {
+      User user = userService.retrieveUserByUsername(auth.getName());
+      Run run = runService.retrieveById(runId);
+      if (userService.isUserAssociatedWithRun(user, run)) {
+        return getRunInfo(run);
+      }
+    } catch (ObjectNotFoundException e) {
+    }
+    return createRunNotFoundInfo();
+  }
+  
+  private HashMap<String, Object> getRunInfo(Run run) {
+    HashMap<String, Object> info = new HashMap<String, Object>();
+    info.put("id", String.valueOf(run.getId()));
+    info.put("name", run.getName());
+    info.put("runCode", run.getRuncode());
+    info.put("startTime", run.getStartTimeMilliseconds());
+    info.put("endTime", run.getEndTimeMilliseconds());
+    info.put("periods", getPeriodNames(run));
+    User owner = run.getOwner();
+    info.put("teacherFirstName", owner.getUserDetails().getFirstname());
+    info.put("teacherLastName", owner.getUserDetails().getLastname());
+    info.put("wiseVersion", run.getProject().getWiseVersion());
+    return info;
+  }
+
+  private List<String> getPeriodNames(Run run) {
+    List<String> periods = new ArrayList<String>();
+    for (Group period : run.getPeriods()) {
+      periods.add(period.getName());
+    }
+    return periods;
+  }
+
+  private HashMap<String, Object> createRunNotFoundInfo() {
+    HashMap<String, Object> info = new HashMap<String, Object>();
+    info.put("error", "runNotFound");
+    return info;
+  }
+
+  @GetMapping("/run/info")
+  HashMap<String, Object> getRunInfoByRunCode(@RequestParam("runCode") String runCode) {
+    try {
+      return getRunInfo(runService.retrieveRunByRuncode(runCode));
+    } catch (ObjectNotFoundException e) {
+      return createRunNotFoundInfo();
+    }
+  }
+
+}
+

--- a/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/student/StudentAPIController.java
@@ -112,15 +112,6 @@ public class StudentAPIController extends UserAPIController {
     return runList;
   }
 
-  @GetMapping("/run/info")
-  HashMap<String, Object> getRunInfoByRunCode(@RequestParam("runCode") String runCode) {
-    try {
-      return getRunInfo(runService.retrieveRunByRuncode(runCode));
-    } catch (ObjectNotFoundException e) {
-      return createRunNotFoundInfo();
-    }
-  }
-
   @PostMapping("/run/launch")
   HashMap<String, Object> launchRun(Authentication auth, @RequestParam("runId") Long runId,
       @RequestParam(value = "workgroupId", required = false) Long workgroupId,

--- a/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/user/UserAPIController.java
@@ -230,49 +230,6 @@ public class UserAPIController {
     return langs;
   }
 
-  @Secured("ROLE_USER")
-  @GetMapping("/run/info-by-id")
-  HashMap<String, Object> getRunInfoById(Authentication auth, @RequestParam("runId") Long runId) {
-    try {
-      User user = userService.retrieveUserByUsername(auth.getName());
-      Run run = runService.retrieveById(runId);
-      if (userService.isUserAssociatedWithRun(user, run)) {
-        return getRunInfo(run);
-      }
-    } catch (ObjectNotFoundException e) {
-    }
-    return createRunNotFoundInfo();
-  }
-
-  protected HashMap<String, Object> getRunInfo(Run run) {
-    HashMap<String, Object> info = new HashMap<String, Object>();
-    info.put("id", String.valueOf(run.getId()));
-    info.put("name", run.getName());
-    info.put("runCode", run.getRuncode());
-    info.put("startTime", run.getStartTimeMilliseconds());
-    info.put("endTime", run.getEndTimeMilliseconds());
-    info.put("periods", getPeriodNames(run));
-    User owner = run.getOwner();
-    info.put("teacherFirstName", owner.getUserDetails().getFirstname());
-    info.put("teacherLastName", owner.getUserDetails().getLastname());
-    info.put("wiseVersion", run.getProject().getWiseVersion());
-    return info;
-  }
-
-  private List<String> getPeriodNames(Run run) {
-    List<String> periods = new ArrayList<String>();
-    for (Group period : run.getPeriods()) {
-      periods.add(period.getName());
-    }
-    return periods;
-  }
-
-  protected HashMap<String, Object> createRunNotFoundInfo() {
-    HashMap<String, Object> info = new HashMap<String, Object>();
-    info.put("error", "runNotFound");
-    return info;
-  }
-
   private String getLanguageName(String localeString) {
     if (localeString.toLowerCase().equals("zh_tw")) {
       return "Chinese (Traditional)";

--- a/src/test/java/org/wise/portal/presentation/web/controllers/run/RunInfoAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/run/RunInfoAPIControllerTest.java
@@ -1,0 +1,77 @@
+package org.wise.portal.presentation.web.controllers.run;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+
+import org.easymock.EasyMockExtension;
+import org.easymock.TestSubject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wise.portal.dao.ObjectNotFoundException;
+import org.wise.portal.domain.run.Run;
+import org.wise.portal.presentation.web.controllers.APIControllerTest;
+
+@ExtendWith(EasyMockExtension.class)
+public class RunInfoAPIControllerTest extends APIControllerTest {
+  
+  @TestSubject
+  private RunInfoAPIController runInfoAPIController = new RunInfoAPIController();
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+  }
+  
+  @Test
+  public void getRunInfoById_RunExistsInDB_ReturnRunInfo() throws ObjectNotFoundException {
+    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
+    expect(userService.isUserAssociatedWithRun(teacher1, run1)).andReturn(true);
+    replay(userService);
+    expect(runService.retrieveById(runId1)).andReturn(run1);
+    replay(runService);
+    HashMap<String, Object> info = runInfoAPIController.getRunInfoById(teacherAuth, runId1);
+    assertEquals("1", info.get("id"));
+    assertEquals(RUN1_RUNCODE, info.get("runCode"));
+    verify(runService);
+  }
+
+  @Test
+  public void getRunInfoById_RunNotInDB_ReturnRunInfo() throws ObjectNotFoundException {
+    Long runIdNotInDB = -1L;
+    expect(runService.retrieveById(runIdNotInDB))
+        .andThrow(new ObjectNotFoundException(runIdNotInDB, Run.class));
+    replay(runService);
+    HashMap<String, Object> info = runInfoAPIController.getRunInfoById(teacherAuth, runIdNotInDB);
+    assertEquals(1, info.size());
+    assertEquals("runNotFound", info.get("error"));
+    verify(runService);
+  }
+
+  @Test
+  public void getRunInfoByRunCode_RunExistsInDB_ReturnRunInfo() throws ObjectNotFoundException {
+    expect(runService.retrieveRunByRuncode(RUN1_RUNCODE)).andReturn(run1);
+    replay(runService);
+    HashMap<String, Object> info = runInfoAPIController.getRunInfoByRunCode(RUN1_RUNCODE);
+    assertEquals("1", info.get("id"));
+    assertEquals(RUN1_RUNCODE, info.get("runCode"));
+    verify(runService);
+  }
+
+  @Test
+  public void getRunInfoByRunCode_RunNotInDB_ReturnRunInfo() throws ObjectNotFoundException {
+    String runCodeNotInDB = "runCodeNotInDB";
+    expect(runService.retrieveRunByRuncode(runCodeNotInDB))
+        .andThrow(new ObjectNotFoundException(runCodeNotInDB, Run.class));
+    replay(runService);
+    HashMap<String, Object> info = runInfoAPIController.getRunInfoByRunCode(runCodeNotInDB);
+    assertEquals(1, info.size());
+    assertEquals("runNotFound", info.get("error"));
+    verify(runService);
+  }
+}
+

--- a/src/test/java/org/wise/portal/presentation/web/controllers/student/StudentAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/student/StudentAPIControllerTest.java
@@ -14,13 +14,11 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.easymock.EasyMockExtension;
-import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.TestSubject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -122,29 +120,7 @@ public class StudentAPIControllerTest extends APIControllerTest {
     verify(request);
   }
 
-  @Test
-  public void getRunInfoByRunCode_RunExistsInDB_ReturnRunInfo() throws ObjectNotFoundException {
-    expect(runService.retrieveRunByRuncode(RUN1_RUNCODE)).andReturn(run1);
-    replay(runService);
-    HashMap<String, Object> info = studentAPIController.getRunInfoByRunCode(RUN1_RUNCODE);
-    assertEquals("1", info.get("id"));
-    assertEquals(RUN1_RUNCODE, info.get("runCode"));
-    verify(runService);
-  }
-
-  @Test
-  public void getRunInfoByRunCode_RunNotInDB_ReturnRunInfo() throws ObjectNotFoundException {
-    String runCodeNotInDB = "runCodeNotInDB";
-    expect(runService.retrieveRunByRuncode(runCodeNotInDB))
-        .andThrow(new ObjectNotFoundException(runCodeNotInDB, Run.class));
-    replay(runService);
-    HashMap<String, Object> info = studentAPIController.getRunInfoByRunCode(runCodeNotInDB);
-    assertEquals(1, info.size());
-    assertEquals("runNotFound", info.get("error"));
-    verify(runService);
-  }
-
-  @Test
+ @Test
   public void getSecurityQuestions_DefaultQuestions_ReturnSixQuestions() {
     expect(i18nProperties.getProperty("accountquestions.QUESTION_ONE"))
         .andReturn("account question 1");

--- a/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
+++ b/src/test/java/org/wise/portal/presentation/web/controllers/user/UserAPIControllerTest.java
@@ -21,8 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.wise.portal.dao.ObjectNotFoundException;
-import org.wise.portal.domain.run.Run;
 import org.wise.portal.presentation.web.controllers.APIControllerTest;
 import org.wise.portal.presentation.web.exception.IncorrectPasswordException;
 import org.wise.portal.service.password.impl.PasswordServiceImpl;
@@ -226,30 +224,4 @@ public class UserAPIControllerTest extends APIControllerTest {
     assertEquals(response.getStatusCode(), HttpStatus.OK);
     assertEquals(response.getBody().get("username"), username);
   }
-
-  @Test
-  public void getRunInfoById_RunExistsInDB_ReturnRunInfo() throws ObjectNotFoundException {
-    expect(userService.retrieveUserByUsername(TEACHER_USERNAME)).andReturn(teacher1);
-    expect(userService.isUserAssociatedWithRun(teacher1, run1)).andReturn(true);
-    replay(userService);
-    expect(runService.retrieveById(runId1)).andReturn(run1);
-    replay(runService);
-    HashMap<String, Object> info = userAPIController.getRunInfoById(teacherAuth, runId1);
-    assertEquals("1", info.get("id"));
-    assertEquals(RUN1_RUNCODE, info.get("runCode"));
-    verify(runService);
-  }
-
-  @Test
-  public void getRunInfoById_RunNotInDB_ReturnRunInfo() throws ObjectNotFoundException {
-    Long runIdNotInDB = -1L;
-    expect(runService.retrieveById(runIdNotInDB))
-        .andThrow(new ObjectNotFoundException(runIdNotInDB, Run.class));
-    replay(runService);
-    HashMap<String, Object> info = userAPIController.getRunInfoById(teacherAuth, runIdNotInDB);
-    assertEquals(1, info.size());
-    assertEquals("runNotFound", info.get("error"));
-    verify(runService);
-  }
-
 }


### PR DESCRIPTION
## Changes
- Moved methods and tests relating to "run info" from the Student and User API controllers into its own RunInfoAPIController class.

## Test
- For this to work, you'll also need this client PR: https://github.com/WISE-Community/WISE-Client/pull/2132
- To test the endpoint at api/run-info/run/info, go to 'Student Home,' click 'Add Unit,' and enter some text that isn't a valid access code. Click off to the side, and it should say "Invalid Access Code."
    - Then enter a valid access code, and the warning should go away.
- To test the endpoint at api/run-info/run/info-by-id, go to 'Student Home' and click 'Report Problem' on any unit. The contact form should include a line showing the name of the project that you clicked on.
- Make sure moved tests still pass.

Closes #292 