### PR TITLE
fix(Contact): Allow contact email to be sent when there is an issue with UserAgent

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/contact/ContactAPIController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/contact/ContactAPIController.java
@@ -169,9 +169,8 @@ public class ContactAPIController {
     addProjectAndRunDetailsToBody(body, runId, projectId);
     try {
       addUserSystemDetailsToBody(body, userAgent);
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (JSONException e) {
+    } catch (Exception e) {
+      // it's ok to not have user agent details. Allow the email to be sent.
       e.printStackTrace();
     }
     return body.toString();


### PR DESCRIPTION
Right now, when there is an issue with parsing the user agent, we don't send the contact email altogether. This PR allows it to proceed because it's not necessary.