### PR TITLE
feat(OpenAI integration): Specify chat api url

### DIFF
--- a/src/main/java/org/wise/portal/presentation/web/controllers/ChatGptController.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/ChatGptController.java
@@ -43,7 +43,8 @@ public class ChatGptController {
       writer.write(body);
       writer.flush();
       writer.close();
-      BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream(),"ISO-8859-1"));
+      BufferedReader br = new BufferedReader(
+          new InputStreamReader(connection.getInputStream(), "UTF-8"));
       String line;
       StringBuffer response = new StringBuffer();
       while ((line = br.readLine()) != null) {

--- a/src/main/java/org/wise/portal/presentation/web/controllers/ChatGptcontroller.java
+++ b/src/main/java/org/wise/portal/presentation/web/controllers/ChatGptcontroller.java
@@ -6,8 +6,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,25 +15,27 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
-public class ChatGptcontroller {
+@RequestMapping("/api/chat-gpt")
+public class ChatGptController {
 
-  @Autowired
-  Environment appProperties;
+  @Value("${openai.api.key:}")
+  private String openAiApiKey;
+
+  @Value("${openai.chat.api.url:https://api.openai.com/v1/chat/completions}")
+  private String openAiChatApiUrl;
 
   @ResponseBody
   @Secured("ROLE_USER")
-  @PostMapping("/chat-gpt")
+  @PostMapping
   protected String sendChatMessage(@RequestBody String body) {
-    String openaiApiKey = appProperties.getProperty("OPENAI_API_KEY");
-    if (openaiApiKey == null || openaiApiKey.isEmpty()) {
+    if (openAiApiKey == null || openAiApiKey.isEmpty()) {
       throw new RuntimeException("OPENAI_API_KEY is not set");
     }
     try {
-      URL url = new URL("https://api.openai.com/v1/chat/completions");
+      URL url = new URL(openAiChatApiUrl);
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod("POST");
-      connection.setRequestProperty("Authorization", "Bearer " + openaiApiKey);
+      connection.setRequestProperty("Authorization", "Bearer " + openAiApiKey);
       connection.setRequestProperty("Content-Type", "application/json; charset=utf-8");
       connection.setRequestProperty("Accept-Charset", "UTF-8");
       connection.setDoOutput(true);

--- a/src/main/resources/application-dockerdev-sample.properties
+++ b/src/main/resources/application-dockerdev-sample.properties
@@ -217,7 +217,8 @@ system-wide-salt=secret
 #speech-to-text.aws.identity-pool-id=
 
 # OpenAI and AWS Bedrock Chat endpoints (optional)
-#OPENAI_API_KEY=
+#openai.api.key=
+#openai.chat.api.url=
 #aws.bedrock.api.key=
 #aws.bedrock.runtime.endpoint=
 

--- a/src/main/resources/application_sample.properties
+++ b/src/main/resources/application_sample.properties
@@ -217,6 +217,7 @@ system-wide-salt=secret
 #speech-to-text.aws.identity-pool-id=
 
 # OpenAI and AWS Bedrock Chat endpoints (optional)
-#OPENAI_API_KEY=
+#openai.api.key=
+#openai.chat.api.url=
 #aws.bedrock.api.key=
 #aws.bedrock.runtime.endpoint=


### PR DESCRIPTION
## Changes
- Rename OpenAPIKey key name from ```OPENAI_API_KEY``` to ```openai.api.key```
- Add ```openai.chat.api.url``` url key. Defaults to ```https://api.openai.com/v1/chat/completions```
- Clean up related code 